### PR TITLE
Add US Code Title 20 browser with section/chapter navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,14 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, jsonify
+import json
+import os
 
 app = Flask(__name__)
+
+def load_title20_data():
+    """Load US Code Title 20 data from JSON file"""
+    data_path = os.path.join(os.path.dirname(__file__), 'data', 'title20_structure.json')
+    with open(data_path, 'r') as f:
+        return json.load(f)
 
 @app.route('/')
 def home():
@@ -13,6 +21,89 @@ def projects():
 @app.route('/clock')
 def clock():
     return render_template('clock.html')
+
+# US Code Browser Routes
+@app.route('/uscode')
+def uscode_home():
+    """Main US Code browser page - redirects to Title 20"""
+    data = load_title20_data()
+    return render_template('uscode/title.html', title=data['title'], chapters=data['chapters'])
+
+@app.route('/uscode/title/20')
+def title20():
+    """Display Title 20 - Education overview"""
+    data = load_title20_data()
+    return render_template('uscode/title.html', title=data['title'], chapters=data['chapters'])
+
+@app.route('/uscode/title/20/chapter/<int:chapter_num>')
+def chapter(chapter_num):
+    """Display a specific chapter"""
+    data = load_title20_data()
+    chapter = next((c for c in data['chapters'] if c['number'] == chapter_num), None)
+
+    if not chapter:
+        return "Chapter not found", 404
+
+    return render_template('uscode/chapter.html',
+                         title=data['title'],
+                         chapter=chapter)
+
+@app.route('/uscode/title/20/section/<section_num>')
+def section(section_num):
+    """Display a specific section"""
+    data = load_title20_data()
+
+    # Convert section_num to appropriate type (int or string)
+    try:
+        section_num = int(section_num)
+    except ValueError:
+        # Keep as string if it can't be converted to int
+        pass
+
+    # Find the section across all chapters
+    section = None
+    parent_chapter = None
+    parent_subchapter = None
+
+    for chapter in data['chapters']:
+        # Check sections directly under chapter
+        if 'sections' in chapter:
+            for sec in chapter['sections']:
+                if sec['number'] == section_num:
+                    section = sec
+                    parent_chapter = chapter
+                    break
+
+        # Check sections under subchapters
+        if 'subchapters' in chapter:
+            for subchapter in chapter['subchapters']:
+                if 'sections' in subchapter:
+                    for sec in subchapter['sections']:
+                        if sec['number'] == section_num:
+                            section = sec
+                            parent_chapter = chapter
+                            parent_subchapter = subchapter
+                            break
+                if section:
+                    break
+        if section:
+            break
+
+    if not section:
+        return "Section not found", 404
+
+    return render_template('uscode/section.html',
+                         title=data['title'],
+                         chapter=parent_chapter,
+                         subchapter=parent_subchapter,
+                         section=section)
+
+# API endpoint for JSON data access
+@app.route('/api/title/20')
+def api_title20():
+    """API endpoint to get Title 20 data as JSON"""
+    data = load_title20_data()
+    return jsonify(data)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/data/title20_structure.json
+++ b/data/title20_structure.json
@@ -1,0 +1,148 @@
+{
+  "title": {
+    "number": 20,
+    "name": "EDUCATION",
+    "is_positive_law": false,
+    "description": "This title contains provisions related to education, including federal education programs, student aid, elementary and secondary education, and higher education."
+  },
+  "chapters": [
+    {
+      "number": 3,
+      "name": "Smithsonian Institution, National Museums and Art Galleries",
+      "subchapters": [
+        {
+          "number": 1,
+          "name": "Charter Provisions",
+          "sections": [
+            {
+              "number": 41,
+              "heading": "Incorporation of institution",
+              "text": "The President, the Vice President, the Chief Justice, and the heads of executive departments are constituted an establishment by the name of the Smithsonian Institution for the increase and diffusion of knowledge among men, and by that name shall be known and have perpetual succession with the powers, limitations, and restrictions hereinafter contained, and no other."
+            },
+            {
+              "number": 42,
+              "heading": "Board of Regents; members",
+              "text": "The business of the Institution shall be conducted at the city of Washington by a Board of Regents, named the Regents of the Smithsonian Institution, to be composed of the Vice President, the Chief Justice of the United States, three Members of the Senate, three Members of the House of Representatives, and nine other persons, other than Members of Congress, two of whom shall be resident in the city of Washington, and seven of whom shall be inhabitants of some State, but no two of them of the same State."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "number": 28,
+      "name": "Higher Education Resources and Student Assistance",
+      "subchapters": [
+        {
+          "number": 1,
+          "name": "General Provisions",
+          "sections": [
+            {
+              "number": 1001,
+              "heading": "General definition of institution of higher education",
+              "text": "(a) Institution of higher education\n\nFor purposes of this chapter, other than subchapter IV, the term 'institution of higher education' means an educational institution in any State that—\n\n(1) admits as regular students only persons having a certificate of graduation from a school providing secondary education, or the recognized equivalent of such a certificate;\n\n(2) is legally authorized within such State to provide a program of education beyond secondary education;\n\n(3) provides an educational program for which the institution awards a bachelor's degree or provides not less than a 2-year program that is acceptable for full credit toward such a degree;\n\n(4) is a public or other nonprofit institution; and\n\n(5) is accredited by a nationally recognized accrediting agency or association, or if not so accredited, is an institution that has been granted preaccreditation status by such an agency or association that has been recognized by the Secretary for the granting of preaccreditation status, and the Secretary has determined that there is satisfactory assurance that the institution will meet the accreditation standards of such an agency or association within a reasonable time."
+            },
+            {
+              "number": 1002,
+              "heading": "Definition of institution of higher education for purposes of student assistance programs",
+              "text": "(a) Definition of institution of higher education for purposes of student assistance programs\n\n(1) Inclusion\n\nExcept as provided in subsection (b), for purposes of subchapter IV the term 'institution of higher education' includes, in addition to the institutions covered by the definition in section 1001 of this title—\n\n(A) a proprietary institution of higher education (as defined in subsection (b)); and\n\n(B) a postsecondary vocational institution (as defined in subsection (c))."
+            }
+          ]
+        },
+        {
+          "number": 4,
+          "name": "Student Assistance",
+          "sections": [
+            {
+              "number": 1070,
+              "heading": "Federal Pell Grants: amount and determinations; applications",
+              "text": "(a) Program authority and method of distribution\n\n(1) For each fiscal year through fiscal year 2024, the Secretary shall pay to each eligible institution such sums as may be necessary to pay to each eligible student (defined in accordance with section 1091 of this title) for each academic year during which that student is in attendance at an institution of higher education, as an undergraduate, a Federal Pell Grant in the amount for which that student is eligible, as determined pursuant to subsection (b).\n\n(2)(A) There are authorized to be appropriated, and there are appropriated, out of any money in the Treasury not otherwise appropriated, for each of fiscal years 2008 through 2024, such sums as may be necessary to provide Federal Pell Grants to all eligible students."
+            },
+            {
+              "number": "1087a",
+              "heading": "Program authority; eligibility",
+              "text": "(a) In general\n\nThere are hereby made available, in accordance with the provisions of this part, such sums as may be necessary (as determined under section 1087h of this title) for loans under this part for any fiscal year beginning on or after July 1, 1994.\n\n(b) Loans for which eligible\n\nExcept as provided in section 1087f of this title, all students at an institution of higher education shall be entitled to borrow under this part if the institution of higher education—\n\n(1) makes available to students attending the institution the opportunity to receive loans under this part; and\n\n(2) meets such other requirements as the Secretary shall specify by regulation."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "number": 31,
+      "name": "National Diffusion Network",
+      "subchapters": [],
+      "sections": [
+        {
+          "number": 1261,
+          "heading": "Statement of purpose",
+          "text": "It is the purpose of this chapter to promote and accelerate the systematic, rapid dissemination and adoption of validated exemplary programs to serve the educational needs of the Nation's students, and for other purposes."
+        }
+      ]
+    },
+    {
+      "number": 33,
+      "name": "Education of Individuals with Disabilities",
+      "subchapters": [
+        {
+          "number": 1,
+          "name": "General Provisions",
+          "sections": [
+            {
+              "number": 1400,
+              "heading": "Short title; findings; purposes",
+              "text": "(a) Short title\n\nThis chapter may be cited as the 'Individuals with Disabilities Education Act'.\n\n(b) Omitted\n\n(c) Findings\n\nCongress finds the following:\n\n(1) Disability is a natural part of the human experience and in no way diminishes the right of individuals to participate in or contribute to society. Improving educational results for children with disabilities is an essential element of our national policy of ensuring equality of opportunity, full participation, independent living, and economic self-sufficiency for individuals with disabilities.\n\n(2) Before the date of enactment of the Education for All Handicapped Children Act of 1975 (Public Law 94–142), the educational needs of millions of children with disabilities were not being fully met."
+            },
+            {
+              "number": 1401,
+              "heading": "Definitions",
+              "text": "Except as otherwise provided, in this chapter:\n\n(1) Assistive technology device\n\nThe term 'assistive technology device' means any item, piece of equipment, or product system, whether acquired commercially off the shelf, modified, or customized, that is used to increase, maintain, or improve functional capabilities of a child with a disability.\n\n(2) Assistive technology service\n\nThe term 'assistive technology service' means any service that directly assists a child with a disability in the selection, acquisition, or use of an assistive technology device."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "number": 48,
+      "name": "Department of Education",
+      "subchapters": [
+        {
+          "number": 1,
+          "name": "General Provisions",
+          "sections": [
+            {
+              "number": 3401,
+              "heading": "Congressional findings",
+              "text": "The Congress finds that—\n\n(1) education is fundamental to the development of individual citizens and the progress of the Nation;\n\n(2) there is a continuing need to ensure equal access for all Americans to educational opportunities of a high quality, and such educational opportunities should not be denied because of race, creed, color, national origin, or sex;\n\n(3) parents have the primary responsibility for the education of their children, and States, localities, and private institutions have the primary responsibility for supporting that parental role."
+            },
+            {
+              "number": 3402,
+              "heading": "Congressional declaration of purpose",
+              "text": "The Congress declares that the establishment of a Department of Education is in the public interest, will promote the general welfare of the United States, will help ensure that education issues receive proper treatment at the Federal level, and will enable the Federal Government to coordinate its education activities more effectively."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "number": 70,
+      "name": "Strengthening and Improvement of Elementary and Secondary Schools",
+      "subchapters": [
+        {
+          "number": 1,
+          "name": "Improving the Academic Achievement of the Disadvantaged",
+          "sections": [
+            {
+              "number": 6301,
+              "heading": "Statement of purpose",
+              "text": "The purpose of this subchapter is to provide all children significant opportunity to receive a fair, equitable, and high-quality education, and to close educational achievement gaps."
+            },
+            {
+              "number": 6311,
+              "heading": "State plans",
+              "text": "(a) Plans required\n\n(1) In general\n\nFor any State desiring to receive a grant under this part, the State educational agency shall submit to the Secretary a plan, developed by the State educational agency, in consultation with local educational agencies, teachers, principals, other school leaders, paraprofessionals, specialized instructional support personnel, charter school leaders (in a State that has charter schools), parents, and other stakeholders, that satisfies the requirements of this section and that is coordinated with other programs under this chapter, the Individuals with Disabilities Education Act, the Rehabilitation Act of 1973, the Carl D. Perkins Career and Technical Education Act of 2006, the Workforce Innovation and Opportunity Act, the Head Start Act, the Child Care and Development Block Grant Act of 1990, the McKinney-Vento Homeless Assistance Act, the Adult Education and Family Literacy Act, and other Acts as appropriate."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,5 +3,67 @@
 {% block title %}Home - My Website{% endblock %}
 
 {% block content %}
-<h1>Home</h1>
+<h1>Welcome</h1>
+
+<div class="project-links">
+    <div class="project-card">
+        <h2>US Code Browser</h2>
+        <p>Browse Title 20 (Education) of the United States Code</p>
+        <a href="/uscode" class="project-link">Explore Title 20 →</a>
+    </div>
+
+    <div class="project-card">
+        <h2>Projects</h2>
+        <p>View all projects and demonstrations</p>
+        <a href="/projects" class="project-link">View Projects →</a>
+    </div>
+</div>
+
+<style>
+    .project-links {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 20px;
+        margin-top: 30px;
+    }
+
+    .project-card {
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 25px;
+        background: white;
+        transition: box-shadow 0.2s;
+    }
+
+    .project-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
+
+    .project-card h2 {
+        margin-top: 0;
+        color: #1a1a1a;
+        font-size: 22px;
+    }
+
+    .project-card p {
+        color: #666;
+        margin: 10px 0 20px 0;
+        line-height: 1.6;
+    }
+
+    .project-link {
+        display: inline-block;
+        padding: 10px 20px;
+        background: #0066cc;
+        color: white;
+        text-decoration: none;
+        border-radius: 5px;
+        font-weight: 500;
+        transition: background 0.2s;
+    }
+
+    .project-link:hover {
+        background: #0052a3;
+    }
+</style>
 {% endblock %}

--- a/templates/uscode/chapter.html
+++ b/templates/uscode/chapter.html
@@ -1,0 +1,212 @@
+{% extends "base.html" %}
+
+{% block title %}Chapter {{ chapter.number }} - {{ chapter.name }} | Title 20 | US Code{% endblock %}
+
+{% block content %}
+<div class="uscode-browser">
+    <nav class="breadcrumb">
+        <a href="/">Home</a> &raquo;
+        <a href="/uscode">US Code</a> &raquo;
+        <a href="/uscode/title/20">Title {{ title.number }}</a> &raquo;
+        <span>Chapter {{ chapter.number }}</span>
+    </nav>
+
+    <header class="chapter-header">
+        <div class="chapter-title">
+            <span class="title-badge">Title 20</span>
+            <h1>Chapter {{ chapter.number }} — {{ chapter.name }}</h1>
+        </div>
+    </header>
+
+    <section class="chapter-content">
+        {% if chapter.subchapters and chapter.subchapters|length > 0 %}
+            <h2>Subchapters</h2>
+            {% for subchapter in chapter.subchapters %}
+            <div class="subchapter-section">
+                <h3 id="subchapter-{{ subchapter.number }}">
+                    Subchapter {{ subchapter.number }} — {{ subchapter.name }}
+                </h3>
+
+                {% if subchapter.sections and subchapter.sections|length > 0 %}
+                <div class="sections-list">
+                    {% for section in subchapter.sections %}
+                    <div class="section-item">
+                        <a href="/uscode/title/20/section/{{ section.number }}" class="section-link">
+                            <span class="section-number">§ {{ section.number }}</span>
+                            <span class="section-heading">{{ section.heading }}</span>
+                        </a>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% else %}
+                <p class="no-data">No sections in this subchapter.</p>
+                {% endif %}
+            </div>
+            {% endfor %}
+        {% endif %}
+
+        {% if chapter.sections and chapter.sections|length > 0 %}
+            <h2>{% if chapter.subchapters and chapter.subchapters|length > 0 %}Direct Chapter Sections{% else %}Sections{% endif %}</h2>
+            <div class="sections-list">
+                {% for section in chapter.sections %}
+                <div class="section-item">
+                    <a href="/uscode/title/20/section/{{ section.number }}" class="section-link">
+                        <span class="section-number">§ {{ section.number }}</span>
+                        <span class="section-heading">{{ section.heading }}</span>
+                    </a>
+                </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+
+        {% if (not chapter.subchapters or chapter.subchapters|length == 0) and (not chapter.sections or chapter.sections|length == 0) %}
+        <p class="no-data">No sections available in this chapter.</p>
+        {% endif %}
+    </section>
+
+    <nav class="chapter-nav">
+        <a href="/uscode/title/20" class="nav-button">← Back to Title 20</a>
+    </nav>
+</div>
+
+<style>
+    .uscode-browser {
+        max-width: 1000px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .breadcrumb {
+        margin-bottom: 20px;
+        font-size: 14px;
+        color: #666;
+    }
+
+    .breadcrumb a {
+        color: #0066cc;
+        text-decoration: none;
+    }
+
+    .breadcrumb a:hover {
+        text-decoration: underline;
+    }
+
+    .chapter-header {
+        margin-bottom: 40px;
+        padding-bottom: 20px;
+        border-bottom: 2px solid #e0e0e0;
+    }
+
+    .chapter-title {
+        display: flex;
+        align-items: center;
+        gap: 15px;
+    }
+
+    .title-badge {
+        background: #0066cc;
+        color: white;
+        padding: 5px 12px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .chapter-header h1 {
+        color: #1a1a1a;
+        font-size: 28px;
+        margin: 0;
+    }
+
+    .chapter-content h2 {
+        font-size: 22px;
+        color: #1a1a1a;
+        margin: 30px 0 20px 0;
+    }
+
+    .subchapter-section {
+        margin-bottom: 40px;
+    }
+
+    .subchapter-section h3 {
+        font-size: 20px;
+        color: #333;
+        margin-bottom: 15px;
+        padding-bottom: 10px;
+        border-bottom: 1px solid #e0e0e0;
+    }
+
+    .sections-list {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .section-item {
+        border: 1px solid #e0e0e0;
+        border-radius: 6px;
+        background: white;
+        transition: all 0.2s;
+    }
+
+    .section-item:hover {
+        border-color: #0066cc;
+        box-shadow: 0 2px 8px rgba(0,102,204,0.1);
+    }
+
+    .section-link {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        padding: 15px;
+        text-decoration: none;
+        color: inherit;
+    }
+
+    .section-number {
+        font-family: 'Courier New', monospace;
+        font-weight: 600;
+        color: #0066cc;
+        font-size: 14px;
+        min-width: 60px;
+    }
+
+    .section-heading {
+        color: #1a1a1a;
+        font-size: 15px;
+        line-height: 1.5;
+    }
+
+    .section-link:hover .section-heading {
+        color: #0066cc;
+    }
+
+    .no-data {
+        color: #999;
+        font-style: italic;
+        margin: 20px 0;
+    }
+
+    .chapter-nav {
+        margin-top: 40px;
+        padding-top: 20px;
+        border-top: 1px solid #e0e0e0;
+    }
+
+    .nav-button {
+        display: inline-block;
+        padding: 10px 20px;
+        background: #0066cc;
+        color: white;
+        text-decoration: none;
+        border-radius: 5px;
+        font-weight: 500;
+        transition: background 0.2s;
+    }
+
+    .nav-button:hover {
+        background: #0052a3;
+    }
+</style>
+{% endblock %}

--- a/templates/uscode/section.html
+++ b/templates/uscode/section.html
@@ -1,0 +1,274 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title.number }} U.S.C. § {{ section.number }} - {{ section.heading }}{% endblock %}
+
+{% block content %}
+<div class="uscode-browser">
+    <nav class="breadcrumb">
+        <a href="/">Home</a> &raquo;
+        <a href="/uscode">US Code</a> &raquo;
+        <a href="/uscode/title/20">Title {{ title.number }}</a> &raquo;
+        <a href="/uscode/title/20/chapter/{{ chapter.number }}">Chapter {{ chapter.number }}</a> &raquo;
+        {% if subchapter %}
+        <span>Subchapter {{ subchapter.number }}</span> &raquo;
+        {% endif %}
+        <span>§ {{ section.number }}</span>
+    </nav>
+
+    <header class="section-header">
+        <div class="section-citation">
+            <span class="citation-badge">{{ title.number }} U.S.C. § {{ section.number }}</span>
+        </div>
+        <h1>{{ section.heading }}</h1>
+
+        <div class="section-context">
+            <div class="context-item">
+                <strong>Title:</strong> {{ title.name }}
+            </div>
+            <div class="context-item">
+                <strong>Chapter:</strong> {{ chapter.name }}
+            </div>
+            {% if subchapter %}
+            <div class="context-item">
+                <strong>Subchapter:</strong> {{ subchapter.name }}
+            </div>
+            {% endif %}
+        </div>
+    </header>
+
+    <article class="section-content">
+        <div class="legal-text">
+            {{ section.text|safe|replace('\n', '<br>')|replace('  ', '&nbsp;&nbsp;') }}
+        </div>
+    </article>
+
+    <aside class="section-info">
+        <div class="info-card">
+            <h3>About This Section</h3>
+            <dl class="info-list">
+                <dt>Title:</dt>
+                <dd>{{ title.number }} - {{ title.name }}</dd>
+
+                <dt>Chapter:</dt>
+                <dd>{{ chapter.number }} - {{ chapter.name }}</dd>
+
+                {% if subchapter %}
+                <dt>Subchapter:</dt>
+                <dd>{{ subchapter.number }} - {{ subchapter.name }}</dd>
+                {% endif %}
+
+                <dt>Section:</dt>
+                <dd>{{ section.number }}</dd>
+
+                <dt>Citation:</dt>
+                <dd><code>{{ title.number }} U.S.C. § {{ section.number }}</code></dd>
+            </dl>
+        </div>
+
+        <div class="info-card">
+            <h3>Legal Notice</h3>
+            <p class="legal-notice">
+                {% if title.is_positive_law %}
+                This is a positive law title. The US Code text is the legal evidence of law.
+                {% else %}
+                This title is not positive law. The Statutes at Large, not the US Code, is the legal evidence of law.
+                {% endif %}
+            </p>
+            <p class="legal-notice">
+                This is an MVP demonstration. For official legal reference, consult official government sources.
+            </p>
+        </div>
+    </aside>
+
+    <nav class="section-nav">
+        <a href="/uscode/title/20/chapter/{{ chapter.number }}" class="nav-button">
+            ← Back to Chapter {{ chapter.number }}
+        </a>
+        <a href="/uscode/title/20" class="nav-button secondary">
+            Back to Title 20
+        </a>
+    </nav>
+</div>
+
+<style>
+    .uscode-browser {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .breadcrumb {
+        margin-bottom: 20px;
+        font-size: 14px;
+        color: #666;
+    }
+
+    .breadcrumb a {
+        color: #0066cc;
+        text-decoration: none;
+    }
+
+    .breadcrumb a:hover {
+        text-decoration: underline;
+    }
+
+    .section-header {
+        margin-bottom: 30px;
+        padding-bottom: 20px;
+        border-bottom: 2px solid #e0e0e0;
+    }
+
+    .section-citation {
+        margin-bottom: 15px;
+    }
+
+    .citation-badge {
+        display: inline-block;
+        background: #1a1a1a;
+        color: white;
+        padding: 6px 12px;
+        border-radius: 4px;
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .section-header h1 {
+        color: #1a1a1a;
+        font-size: 28px;
+        margin: 15px 0;
+        line-height: 1.3;
+    }
+
+    .section-context {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 20px;
+        margin-top: 15px;
+        font-size: 14px;
+        color: #666;
+    }
+
+    .context-item strong {
+        color: #333;
+        margin-right: 5px;
+    }
+
+    .section-content {
+        background: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 8px;
+        padding: 30px;
+        margin-bottom: 30px;
+    }
+
+    .legal-text {
+        font-family: 'Georgia', serif;
+        font-size: 16px;
+        line-height: 1.8;
+        color: #1a1a1a;
+        white-space: pre-wrap;
+    }
+
+    .section-info {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+        margin-bottom: 30px;
+    }
+
+    .info-card {
+        background: white;
+        border: 1px solid #dee2e6;
+        border-radius: 8px;
+        padding: 20px;
+    }
+
+    .info-card h3 {
+        font-size: 16px;
+        color: #1a1a1a;
+        margin: 0 0 15px 0;
+        padding-bottom: 10px;
+        border-bottom: 1px solid #e0e0e0;
+    }
+
+    .info-list {
+        margin: 0;
+        font-size: 14px;
+    }
+
+    .info-list dt {
+        font-weight: 600;
+        color: #555;
+        margin-top: 10px;
+    }
+
+    .info-list dt:first-child {
+        margin-top: 0;
+    }
+
+    .info-list dd {
+        margin: 5px 0 0 0;
+        color: #333;
+    }
+
+    .info-list code {
+        background: #f0f0f0;
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-family: 'Courier New', monospace;
+        font-size: 13px;
+    }
+
+    .legal-notice {
+        font-size: 13px;
+        color: #666;
+        line-height: 1.6;
+        margin: 10px 0;
+    }
+
+    .legal-notice:first-of-type {
+        margin-top: 0;
+    }
+
+    .section-nav {
+        display: flex;
+        gap: 15px;
+        padding-top: 20px;
+        border-top: 1px solid #e0e0e0;
+    }
+
+    .nav-button {
+        display: inline-block;
+        padding: 10px 20px;
+        background: #0066cc;
+        color: white;
+        text-decoration: none;
+        border-radius: 5px;
+        font-weight: 500;
+        transition: background 0.2s;
+    }
+
+    .nav-button:hover {
+        background: #0052a3;
+    }
+
+    .nav-button.secondary {
+        background: #6c757d;
+    }
+
+    .nav-button.secondary:hover {
+        background: #545b62;
+    }
+
+    @media (max-width: 768px) {
+        .section-info {
+            grid-template-columns: 1fr;
+        }
+
+        .section-nav {
+            flex-direction: column;
+        }
+    }
+</style>
+{% endblock %}

--- a/templates/uscode/title.html
+++ b/templates/uscode/title.html
@@ -1,0 +1,233 @@
+{% extends "base.html" %}
+
+{% block title %}Title {{ title.number }} - {{ title.name }} | US Code Browser{% endblock %}
+
+{% block content %}
+<div class="uscode-browser">
+    <nav class="breadcrumb">
+        <a href="/">Home</a> &raquo;
+        <a href="/uscode">US Code</a> &raquo;
+        <span>Title {{ title.number }}</span>
+    </nav>
+
+    <header class="title-header">
+        <h1>Title {{ title.number }} — {{ title.name }}</h1>
+        {% if not title.is_positive_law %}
+        <div class="notice notice-warning">
+            <strong>⚠️ Non-Positive Law Title</strong>
+            <p>This title is a non-positive law codification. The United States Statutes at Large, not the US Code, is the legal evidence of law.</p>
+        </div>
+        {% else %}
+        <div class="notice notice-info">
+            <strong>✓ Positive Law Title</strong>
+            <p>This title has been enacted as positive law. The US Code text is the legal evidence of law.</p>
+        </div>
+        {% endif %}
+
+        <p class="title-description">{{ title.description }}</p>
+    </header>
+
+    <section class="chapters-list">
+        <h2>Chapters</h2>
+
+        {% if chapters|length == 0 %}
+        <p class="no-data">No chapters available.</p>
+        {% else %}
+        <div class="chapters-grid">
+            {% for chapter in chapters %}
+            <div class="chapter-card">
+                <div class="chapter-header">
+                    <a href="/uscode/title/20/chapter/{{ chapter.number }}" class="chapter-link">
+                        <span class="chapter-number">Chapter {{ chapter.number }}</span>
+                        <span class="chapter-name">{{ chapter.name }}</span>
+                    </a>
+                </div>
+
+                <div class="chapter-meta">
+                    {% if chapter.subchapters %}
+                    <span class="meta-item">{{ chapter.subchapters|length }} subchapter(s)</span>
+                    {% endif %}
+
+                    {% set section_count = 0 %}
+                    {% if chapter.sections %}
+                        {% set section_count = section_count + chapter.sections|length %}
+                    {% endif %}
+                    {% if chapter.subchapters %}
+                        {% for subchapter in chapter.subchapters %}
+                            {% if subchapter.sections %}
+                                {% set section_count = section_count + subchapter.sections|length %}
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
+
+                    {% if section_count > 0 %}
+                    <span class="meta-item">{{ section_count }} section(s)</span>
+                    {% endif %}
+                </div>
+
+                {% if chapter.subchapters and chapter.subchapters|length > 0 %}
+                <ul class="subchapter-list">
+                    {% for subchapter in chapter.subchapters[:3] %}
+                    <li>{{ subchapter.name }}</li>
+                    {% endfor %}
+                    {% if chapter.subchapters|length > 3 %}
+                    <li><em>... and {{ chapter.subchapters|length - 3 }} more</em></li>
+                    {% endif %}
+                </ul>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </section>
+</div>
+
+<style>
+    .uscode-browser {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .breadcrumb {
+        margin-bottom: 20px;
+        font-size: 14px;
+        color: #666;
+    }
+
+    .breadcrumb a {
+        color: #0066cc;
+        text-decoration: none;
+    }
+
+    .breadcrumb a:hover {
+        text-decoration: underline;
+    }
+
+    .title-header {
+        margin-bottom: 40px;
+    }
+
+    .title-header h1 {
+        color: #1a1a1a;
+        margin-bottom: 20px;
+        font-size: 32px;
+    }
+
+    .notice {
+        padding: 15px;
+        border-radius: 5px;
+        margin: 20px 0;
+    }
+
+    .notice-warning {
+        background-color: #fff3cd;
+        border-left: 4px solid #ffc107;
+    }
+
+    .notice-info {
+        background-color: #d1ecf1;
+        border-left: 4px solid #0dcaf0;
+    }
+
+    .notice strong {
+        display: block;
+        margin-bottom: 5px;
+    }
+
+    .notice p {
+        margin: 0;
+        font-size: 14px;
+    }
+
+    .title-description {
+        font-size: 16px;
+        color: #555;
+        line-height: 1.6;
+    }
+
+    .chapters-list h2 {
+        font-size: 24px;
+        margin-bottom: 20px;
+        color: #1a1a1a;
+    }
+
+    .chapters-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+        gap: 20px;
+    }
+
+    .chapter-card {
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 20px;
+        background: white;
+        transition: box-shadow 0.2s;
+    }
+
+    .chapter-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
+
+    .chapter-header {
+        margin-bottom: 12px;
+    }
+
+    .chapter-link {
+        text-decoration: none;
+        color: inherit;
+        display: block;
+    }
+
+    .chapter-link:hover .chapter-name {
+        color: #0066cc;
+    }
+
+    .chapter-number {
+        display: block;
+        font-size: 14px;
+        color: #666;
+        font-weight: 600;
+        margin-bottom: 5px;
+    }
+
+    .chapter-name {
+        display: block;
+        font-size: 18px;
+        font-weight: 600;
+        color: #1a1a1a;
+        transition: color 0.2s;
+    }
+
+    .chapter-meta {
+        display: flex;
+        gap: 15px;
+        margin-bottom: 12px;
+        font-size: 13px;
+        color: #666;
+    }
+
+    .meta-item {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .subchapter-list {
+        list-style: none;
+        padding: 0;
+        margin: 10px 0 0 0;
+        font-size: 13px;
+        color: #555;
+    }
+
+    .subchapter-list li {
+        padding: 3px 0;
+    }
+
+    .no-data {
+        color: #999;
+        font-style: italic;
+    }
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
This PR adds a new US Code browser feature to the application, starting with Title 20 (Education). Users can now browse the hierarchical structure of the US Code, navigating from titles to chapters to sections with full legal text display.

## Key Changes

- **Backend Routes**: Added 5 new routes to handle US Code navigation:
  - `/uscode` - Main US Code browser (redirects to Title 20)
  - `/uscode/title/20` - Title 20 overview with chapter listing
  - `/uscode/title/20/chapter/<num>` - Chapter view with sections/subchapters
  - `/uscode/title/20/section/<num>` - Individual section with full legal text
  - `/api/title/20` - JSON API endpoint for programmatic access

- **Data Structure**: Added `data/title20_structure.json` containing:
  - Title metadata (number, name, positive law status, description)
  - 6 chapters with hierarchical structure (chapters → subchapters → sections)
  - Sample legal text from actual US Code sections (Smithsonian Institution, Higher Education, IDEA, etc.)

- **Frontend Templates**: Created 3 new templates in `templates/uscode/`:
  - `title.html` - Title overview with chapter cards showing metadata
  - `chapter.html` - Chapter view with organized section listings
  - `section.html` - Full section display with legal text, citation info, and navigation

- **Home Page**: Updated `home.html` with project cards linking to the new US Code browser

## Implementation Details

- Section lookup uses flexible matching (handles both int and string section numbers)
- Breadcrumb navigation on all pages for easy orientation
- Responsive grid layouts for chapter cards
- Legal text preserves formatting with proper whitespace handling
- Includes legal notices about positive law status and MVP disclaimer
- Clean, accessible styling with hover states and visual hierarchy