### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,16 +29,16 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Build and push backend image
         run: |
@@ -70,16 +70,16 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Get backend URL
         id: backend-url
@@ -121,13 +121,13 @@ jobs:
 
     steps:
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Deploy backend to Cloud Run
         run: |


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions used in the CD workflow to their latest major versions to ensure compatibility, security patches, and access to the latest features.

## Key Changes
- **actions/checkout**: Updated from v4 to v6
- **google-github-actions/auth**: Updated from v2 to v3
- **google-github-actions/setup-gcloud**: Updated from v2 to v3

These updates are applied consistently across all three jobs in the CD workflow:
- Backend build and push job
- Frontend build and push job
- Backend deployment job

## Implementation Details
All action upgrades are straightforward version bumps with no changes to the action configurations or parameters. The workflow logic and GCP authentication setup remain unchanged, ensuring the CD pipeline continues to function as expected with the updated action versions.

https://claude.ai/code/session_01LrFd5SvyWu9rXb4i4bTYuy