### PR TITLE
fix: strip orphaned brackets from repealed/reserved chapter headings

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -92,6 +92,23 @@ def title_case_heading(text: str) -> str:
     return " ".join(result)
 
 
+def _clean_bracket_heading(text: str) -> str:
+    """Strip orphaned brackets from heading text.
+
+    OLRC XML splits bracket-enclosed status markers across <num> and <heading>
+    elements, e.g. ``<num>[CHAPTER 5—</num><heading>REPEALED]</heading>``.
+    This produces headings like ``REPEALED]`` (trailing bracket, missing opening
+    bracket) or ``[Reserved]`` (fully bracketed). Strip leading ``[`` and
+    trailing ``]`` so downstream title-casing works on clean text.
+    """
+    text = text.strip()
+    if text.startswith("["):
+        text = text[1:]
+    if text.endswith("]"):
+        text = text[:-1]
+    return text.strip()
+
+
 # Alias for backward compatibility
 to_title_case = title_case_heading
 
@@ -513,7 +530,9 @@ class USLMParser:
 
         # Extract chapter number and name (convert ALL-CAPS to Title Case)
         chapter_number = self._get_number(chapter_elem)
-        chapter_name = title_case_heading(self._get_heading(chapter_elem))
+        chapter_name = title_case_heading(
+            _clean_bracket_heading(self._get_heading(chapter_elem))
+        )
 
         if not chapter_number:
             chapter_number = str(self._chapter_order)
@@ -564,7 +583,9 @@ class USLMParser:
         self._section_order = 0
 
         subch_number = self._get_number(subch_elem)
-        subch_name = title_case_heading(self._get_heading(subch_elem))
+        subch_name = title_case_heading(
+            _clean_bracket_heading(self._get_heading(subch_elem))
+        )
 
         if not subch_number:
             subch_number = str(self._subchapter_order)

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -7,6 +7,7 @@ from lxml import etree
 
 from pipeline.olrc.parser import (
     USLMParser,
+    _clean_bracket_heading,
     compute_text_hash,
     title_case_heading,
     to_title_case,
@@ -379,3 +380,35 @@ class TestTitleCaseHeading:
             title_case_heading("PROTECTION OF TRADING WITH ENEMIES")
             == "Protection of Trading with Enemies"
         )
+
+
+class TestCleanBracketHeading:
+    """Tests for _clean_bracket_heading()."""
+
+    def test_trailing_bracket_allcaps(self) -> None:
+        """Test trailing bracket from split-bracket REPEALED status."""
+        assert _clean_bracket_heading("REPEALED]") == "REPEALED"
+
+    def test_trailing_bracket_mixed_case(self) -> None:
+        """Test trailing bracket from split-bracket Repealed status."""
+        assert _clean_bracket_heading("Repealed]") == "Repealed"
+
+    def test_trailing_bracket_transferred(self) -> None:
+        """Test trailing bracket from split-bracket TRANSFERRED status."""
+        assert _clean_bracket_heading("TRANSFERRED]") == "TRANSFERRED"
+
+    def test_fully_bracketed_reserved(self) -> None:
+        """Test fully bracketed [Reserved] heading."""
+        assert _clean_bracket_heading("[Reserved]") == "Reserved"
+
+    def test_fully_bracketed_allcaps_reserved(self) -> None:
+        """Test fully bracketed [RESERVED] heading."""
+        assert _clean_bracket_heading("[RESERVED]") == "RESERVED"
+
+    def test_normal_heading_unchanged(self) -> None:
+        """Test normal heading without brackets is unchanged."""
+        assert _clean_bracket_heading("GENERAL PROVISIONS") == "GENERAL PROVISIONS"
+
+    def test_empty_string(self) -> None:
+        """Test empty string returns empty string."""
+        assert _clean_bracket_heading("") == ""


### PR DESCRIPTION
## Summary

Fixes #62

- OLRC XML splits bracket-enclosed status markers across `<num>` and `<heading>` elements (e.g. `<num>[CHAPTER 5—</num><heading>REPEALED]</heading>`), producing headings like `REPEALED]` instead of `Repealed`
- Adds `_clean_bracket_heading()` helper that strips leading `[` and trailing `]` before title-case conversion
- Applied to both `_parse_chapter()` and `_parse_subchapter()` in the USLM parser

## Test plan

- [x] Added 7 unit tests covering: `REPEALED]`, `Repealed]`, `TRANSFERRED]`, `[Reserved]`, `[RESERVED]`, normal heading unchanged, empty string
- [x] All 319 backend tests pass
- [x] Ruff, Black, mypy all pass
- [x] Re-ingest Title 26 and verify Chapter 5 shows "Repealed" in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)