### PR TITLE
fix: replace ::type casts with CAST() to fix asyncpg syntax error on /diffs

### DIFF
--- a/backend/pipeline/olrc/snapshot_service.py
+++ b/backend/pipeline/olrc/snapshot_service.py
@@ -268,13 +268,13 @@ class SnapshotService:
                     ss.normalized_notes, ss.notes_hash, ss.full_citation,
                     ss.is_deleted, ss.group_id, ss.sort_order
                 FROM section_snapshot ss
-                JOIN unnest(:titles::int[], :sections::text[])
+                JOIN unnest(CAST(:titles AS int[]), CAST(:sections AS text[]))
                      AS keys(title, section)
                   ON ss.title_number = keys.title
                  AND ss.section_number = keys.section
-                WHERE ss.revision_id = ANY(:chain)
+                WHERE ss.revision_id = ANY(CAST(:chain AS int[]))
                 ORDER BY ss.title_number, ss.section_number,
-                    array_position(:chain, ss.revision_id)
+                    array_position(CAST(:chain AS int[]), ss.revision_id)
             """),
             {"chain": chain, "titles": titles, "sections": sections},
         )


### PR DESCRIPTION
## Summary

- **Bug**: `/api/v1/laws/<congress>/<law>/diffs` returns 500 in production
- **Root cause**: `get_sections_at_revision()` in `snapshot_service.py` (introduced in the `improve-page-load` branch) uses `text()` with `:param::type` syntax (e.g. `:titles::int[]`). asyncpg doesn't support PostgreSQL's `::` cast operator immediately after a named parameter — it sees the `:` and misparses it, producing `syntax error at or near ":"`
- **Fix**: Replace all three `:param::type` occurrences with `CAST(:param AS type)`, which asyncpg handles correctly

This branch is based on `claude/improve-page-load-a4Jbz` and includes all performance improvements from that branch plus this bugfix.

## Test plan

- [ ] Hit `/api/v1/laws/113/23/diffs` and confirm 200 response
- [ ] Verify no regression on other `/diffs` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)