### PR TITLE
fix: add workflow_call trigger to CI for CD reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   backend:


### PR DESCRIPTION
## Summary

- Add `workflow_call` trigger to CI workflow so the CD workflow can reuse it as a prerequisite

The CD workflow (`cd.yml`) uses `uses: ./.github/workflows/ci.yml` to run CI before deploying, but CI was missing the `workflow_call` trigger needed for reusable workflows.

## Test plan

- [x] CD workflow triggers and CI job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)