### PR TITLE
Update GitHub Actions and Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
         working-directory: backend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: 'backend/uv.lock'
@@ -52,12 +52,12 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 


### PR DESCRIPTION
## Summary
This PR updates the CI/CD workflow to use newer versions of GitHub Actions and updates the Node.js runtime version for the frontend environment.

## Key Changes
- **GitHub Actions updates:**
  - `actions/checkout`: v4 → v6
  - `actions/setup-python`: v5 → v6
  - `actions/setup-node`: v4 → v6
  - `astral-sh/setup-uv`: v4 → v8.1.0

- **Runtime updates:**
  - Node.js version: 20 → 24 (frontend)

## Details
These updates ensure the CI pipeline uses the latest stable versions of GitHub Actions, which include bug fixes, security patches, and performance improvements. The Node.js version bump to 24 aligns the frontend development environment with the latest LTS/stable release.

https://claude.ai/code/session_01RJ6TNdbRwkkaCDZ7iGGxK4