### PR TITLE
Fix continuation line indentation in multi-sentence provisions

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1686,7 +1686,8 @@ def normalize_section(
             else:
                 # No header detected - split multi-sentence content onto
                 # separate lines.  The first sentence stays with the marker;
-                # subsequent sentences get their own lines at the same indent.
+                # subsequent sentences are indented one level deeper, flush
+                # with the text portion of the first line (not the marker).
                 if item_content:
                     sentences = _split_into_sentences(
                         item_content, start_offset=marker_end
@@ -1707,14 +1708,17 @@ def normalize_section(
                     ) in enumerate(real_sentences):
                         if i == 0:
                             full_content = f"{marker_text} {sentence_text}"
+                            line_indent = indent_level
                         else:
                             full_content = sentence_text
+                            # Continuation lines align with the text, not the marker.
+                            line_indent = indent_level + 1
                         line_number += 1
                         lines.append(
                             ParsedLine(
                                 line_number=line_number,
                                 content=full_content,
-                                indent_level=indent_level,
+                                indent_level=line_indent,
                                 marker=marker_text if i == 0 else None,
                                 is_header=False,
                                 start_char=pos if i == 0 else start_char,
@@ -1962,7 +1966,7 @@ def _normalize_subsection_recursive(
         # No heading - marker and content on one line.
         # Split multi-sentence content so each sentence gets its own line.
         # The first sentence stays with the marker; subsequent sentences
-        # appear on their own lines at the same indent level.
+        # appear indented one level deeper, flush with the text (not the marker).
         if subsection.content:
             sentences = _split_into_sentences(subsection.content)
             real_sentences = [
@@ -1979,9 +1983,13 @@ def _normalize_subsection_recursive(
                         else sentence_text
                     )
                     marker = subsection.marker if subsection.marker else None
+                    line_indent = base_indent
                 else:
                     content = sentence_text
                     marker = None
+                    # Indent one level deeper so continuation lines align with
+                    # the text portion of the first line, not the marker.
+                    line_indent = base_indent + 1
 
                 line_counter[0] += 1
                 start_pos = char_pos[0]
@@ -1990,7 +1998,7 @@ def _normalize_subsection_recursive(
                     ParsedLine(
                         line_number=line_counter[0],
                         content=content,
-                        indent_level=base_indent,
+                        indent_level=line_indent,
                         marker=marker,
                         is_header=False,
                         start_char=start_pos,

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1614,7 +1614,9 @@ class TestMultiSentenceSplitting:
         assert result.provisions[1].marker is None
         # Continuation line is indented one level deeper, flush with the text
         # portion of line 0 (not the marker). Fixes: github.com/SanthoshBala/code-we-live-by/issues/122
-        assert result.provisions[1].indent_level == result.provisions[0].indent_level + 1
+        assert (
+            result.provisions[1].indent_level == result.provisions[0].indent_level + 1
+        )
 
     def test_xml_single_sentence_unchanged(self) -> None:
         """Single-sentence content still produces exactly one line."""
@@ -1787,7 +1789,9 @@ class TestMultiSentenceSplitting:
         assert result.provisions[1].content.startswith("No exemption")
         assert result.provisions[1].marker is None
         # Continuation line must be one level deeper (flush with text, not marker).
-        assert result.provisions[1].indent_level == result.provisions[0].indent_level + 1
+        assert (
+            result.provisions[1].indent_level == result.provisions[0].indent_level + 1
+        )
 
     def test_fallback_single_sentence_unchanged(self) -> None:
         """Fallback single-sentence list items remain on one line."""

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1612,7 +1612,9 @@ class TestMultiSentenceSplitting:
         assert result.provisions[0].marker == "(a)"
         assert result.provisions[1].content == "Second sentence continues here."
         assert result.provisions[1].marker is None
-        assert result.provisions[1].indent_level == result.provisions[0].indent_level
+        # Continuation line is indented one level deeper, flush with the text
+        # portion of line 0 (not the marker). Fixes: github.com/SanthoshBala/code-we-live-by/issues/122
+        assert result.provisions[1].indent_level == result.provisions[0].indent_level + 1
 
     def test_xml_single_sentence_unchanged(self) -> None:
         """Single-sentence content still produces exactly one line."""
@@ -1784,6 +1786,8 @@ class TestMultiSentenceSplitting:
         assert result.provisions[0].marker == "(a)"
         assert result.provisions[1].content.startswith("No exemption")
         assert result.provisions[1].marker is None
+        # Continuation line must be one level deeper (flush with text, not marker).
+        assert result.provisions[1].indent_level == result.provisions[0].indent_level + 1
 
     def test_fallback_single_sentence_unchanged(self) -> None:
         """Fallback single-sentence list items remain on one line."""
@@ -1836,6 +1840,46 @@ class TestMultiSentenceSplitting:
         # This should produce 2 lines
         assert result.provision_count == 2
         assert "et seq." in result.provisions[0].content
+
+    def test_xml_no_heading_continuation_indent_2usc31_2(self) -> None:
+        """Continuation lines of a no-heading provision are indented one level
+        deeper than the marker line (flush with the text portion).
+
+        Regression test for 2 U.S.C. § 31-2 L18-19 being flush with the marker
+        instead of the text. See: github.com/SanthoshBala/code-we-live-by/issues/122
+        """
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        # Mimics the structure of 2 U.S.C. § 31-2 where (a) has multiple sentences
+        section = ParsedSection(
+            section_number="31-2",
+            heading="Lump-sum payments",
+            full_citation="2 U.S.C. § 31-2",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="(a)",
+                    heading=None,
+                    content=(
+                        "Each Member of the House of Representatives may receive a lump-sum payment. "
+                        "Such payment shall be in lieu of any other payment. "
+                        "The amount shall be determined by the Committee."
+                    ),
+                    level="subsection",
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+
+        assert result.provision_count == 3
+        # First line: marker + first sentence at base indent
+        assert result.provisions[0].marker == "(a)"
+        marker_indent = result.provisions[0].indent_level
+        # Continuation lines (L18-19 equivalent) must be one level deeper
+        assert result.provisions[1].indent_level == marker_indent + 1
+        assert result.provisions[2].indent_level == marker_indent + 1
 
 
 class TestNoteRefsToSchemas:


### PR DESCRIPTION
## Summary
Fixed incorrect indentation of continuation lines in multi-sentence provisions. Continuation lines are now indented one level deeper than the marker line, aligning them with the text portion of the first line rather than the marker itself.

## Changes
- **normalized_section.py**: Updated two code paths that handle multi-sentence content without headings:
  - In `normalize_section()`: Continuation sentences now receive `indent_level + 1` instead of `indent_level`
  - In `_normalize_subsection_recursive()`: Same indentation fix applied for consistency
  - Updated comments to clarify that continuation lines should align with text, not markers

- **test_normalized_section.py**: Updated and added tests to verify correct behavior:
  - Fixed assertion in `test_xml_no_heading_multi_sentence_content()` to expect deeper indentation
  - Added assertion in `test_fallback_multi_sentence_list_item()` to verify continuation indent
  - Added new regression test `test_xml_no_heading_continuation_indent_2usc31_2()` covering the specific case from 2 U.S.C. § 31-2

## Implementation Details
The fix ensures that when a provision marker (e.g., "(a)") is followed by multiple sentences, the first sentence appears on the same line as the marker, while subsequent sentences are indented one level deeper. This creates proper visual alignment where continuation lines flush with the text content rather than the marker itself, improving readability and consistency with legal document formatting conventions.

Fixes: github.com/SanthoshBala/code-we-live-by/issues/122

https://claude.ai/code/session_01E99T9oaiT5bsFVvG33s53o