### PR TITLE
fix: adjust tree node subtitle padding for consistent alignment

### DIFF
--- a/frontend/src/components/law-viewer/AffectedSectionsTree.tsx
+++ b/frontend/src/components/law-viewer/AffectedSectionsTree.tsx
@@ -101,7 +101,7 @@ function PrunedGroupNode({
       </div>
       {expanded && (
         <div className="ml-4 border-l border-gray-300 pl-2">
-          <p className="px-2 py-0.5 font-mono text-xs text-gray-400">
+          <p className="py-0.5 pl-3 pr-2 font-mono text-xs text-gray-400">
             {capitalizeGroupType(group.group_type)} {group.number}
           </p>
           {affectedChildren.map((child) => (
@@ -144,7 +144,7 @@ function PrunedGroupNode({
                 </div>
                 {isActive && (
                   <div className="ml-4 border-l border-gray-300 pl-2">
-                    <p className="px-2 py-0.5 font-mono text-xs text-gray-400">
+                    <p className="py-0.5 pl-3 pr-2 font-mono text-xs text-gray-400">
                       &sect;&thinsp;{section.section_number}
                     </p>
                     <button
@@ -196,7 +196,7 @@ function TitleTreeNode({
       </div>
       {expanded && (
         <div className="ml-4 border-l border-gray-300 pl-2">
-          <p className="px-2 py-0.5 font-mono text-xs text-gray-400">
+          <p className="py-0.5 pl-3 pr-2 font-mono text-xs text-gray-400">
             Title {titleNumber}
           </p>
           {isLoading && (

--- a/frontend/src/components/tree/GroupNode.tsx
+++ b/frontend/src/components/tree/GroupNode.tsx
@@ -81,7 +81,7 @@ export default function GroupNode({
       </div>
       {expanded && (
         <div className="ml-4 border-l border-gray-300 pl-2">
-          <p className="px-2 py-0.5 font-mono text-xs text-gray-400">
+          <p className="py-0.5 pl-3 pr-2 font-mono text-xs text-gray-400">
             {capitalizeGroupType(group.group_type)} {group.number}
           </p>
           {group.children.map((child) => (

--- a/frontend/src/components/tree/SectionNode.tsx
+++ b/frontend/src/components/tree/SectionNode.tsx
@@ -49,7 +49,7 @@ export default function SectionNode({
       </div>
       {expanded && (
         <div className="ml-4 border-l border-gray-300 pl-2">
-          <p className="px-2 py-0.5 font-mono text-xs text-gray-400">
+          <p className="py-0.5 pl-3 pr-2 font-mono text-xs text-gray-400">
             &sect;&thinsp;{section.section_number}
           </p>
           <Link

--- a/frontend/src/components/tree/TitleNode.tsx
+++ b/frontend/src/components/tree/TitleNode.tsx
@@ -48,7 +48,7 @@ export default function TitleNode({ title, activePath }: TitleNodeProps) {
       </div>
       {expanded && (
         <div className="ml-4 border-l border-gray-300 pl-2">
-          <p className="px-2 py-0.5 font-mono text-xs text-gray-400">
+          <p className="py-0.5 pl-3 pr-2 font-mono text-xs text-gray-400">
             Title {title.title_number}
           </p>
           {isLoading && (


### PR DESCRIPTION
## Summary
- Replaces `px-2` with `pl-3 pr-2` on tree node subtitle labels across all sidebar tree components for consistent left-alignment with node content

## Test plan
- [x] Verify US Code tree sidebar nodes render with correct padding
- [x] Verify law viewer amended sections sidebar nodes render with correct padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)