### PR TITLE
feat: add RP-to-RP diffing engine and release point ingestor (Task 1.20)

### DIFF
--- a/backend/pipeline/olrc/diff_engine.py
+++ b/backend/pipeline/olrc/diff_engine.py
@@ -1,0 +1,189 @@
+"""RP-to-RP diff engine for the chronological pipeline.
+
+Compares two revisions by materializing their section state and classifying
+every section as ADDED, MODIFIED, DELETED, or UNCHANGED based on text_hash
+and notes_hash comparisons.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pipeline.olrc.snapshot_service import SectionState, SnapshotService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SectionDiff:
+    """One section's change between two revisions."""
+
+    title_number: int
+    section_number: str
+    change_type: str  # "added", "modified", "deleted"
+    text_changed: bool
+    notes_changed: bool
+    before_state: SectionState | None  # None for added
+    after_state: SectionState | None  # None for deleted
+
+
+@dataclass
+class RevisionDiffResult:
+    """Full diff between two revisions."""
+
+    before_revision_id: int
+    after_revision_id: int
+    sections_added: int
+    sections_modified: int
+    sections_deleted: int
+    sections_unchanged: int
+    diffs: list[SectionDiff]  # Only changed sections
+    elapsed_seconds: float
+
+
+class RevisionDiffEngine:
+    """Compares two revisions and produces a section-level diff."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.snapshot_service = SnapshotService(session)
+
+    async def diff(
+        self, before_revision_id: int, after_revision_id: int
+    ) -> RevisionDiffResult:
+        """Diff two revisions by comparing section hashes.
+
+        Args:
+            before_revision_id: The earlier revision ID.
+            after_revision_id: The later revision ID.
+
+        Returns:
+            RevisionDiffResult with counts and changed-section diffs.
+        """
+        start = time.monotonic()
+
+        before_states = await self.snapshot_service.get_all_sections_at_revision(
+            before_revision_id
+        )
+        after_states = await self.snapshot_service.get_all_sections_at_revision(
+            after_revision_id
+        )
+
+        result = diff_section_maps(
+            before_states, after_states, before_revision_id, after_revision_id
+        )
+
+        elapsed = time.monotonic() - start
+        result.elapsed_seconds = elapsed
+
+        logger.info(
+            f"Diff {before_revision_id} -> {after_revision_id}: "
+            f"+{result.sections_added} ~{result.sections_modified} "
+            f"-{result.sections_deleted} ={result.sections_unchanged} "
+            f"({elapsed:.1f}s)"
+        )
+
+        return result
+
+
+def diff_section_maps(
+    before_states: list[SectionState],
+    after_states: list[SectionState],
+    before_revision_id: int,
+    after_revision_id: int,
+) -> RevisionDiffResult:
+    """Pure-function diff logic operating on SectionState lists.
+
+    Separated from the engine class so it can be tested without DB mocks.
+
+    Args:
+        before_states: Sections at the earlier revision.
+        after_states: Sections at the later revision.
+        before_revision_id: ID of the earlier revision.
+        after_revision_id: ID of the later revision.
+
+    Returns:
+        RevisionDiffResult (elapsed_seconds set to 0.0; caller may override).
+    """
+    before_map: dict[tuple[int, str], SectionState] = {
+        (s.title_number, s.section_number): s for s in before_states
+    }
+    after_map: dict[tuple[int, str], SectionState] = {
+        (s.title_number, s.section_number): s for s in after_states
+    }
+
+    diffs: list[SectionDiff] = []
+    added = 0
+    modified = 0
+    deleted = 0
+    unchanged = 0
+
+    # Check after_map against before_map
+    for key, after_state in after_map.items():
+        before_state = before_map.get(key)
+        if before_state is None:
+            # ADDED
+            diffs.append(
+                SectionDiff(
+                    title_number=key[0],
+                    section_number=key[1],
+                    change_type="added",
+                    text_changed=True,
+                    notes_changed=after_state.notes_hash is not None,
+                    before_state=None,
+                    after_state=after_state,
+                )
+            )
+            added += 1
+        else:
+            text_changed = before_state.text_hash != after_state.text_hash
+            notes_changed = before_state.notes_hash != after_state.notes_hash
+            if text_changed or notes_changed:
+                # MODIFIED
+                diffs.append(
+                    SectionDiff(
+                        title_number=key[0],
+                        section_number=key[1],
+                        change_type="modified",
+                        text_changed=text_changed,
+                        notes_changed=notes_changed,
+                        before_state=before_state,
+                        after_state=after_state,
+                    )
+                )
+                modified += 1
+            else:
+                unchanged += 1
+
+    # Check for deletions (in before but not in after)
+    for key, before_state in before_map.items():
+        if key not in after_map:
+            diffs.append(
+                SectionDiff(
+                    title_number=key[0],
+                    section_number=key[1],
+                    change_type="deleted",
+                    text_changed=True,
+                    notes_changed=before_state.notes_hash is not None,
+                    before_state=before_state,
+                    after_state=None,
+                )
+            )
+            deleted += 1
+
+    # Sort diffs by title and section for consistent output
+    diffs.sort(key=lambda d: (d.title_number, d.section_number))
+
+    return RevisionDiffResult(
+        before_revision_id=before_revision_id,
+        after_revision_id=after_revision_id,
+        sections_added=added,
+        sections_modified=modified,
+        sections_deleted=deleted,
+        sections_unchanged=unchanged,
+        diffs=diffs,
+        elapsed_seconds=0.0,
+    )

--- a/backend/pipeline/olrc/rp_ingestor.py
+++ b/backend/pipeline/olrc/rp_ingestor.py
@@ -1,0 +1,238 @@
+"""Release Point ingestor for the chronological pipeline.
+
+Ingests a subsequent OLRC release point (after bootstrap) by downloading,
+parsing, and storing SectionSnapshot records, then running the diff engine
+to classify changes relative to the parent revision.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.enums import RevisionStatus, RevisionType
+from app.models.release_point import OLRCReleasePoint
+from app.models.revision import CodeRevision
+from pipeline.olrc.bootstrap import ALL_TITLES, ingest_title
+from pipeline.olrc.diff_engine import RevisionDiffEngine, RevisionDiffResult
+from pipeline.olrc.downloader import OLRCDownloader
+from pipeline.olrc.parser import USLMParser
+from pipeline.olrc.release_point import parse_release_point_identifier
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RPIngestResult:
+    """Summary returned by RPIngestor.ingest_release_point."""
+
+    revision_id: int
+    rp_identifier: str
+    parent_revision_id: int
+    titles_processed: int
+    titles_skipped: int
+    total_sections: int
+    diff_summary: RevisionDiffResult | None
+    elapsed_seconds: float
+
+
+class RPIngestor:
+    """Ingests a subsequent OLRC release point and diffs against the parent."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        downloader: OLRCDownloader,
+        parser: USLMParser,
+    ) -> None:
+        self.session = session
+        self.downloader = downloader
+        self.parser = parser
+
+    async def ingest_release_point(
+        self,
+        rp_identifier: str,
+        parent_revision_id: int,
+        sequence_number: int,
+        titles: list[int] | None = None,
+        force: bool = False,
+    ) -> RPIngestResult:
+        """Ingest a release point and diff against the parent revision.
+
+        Args:
+            rp_identifier: Release point identifier (e.g., "113-37").
+            parent_revision_id: Revision ID of the parent (earlier RP).
+            sequence_number: Global ordering position in the timeline.
+            titles: Title numbers to ingest (default: 1-54).
+            force: Re-ingest even if already completed.
+
+        Returns:
+            RPIngestResult with summary statistics and diff.
+        """
+        start_time = time.monotonic()
+        title_list = titles or ALL_TITLES
+        revision: CodeRevision | None = None
+
+        try:
+            # Step 1: Check idempotency
+            release_point, revision = await self._get_or_create_records(rp_identifier)
+
+            if (
+                revision
+                and revision.status == RevisionStatus.INGESTED.value
+                and not force
+            ):
+                elapsed = time.monotonic() - start_time
+                logger.info(
+                    f"Release point {rp_identifier} already ingested "
+                    f"(revision {revision.revision_id})"
+                )
+                return RPIngestResult(
+                    revision_id=revision.revision_id,
+                    rp_identifier=rp_identifier,
+                    parent_revision_id=parent_revision_id,
+                    titles_processed=0,
+                    titles_skipped=0,
+                    total_sections=0,
+                    diff_summary=None,
+                    elapsed_seconds=elapsed,
+                )
+
+            # Step 2: Create or reuse release point record
+            if release_point is None:
+                release_point = await self._upsert_release_point(rp_identifier)
+
+            # Step 3: Create or reuse revision record
+            if revision is None:
+                revision = await self._create_revision(
+                    release_point, parent_revision_id, sequence_number
+                )
+
+            # Step 4: Ingest titles
+            titles_processed = 0
+            titles_skipped = 0
+            total_sections = 0
+
+            for title_num in title_list:
+                count = await ingest_title(
+                    self.session,
+                    self.downloader,
+                    self.parser,
+                    title_num,
+                    rp_identifier,
+                    revision.revision_id,
+                )
+                if count is None:
+                    titles_skipped += 1
+                else:
+                    titles_processed += 1
+                    total_sections += count
+
+            # Step 5: Run diff
+            diff_engine = RevisionDiffEngine(self.session)
+            diff_result = await diff_engine.diff(
+                parent_revision_id, revision.revision_id
+            )
+
+            # Step 6: Mark complete
+            revision.status = RevisionStatus.INGESTED.value
+            await self.session.commit()
+
+            elapsed = time.monotonic() - start_time
+            logger.info(
+                f"RP ingestion complete: {rp_identifier}, "
+                f"{titles_processed} titles, {total_sections} sections, "
+                f"+{diff_result.sections_added} ~{diff_result.sections_modified} "
+                f"-{diff_result.sections_deleted} in {elapsed:.1f}s"
+            )
+            return RPIngestResult(
+                revision_id=revision.revision_id,
+                rp_identifier=rp_identifier,
+                parent_revision_id=parent_revision_id,
+                titles_processed=titles_processed,
+                titles_skipped=titles_skipped,
+                total_sections=total_sections,
+                diff_summary=diff_result,
+                elapsed_seconds=elapsed,
+            )
+
+        except Exception:
+            if revision is not None:
+                revision.status = RevisionStatus.FAILED.value
+                await self.session.commit()
+            raise
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _get_or_create_records(
+        self, rp_identifier: str
+    ) -> tuple[OLRCReleasePoint | None, CodeRevision | None]:
+        """Check for existing release point and revision records."""
+        stmt = select(OLRCReleasePoint).where(
+            OLRCReleasePoint.full_identifier == rp_identifier
+        )
+        result = await self.session.execute(stmt)
+        release_point = result.scalar_one_or_none()
+
+        revision = None
+        if release_point is not None:
+            stmt = select(CodeRevision).where(
+                CodeRevision.release_point_id == release_point.release_point_id
+            )
+            result = await self.session.execute(stmt)
+            revision = result.scalar_one_or_none()
+
+        return release_point, revision
+
+    async def _upsert_release_point(self, rp_identifier: str) -> OLRCReleasePoint:
+        """Create or fetch the OLRCReleasePoint record."""
+        congress, law_id = parse_release_point_identifier(rp_identifier)
+
+        stmt = select(OLRCReleasePoint).where(
+            OLRCReleasePoint.full_identifier == rp_identifier
+        )
+        result = await self.session.execute(stmt)
+        existing = result.scalar_one_or_none()
+        if existing is not None:
+            await self.session.flush()
+            return existing
+
+        rp = OLRCReleasePoint(
+            full_identifier=rp_identifier,
+            congress=congress,
+            law_identifier=law_id,
+            is_initial=False,
+        )
+        self.session.add(rp)
+        await self.session.flush()
+        return rp
+
+    async def _create_revision(
+        self,
+        release_point: OLRCReleasePoint,
+        parent_revision_id: int,
+        sequence_number: int,
+    ) -> CodeRevision:
+        """Create a CodeRevision linked to the parent."""
+        effective = release_point.publication_date or date(2013, 1, 1)
+
+        revision = CodeRevision(
+            revision_type=RevisionType.RELEASE_POINT.value,
+            release_point_id=release_point.release_point_id,
+            parent_revision_id=parent_revision_id,
+            is_ground_truth=True,
+            status=RevisionStatus.INGESTING.value,
+            sequence_number=sequence_number,
+            effective_date=effective,
+            summary=f"OLRC release point {release_point.full_identifier}",
+        )
+        self.session.add(revision)
+        await self.session.flush()
+        return revision

--- a/backend/tests/pipeline/test_diff_engine.py
+++ b/backend/tests/pipeline/test_diff_engine.py
@@ -1,0 +1,195 @@
+"""Tests for the RP-to-RP diff engine (Task 1.20)."""
+
+from __future__ import annotations
+
+from pipeline.olrc.diff_engine import diff_section_maps
+from pipeline.olrc.snapshot_service import SectionState
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(
+    title: int = 17,
+    section: str = "101",
+    text_hash: str = "abc123",
+    notes_hash: str | None = None,
+    revision_id: int = 1,
+) -> SectionState:
+    """Create a minimal SectionState for testing."""
+    return SectionState(
+        title_number=title,
+        section_number=section,
+        heading=f"Section {section}",
+        text_content="text",
+        text_hash=text_hash,
+        normalized_provisions=None,
+        notes=None,
+        normalized_notes=None,
+        notes_hash=notes_hash,
+        full_citation=f"{title} U.S.C. § {section}",
+        snapshot_id=1,
+        revision_id=revision_id,
+        is_deleted=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiffSectionMaps:
+    """Tests for the pure diff_section_maps function."""
+
+    def test_identical_revisions(self) -> None:
+        """All sections unchanged -> empty diffs, correct unchanged count."""
+        states = [
+            _make_state(section="101", text_hash="aaa"),
+            _make_state(section="102", text_hash="bbb"),
+        ]
+        result = diff_section_maps(
+            states, states, before_revision_id=1, after_revision_id=2
+        )
+
+        assert result.sections_added == 0
+        assert result.sections_modified == 0
+        assert result.sections_deleted == 0
+        assert result.sections_unchanged == 2
+        assert result.diffs == []
+
+    def test_section_added(self) -> None:
+        """Section in after but not before -> ADDED."""
+        before = [_make_state(section="101", text_hash="aaa")]
+        after = [
+            _make_state(section="101", text_hash="aaa"),
+            _make_state(section="102", text_hash="bbb"),
+        ]
+        result = diff_section_maps(before, after, 1, 2)
+
+        assert result.sections_added == 1
+        assert result.sections_unchanged == 1
+        assert len(result.diffs) == 1
+        diff = result.diffs[0]
+        assert diff.change_type == "added"
+        assert diff.section_number == "102"
+        assert diff.before_state is None
+        assert diff.after_state is not None
+        assert diff.text_changed is True
+
+    def test_section_deleted(self) -> None:
+        """Section in before but not after -> DELETED."""
+        before = [
+            _make_state(section="101", text_hash="aaa"),
+            _make_state(section="102", text_hash="bbb"),
+        ]
+        after = [_make_state(section="101", text_hash="aaa")]
+        result = diff_section_maps(before, after, 1, 2)
+
+        assert result.sections_deleted == 1
+        assert result.sections_unchanged == 1
+        assert len(result.diffs) == 1
+        diff = result.diffs[0]
+        assert diff.change_type == "deleted"
+        assert diff.section_number == "102"
+        assert diff.before_state is not None
+        assert diff.after_state is None
+
+    def test_section_text_modified(self) -> None:
+        """Different text_hash -> MODIFIED with text_changed=True."""
+        before = [_make_state(section="101", text_hash="aaa", notes_hash="nnn")]
+        after = [_make_state(section="101", text_hash="bbb", notes_hash="nnn")]
+        result = diff_section_maps(before, after, 1, 2)
+
+        assert result.sections_modified == 1
+        assert result.sections_unchanged == 0
+        assert len(result.diffs) == 1
+        diff = result.diffs[0]
+        assert diff.change_type == "modified"
+        assert diff.text_changed is True
+        assert diff.notes_changed is False
+        assert diff.before_state is not None
+        assert diff.after_state is not None
+
+    def test_section_notes_modified(self) -> None:
+        """Same text_hash, different notes_hash -> MODIFIED with notes_changed=True."""
+        before = [_make_state(section="101", text_hash="aaa", notes_hash="nnn")]
+        after = [_make_state(section="101", text_hash="aaa", notes_hash="mmm")]
+        result = diff_section_maps(before, after, 1, 2)
+
+        assert result.sections_modified == 1
+        assert len(result.diffs) == 1
+        diff = result.diffs[0]
+        assert diff.change_type == "modified"
+        assert diff.text_changed is False
+        assert diff.notes_changed is True
+
+    def test_mixed_changes(self) -> None:
+        """Combination of added, modified, deleted, and unchanged."""
+        before = [
+            _make_state(section="101", text_hash="aaa"),  # unchanged
+            _make_state(section="102", text_hash="bbb"),  # modified
+            _make_state(section="103", text_hash="ccc"),  # deleted
+        ]
+        after = [
+            _make_state(section="101", text_hash="aaa"),  # unchanged
+            _make_state(section="102", text_hash="xxx"),  # modified
+            _make_state(section="104", text_hash="ddd"),  # added
+        ]
+        result = diff_section_maps(before, after, 1, 2)
+
+        assert result.sections_added == 1
+        assert result.sections_modified == 1
+        assert result.sections_deleted == 1
+        assert result.sections_unchanged == 1
+        assert len(result.diffs) == 3
+
+        by_type = {d.change_type: d for d in result.diffs}
+        assert by_type["added"].section_number == "104"
+        assert by_type["modified"].section_number == "102"
+        assert by_type["deleted"].section_number == "103"
+
+    def test_diffs_sorted_by_title_and_section(self) -> None:
+        """Diffs should be sorted by (title_number, section_number)."""
+        before: list[SectionState] = []
+        after = [
+            _make_state(title=18, section="201", text_hash="aaa"),
+            _make_state(title=17, section="102", text_hash="bbb"),
+            _make_state(title=17, section="101", text_hash="ccc"),
+        ]
+        result = diff_section_maps(before, after, 1, 2)
+
+        assert len(result.diffs) == 3
+        assert result.diffs[0].title_number == 17
+        assert result.diffs[0].section_number == "101"
+        assert result.diffs[1].title_number == 17
+        assert result.diffs[1].section_number == "102"
+        assert result.diffs[2].title_number == 18
+        assert result.diffs[2].section_number == "201"
+
+    def test_notes_hash_none_to_value(self) -> None:
+        """notes_hash changing from None to a value -> MODIFIED."""
+        before = [_make_state(section="101", text_hash="aaa", notes_hash=None)]
+        after = [_make_state(section="101", text_hash="aaa", notes_hash="nnn")]
+        result = diff_section_maps(before, after, 1, 2)
+
+        assert result.sections_modified == 1
+        diff = result.diffs[0]
+        assert diff.notes_changed is True
+        assert diff.text_changed is False
+
+    def test_empty_revisions(self) -> None:
+        """Both revisions empty -> all zeros."""
+        result = diff_section_maps([], [], 1, 2)
+        assert result.sections_added == 0
+        assert result.sections_modified == 0
+        assert result.sections_deleted == 0
+        assert result.sections_unchanged == 0
+        assert result.diffs == []
+
+    def test_revision_ids_preserved(self) -> None:
+        """Result should carry the correct revision IDs."""
+        result = diff_section_maps([], [], before_revision_id=10, after_revision_id=20)
+        assert result.before_revision_id == 10
+        assert result.after_revision_id == 20

--- a/backend/tests/pipeline/test_rp_ingestor.py
+++ b/backend/tests/pipeline/test_rp_ingestor.py
@@ -1,0 +1,348 @@
+"""Tests for the RP ingestor (Task 1.20)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.enums import RevisionStatus, RevisionType
+from pipeline.olrc.parser import ParsedGroup, ParsedSection, USLMParseResult
+from pipeline.olrc.rp_ingestor import RPIngestor, RPIngestResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parsed_section(
+    section_number: str = "101",
+    heading: str = "Test heading",
+    text_content: str = "The owner of copyright shall have exclusive rights.",
+    notes: str | None = None,
+    full_citation: str = "17 U.S.C. § 101",
+) -> ParsedSection:
+    """Create a minimal ParsedSection for testing."""
+    return ParsedSection(
+        section_number=section_number,
+        heading=heading,
+        text_content=text_content,
+        full_citation=full_citation,
+        notes=notes,
+    )
+
+
+def _make_parse_result(
+    title_number: int = 17,
+    sections: list[ParsedSection] | None = None,
+) -> USLMParseResult:
+    """Create a minimal USLMParseResult for testing."""
+    if sections is None:
+        sections = [_make_parsed_section()]
+    title_group = ParsedGroup(
+        group_type="title",
+        number=str(title_number),
+        name=f"Title {title_number}",
+        key=f"title:{title_number}",
+    )
+    return USLMParseResult(
+        title=title_group,
+        groups=[title_group],
+        sections=sections,
+    )
+
+
+def _make_mock_session() -> AsyncMock:
+    """Create a mock AsyncSession with execute returning no results."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    session.execute.return_value = mock_result
+    session.add = MagicMock()
+    return session
+
+
+def _make_mock_downloader(
+    xml_path: Path | None = Path("/fake/title17.xml"),
+) -> MagicMock:
+    """Create a mock OLRCDownloader."""
+    downloader = MagicMock()
+    downloader.download_title_at_release_point = AsyncMock(return_value=xml_path)
+    return downloader
+
+
+def _make_mock_parser(parse_result: USLMParseResult | None = None) -> MagicMock:
+    """Create a mock USLMParser."""
+    parser = MagicMock()
+    parser.parse_file.return_value = parse_result or _make_parse_result()
+    return parser
+
+
+def _make_mock_diff_result() -> MagicMock:
+    """Create a mock RevisionDiffResult."""
+    from pipeline.olrc.diff_engine import RevisionDiffResult
+
+    return RevisionDiffResult(
+        before_revision_id=1,
+        after_revision_id=2,
+        sections_added=1,
+        sections_modified=0,
+        sections_deleted=0,
+        sections_unchanged=0,
+        diffs=[],
+        elapsed_seconds=0.1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRPIngestResult:
+    """Tests for the RPIngestResult dataclass."""
+
+    def test_creation(self) -> None:
+        result = RPIngestResult(
+            revision_id=2,
+            rp_identifier="113-37",
+            parent_revision_id=1,
+            titles_processed=3,
+            titles_skipped=1,
+            total_sections=100,
+            diff_summary=None,
+            elapsed_seconds=5.2,
+        )
+        assert result.revision_id == 2
+        assert result.rp_identifier == "113-37"
+        assert result.parent_revision_id == 1
+        assert result.titles_processed == 3
+
+
+class TestRPIngestor:
+    """Tests for RPIngestor.ingest_release_point."""
+
+    @pytest.mark.asyncio
+    async def test_ingest_creates_revision_with_parent(self) -> None:
+        """Verify CodeRevision is created with parent link and sequence_number."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        parser = _make_mock_parser()
+
+        ingestor = RPIngestor(session, downloader, parser)
+
+        with (
+            patch(
+                "pipeline.olrc.rp_ingestor.ingest_title",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "pipeline.olrc.rp_ingestor.RevisionDiffEngine",
+            ) as mock_engine_cls,
+        ):
+            mock_engine = MagicMock()
+            mock_engine.diff = AsyncMock(return_value=_make_mock_diff_result())
+            mock_engine_cls.return_value = mock_engine
+
+            result = await ingestor.ingest_release_point(
+                "113-37",
+                parent_revision_id=1,
+                sequence_number=1,
+                titles=[17],
+            )
+
+        assert result.rp_identifier == "113-37"
+        assert result.parent_revision_id == 1
+        assert result.titles_processed == 1
+
+        # Verify revision was created with parent link
+        from app.models.revision import CodeRevision
+
+        added_objects = [call.args[0] for call in session.add.call_args_list]
+        revisions = [o for o in added_objects if isinstance(o, CodeRevision)]
+        assert len(revisions) == 1
+        rev = revisions[0]
+        assert rev.parent_revision_id == 1
+        assert rev.sequence_number == 1
+        assert rev.revision_type == RevisionType.RELEASE_POINT.value
+        assert rev.is_ground_truth is True
+
+    @pytest.mark.asyncio
+    async def test_ingest_creates_snapshots(self) -> None:
+        """Parsed sections become snapshots via ingest_title."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        parser = _make_mock_parser()
+
+        ingestor = RPIngestor(session, downloader, parser)
+
+        with (
+            patch(
+                "pipeline.olrc.rp_ingestor.ingest_title",
+                new_callable=AsyncMock,
+                return_value=3,
+            ) as mock_ingest,
+            patch(
+                "pipeline.olrc.rp_ingestor.RevisionDiffEngine",
+            ) as mock_engine_cls,
+        ):
+            mock_engine = MagicMock()
+            mock_engine.diff = AsyncMock(return_value=_make_mock_diff_result())
+            mock_engine_cls.return_value = mock_engine
+
+            result = await ingestor.ingest_release_point(
+                "113-37",
+                parent_revision_id=1,
+                sequence_number=1,
+                titles=[17],
+            )
+
+        assert result.total_sections == 3
+        mock_ingest.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ingest_runs_diff(self) -> None:
+        """Diff engine should be called after ingestion."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        parser = _make_mock_parser()
+
+        ingestor = RPIngestor(session, downloader, parser)
+
+        with (
+            patch(
+                "pipeline.olrc.rp_ingestor.ingest_title",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch(
+                "pipeline.olrc.rp_ingestor.RevisionDiffEngine",
+            ) as mock_engine_cls,
+        ):
+            mock_engine = MagicMock()
+            diff_result = _make_mock_diff_result()
+            mock_engine.diff = AsyncMock(return_value=diff_result)
+            mock_engine_cls.return_value = mock_engine
+
+            result = await ingestor.ingest_release_point(
+                "113-37",
+                parent_revision_id=1,
+                sequence_number=1,
+                titles=[17],
+            )
+
+        assert result.diff_summary is not None
+        assert result.diff_summary.sections_added == 1
+        mock_engine.diff.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_completed(self) -> None:
+        """Already-ingested RP returns early without re-processing."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        parser = _make_mock_parser()
+
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.release_point_id = 2
+        mock_rp.full_identifier = "113-37"
+
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 42
+        mock_rev.status = RevisionStatus.INGESTED.value
+
+        call_count = 0
+
+        def fake_execute(_stmt):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_rp
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_rev
+            else:
+                result.scalar_one_or_none.return_value = None
+            return result
+
+        session.execute = AsyncMock(side_effect=fake_execute)
+
+        ingestor = RPIngestor(session, downloader, parser)
+        result = await ingestor.ingest_release_point(
+            "113-37",
+            parent_revision_id=1,
+            sequence_number=1,
+            titles=[17],
+        )
+
+        assert result.revision_id == 42
+        assert result.titles_processed == 0
+        assert result.diff_summary is None
+        downloader.download_title_at_release_point.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_resume_failed(self) -> None:
+        """Failed status resumes ingestion."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        parser = _make_mock_parser()
+
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.release_point_id = 2
+        mock_rp.full_identifier = "113-37"
+        mock_rp.publication_date = None
+
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 42
+        mock_rev.status = RevisionStatus.FAILED.value
+
+        call_count = 0
+
+        def fake_execute(_stmt):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = mock_rp
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = mock_rev
+            else:
+                result.scalar_one_or_none.return_value = None
+            return result
+
+        session.execute = AsyncMock(side_effect=fake_execute)
+
+        ingestor = RPIngestor(session, downloader, parser)
+
+        with (
+            patch(
+                "pipeline.olrc.rp_ingestor.ingest_title",
+                new_callable=AsyncMock,
+                return_value=5,
+            ),
+            patch(
+                "pipeline.olrc.rp_ingestor.RevisionDiffEngine",
+            ) as mock_engine_cls,
+        ):
+            mock_engine = MagicMock()
+            mock_engine.diff = AsyncMock(return_value=_make_mock_diff_result())
+            mock_engine_cls.return_value = mock_engine
+
+            result = await ingestor.ingest_release_point(
+                "113-37",
+                parent_revision_id=1,
+                sequence_number=1,
+                titles=[17],
+            )
+
+        # Should proceed with ingestion
+        assert result.revision_id == 42
+        assert result.titles_processed == 1
+        assert result.diff_summary is not None


### PR DESCRIPTION
## Summary

- **Diff engine** (`diff_engine.py`): Compares two revisions by materializing section state via `SnapshotService` and classifying each section as added/modified/deleted/unchanged based on `text_hash` and `notes_hash`. Exposes a pure `diff_section_maps()` function for easy unit testing.
- **RP ingestor** (`rp_ingestor.py`): Ingests a subsequent OLRC release point — creates `OLRCReleasePoint` + `CodeRevision` (linked to parent), downloads/parses titles into `SectionSnapshot` records, then runs the diff engine automatically.
- **Shared helper**: Extracted `ingest_title()` from `BootstrapService` into a module-level function so both bootstrap and RP ingestor reuse the same download→parse→snapshot logic.
- **CLI command**: `chrono-ingest-rp <rp_identifier>` with `--parent-revision`, `--titles`, `--force`, `--dir` flags. Auto-detects the latest ingested revision as parent when `--parent-revision` is omitted.

Phase 3 of chrono pipeline: 1.18 foundation → 1.19 bootstrap → **1.20 RP diffing** → 1.20b amendment application.

## Test plan

- [x] `test_diff_engine.py` — 10 tests covering identical/added/deleted/modified/mixed/empty/sorted scenarios
- [x] `test_rp_ingestor.py` — 7 tests covering revision creation with parent, snapshot creation, diff execution, idempotency (completed + resume failed)
- [x] `test_bootstrap.py` — All 11 existing tests still pass (verifies refactored `ingest_title` extraction)
- [x] Full suite: 506 tests pass
- [x] Linting: `ruff check .` clean
- [x] Formatting: `black --check .` clean
- [x] Type checking: `mypy app --ignore-missing-imports` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)