### PR TITLE
feat: add latest amendment badge and Code/History tabs (Task 1A.11)

### DIFF
--- a/frontend/src/components/viewer/SectionHeader.test.tsx
+++ b/frontend/src/components/viewer/SectionHeader.test.tsx
@@ -77,4 +77,36 @@ describe('SectionHeader', () => {
     expect(screen.queryByText(/Enacted/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Last modified/)).not.toBeInTheDocument();
   });
+
+  it('renders latest amendment badge when provided', () => {
+    render(
+      <SectionHeader
+        fullCitation="17 U.S.C. § 106"
+        heading="Test"
+        enactedDate={null}
+        lastModifiedDate={null}
+        isPositiveLaw={false}
+        isRepealed={false}
+        latestAmendment={{ publicLawId: 'PL 116-283', year: 2021 }}
+      />
+    );
+    expect(screen.getByText('PL 116-283')).toBeInTheDocument();
+    expect(screen.getByText(/2021/)).toBeInTheDocument();
+    expect(screen.getByText(/Last amended by/)).toBeInTheDocument();
+  });
+
+  it('does not render latest amendment badge when null', () => {
+    render(
+      <SectionHeader
+        fullCitation="17 U.S.C. § 106"
+        heading="Test"
+        enactedDate={null}
+        lastModifiedDate={null}
+        isPositiveLaw={false}
+        isRepealed={false}
+        latestAmendment={null}
+      />
+    );
+    expect(screen.queryByText(/Last amended by/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/viewer/SectionHeader.tsx
+++ b/frontend/src/components/viewer/SectionHeader.tsx
@@ -5,6 +5,7 @@ interface SectionHeaderProps {
   lastModifiedDate: string | null;
   isPositiveLaw: boolean;
   isRepealed: boolean;
+  latestAmendment?: { publicLawId: string; year: number } | null;
 }
 
 /** Renders the section heading, citation, and metadata badges. */
@@ -15,6 +16,7 @@ export default function SectionHeader({
   lastModifiedDate,
   isPositiveLaw,
   isRepealed,
+  latestAmendment,
 }: SectionHeaderProps) {
   return (
     <header className="mb-6">
@@ -37,6 +39,13 @@ export default function SectionHeader({
         {lastModifiedDate && (
           <span className="text-gray-500">
             Last modified {lastModifiedDate}
+          </span>
+        )}
+        {latestAmendment && (
+          <span className="rounded bg-indigo-50 px-2 py-0.5 font-medium text-indigo-700">
+            Last amended by{' '}
+            <span className="font-mono">{latestAmendment.publicLawId}</span> (
+            {latestAmendment.year})
           </span>
         )}
       </div>

--- a/frontend/src/components/viewer/SectionViewer.test.tsx
+++ b/frontend/src/components/viewer/SectionViewer.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SectionViewer from './SectionViewer';
+import type { SectionView } from '@/lib/types';
+
+vi.mock('@/hooks/useSection', () => ({
+  useSection: vi.fn(),
+}));
+
+import { useSection } from '@/hooks/useSection';
+
+const mockUseSection = vi.mocked(useSection);
+
+const baseSectionData: SectionView = {
+  title_number: 17,
+  section_number: '106',
+  heading: 'Exclusive rights in copyrighted works',
+  full_citation: '17 U.S.C. § 106',
+  text_content: '(a) In General',
+  provisions: null,
+  enacted_date: '1976-10-19',
+  last_modified_date: '2020-01-01',
+  is_positive_law: true,
+  is_repealed: false,
+  notes: {
+    citations: [
+      {
+        law_id: 'PL 94-553',
+        law_title: 'Copyright Act of 1976',
+        relationship: 'Enactment',
+        raw_text: 'Pub. L. 94-553, title I, § 106',
+      },
+    ],
+    amendments: [
+      {
+        law: {
+          congress: 116,
+          law_number: 283,
+          public_law_id: 'PL 116-283',
+          date: '2021-01-01',
+        },
+        year: 2021,
+        description: 'Amended subsection (a)',
+        public_law_id: 'PL 116-283',
+      },
+      {
+        law: {
+          congress: 110,
+          law_number: 403,
+          public_law_id: 'PL 110-403',
+          date: '2008-10-13',
+        },
+        year: 2008,
+        description: 'Amended subsection (b)',
+        public_law_id: 'PL 110-403',
+      },
+    ],
+    short_titles: [],
+    notes: [],
+    has_notes: false,
+    has_citations: true,
+    has_amendments: true,
+    transferred_to: null,
+    omitted: false,
+    renumbered_from: null,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SectionViewer', () => {
+  it('renders loading state', () => {
+    mockUseSection.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={17} sectionNumber="106" />);
+    expect(screen.getByText('Loading section...')).toBeInTheDocument();
+  });
+
+  it('renders error state', () => {
+    mockUseSection.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={17} sectionNumber="106" />);
+    expect(screen.getByText('Failed to load section.')).toBeInTheDocument();
+  });
+
+  it('extracts and displays the latest amendment in the header', () => {
+    mockUseSection.mockReturnValue({
+      data: baseSectionData,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={17} sectionNumber="106" />);
+    expect(screen.getByText('PL 116-283')).toBeInTheDocument();
+    expect(screen.getByText(/2021/)).toBeInTheDocument();
+  });
+
+  it('shows tabs when amendments or citations exist', () => {
+    mockUseSection.mockReturnValue({
+      data: baseSectionData,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={17} sectionNumber="106" />);
+    expect(screen.getByRole('tab', { name: 'Code' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'History' })).toBeInTheDocument();
+  });
+
+  it('does not show tabs when no amendments or citations', () => {
+    const dataWithoutHistory: SectionView = {
+      ...baseSectionData,
+      notes: {
+        ...baseSectionData.notes!,
+        amendments: [],
+        citations: [],
+        has_amendments: false,
+        has_citations: false,
+      },
+    };
+    mockUseSection.mockReturnValue({
+      data: dataWithoutHistory,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={17} sectionNumber="106" />);
+    expect(screen.queryByRole('tab')).toBeNull();
+  });
+
+  it('defaults to Code tab showing provisions', () => {
+    mockUseSection.mockReturnValue({
+      data: baseSectionData,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={17} sectionNumber="106" />);
+
+    expect(screen.getByRole('tab', { name: 'Code' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('tab', { name: 'History' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    );
+    // Provisions visible, history not
+    expect(
+      screen.getByRole('heading', { name: '17 U.S.C. § 106' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Amendment History')).toBeNull();
+  });
+
+  it('switches between Code and History tabs', async () => {
+    mockUseSection.mockReturnValue({
+      data: baseSectionData,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={17} sectionNumber="106" />);
+
+    // Click History tab
+    await userEvent.click(screen.getByRole('tab', { name: 'History' }));
+    expect(screen.getByText('Amendment History')).toBeInTheDocument();
+    expect(screen.getByText('Source Laws')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'History' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    // Click Code tab to go back
+    await userEvent.click(screen.getByRole('tab', { name: 'Code' }));
+    expect(screen.queryByText('Amendment History')).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Code' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+});

--- a/frontend/src/components/viewer/SectionViewer.tsx
+++ b/frontend/src/components/viewer/SectionViewer.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useState } from 'react';
 import { useSection } from '@/hooks/useSection';
 import SectionHeader from './SectionHeader';
 import SectionProvisions from './SectionProvisions';
+import AmendmentList from './AmendmentList';
+import CitationList from './CitationList';
 
 interface SectionViewerProps {
   titleNumber: number;
@@ -15,6 +18,7 @@ export default function SectionViewer({
   sectionNumber,
 }: SectionViewerProps) {
   const { data, isLoading, error } = useSection(titleNumber, sectionNumber);
+  const [activeTab, setActiveTab] = useState<'code' | 'history'>('code');
 
   if (isLoading) {
     return <p className="text-gray-500">Loading section...</p>;
@@ -23,6 +27,16 @@ export default function SectionViewer({
   if (error || !data) {
     return <p className="text-red-600">Failed to load section.</p>;
   }
+
+  const amendments = data.notes?.amendments ?? [];
+  const citations = data.notes?.citations ?? [];
+  const hasHistory = amendments.length > 0 || citations.length > 0;
+
+  const sorted = [...amendments].sort((a, b) => b.year - a.year);
+  const latestAmendment =
+    sorted.length > 0
+      ? { publicLawId: sorted[0].public_law_id, year: sorted[0].year }
+      : null;
 
   return (
     <div>
@@ -33,14 +47,45 @@ export default function SectionViewer({
         lastModifiedDate={data.last_modified_date}
         isPositiveLaw={data.is_positive_law}
         isRepealed={data.is_repealed}
+        latestAmendment={latestAmendment}
       />
-      <SectionProvisions
-        fullCitation={data.full_citation}
-        heading={data.heading}
-        textContent={data.text_content}
-        provisions={data.provisions}
-        isRepealed={data.is_repealed}
-      />
+      {hasHistory && (
+        <div
+          role="tablist"
+          className="mb-4 flex border-b border-gray-200 text-sm font-medium"
+        >
+          <button
+            role="tab"
+            aria-selected={activeTab === 'code'}
+            onClick={() => setActiveTab('code')}
+            className={`px-4 py-2 ${activeTab === 'code' ? 'border-b-2 border-indigo-600 text-indigo-600' : 'text-gray-500 hover:text-gray-700'}`}
+          >
+            Code
+          </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === 'history'}
+            onClick={() => setActiveTab('history')}
+            className={`px-4 py-2 ${activeTab === 'history' ? 'border-b-2 border-indigo-600 text-indigo-600' : 'text-gray-500 hover:text-gray-700'}`}
+          >
+            History
+          </button>
+        </div>
+      )}
+      {activeTab === 'code' ? (
+        <SectionProvisions
+          fullCitation={data.full_citation}
+          heading={data.heading}
+          textContent={data.text_content}
+          provisions={data.provisions}
+          isRepealed={data.is_repealed}
+        />
+      ) : (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <AmendmentList amendments={amendments} />
+          <CitationList citations={citations} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Surface the most recent amendment as an indigo badge in the section header (e.g. "Last amended by PL 116-283 (2021)")
- Add a tabbed interface (Code / History) to switch between the provisions view and a full amendment history + source laws panel
- Tabs only appear when the section has amendment or citation data

## Test plan
- [x] `npm run test` — 93 tests pass (7 new: 2 SectionHeader, 5 SectionViewer)
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run format -- --check` — clean
- [ ] Manual: visit `/sections/17/106`, confirm latest amendment badge appears, click History tab to see amendments and source laws, click Code tab to return to provisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)