### PR TITLE
Add diff summary statistics to law viewer

### DIFF
--- a/frontend/src/components/law-viewer/LawDiffViewer.tsx
+++ b/frontend/src/components/law-viewer/LawDiffViewer.tsx
@@ -209,40 +209,40 @@ export default function LawDiffViewer({
       )}
 
       <div className="flex h-[calc(100vh-17rem)] gap-6">
-      {/* Left sidebar — affected sections tree (independently scrollable) */}
-      <div className="hidden w-72 shrink-0 overflow-y-auto lg:block">
-        <h2 className="sticky top-0 z-10 mb-2 bg-white px-3 pb-1 text-sm font-semibold text-gray-900">
-          Amended Sections
-        </h2>
-        <AffectedSectionsTree
-          amendments={allAmendments}
-          activeSection={activeSection}
-          onSectionClick={handleSectionClick}
-        />
-      </div>
+        {/* Left sidebar — affected sections tree (independently scrollable) */}
+        <div className="hidden w-72 shrink-0 overflow-y-auto lg:block">
+          <h2 className="sticky top-0 z-10 mb-2 bg-white px-3 pb-1 text-sm font-semibold text-gray-900">
+            Amended Sections
+          </h2>
+          <AffectedSectionsTree
+            amendments={allAmendments}
+            activeSection={activeSection}
+            onSectionClick={handleSectionClick}
+          />
+        </div>
 
-      {/* Main panel — unified diff cards per section */}
-      <div
-        ref={mainPanelRef}
-        className="min-w-0 flex-1 space-y-6 overflow-y-auto"
-      >
-        {diffs.map((diff) => (
-          <div
-            key={diff.section_key}
-            ref={(el) => {
-              if (el) sectionRefs.current.set(diff.section_key, el);
-            }}
-          >
-            <h3 className="mb-3">
-              <SectionBreadcrumb
-                titleNumber={diff.title_number}
-                sectionNumber={diff.section_number}
-              />
-            </h3>
-            <UnifiedDiffCard diff={diff} />
-          </div>
-        ))}
-      </div>
+        {/* Main panel — unified diff cards per section */}
+        <div
+          ref={mainPanelRef}
+          className="min-w-0 flex-1 space-y-6 overflow-y-auto"
+        >
+          {diffs.map((diff) => (
+            <div
+              key={diff.section_key}
+              ref={(el) => {
+                if (el) sectionRefs.current.set(diff.section_key, el);
+              }}
+            >
+              <h3 className="mb-3">
+                <SectionBreadcrumb
+                  titleNumber={diff.title_number}
+                  sectionNumber={diff.section_number}
+                />
+              </h3>
+              <UnifiedDiffCard diff={diff} />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/law-viewer/LawDiffViewer.tsx
+++ b/frontend/src/components/law-viewer/LawDiffViewer.tsx
@@ -131,6 +131,34 @@ export default function LawDiffViewer({
     [diffs]
   );
 
+  // Compute total line change counts across all sections
+  const totalAdded = useMemo(
+    () =>
+      diffs.reduce(
+        (sum, d) =>
+          sum +
+          d.hunks.reduce(
+            (s, h) => s + h.lines.filter((l) => l.type === 'added').length,
+            0
+          ),
+        0
+      ),
+    [diffs]
+  );
+  const totalRemoved = useMemo(
+    () =>
+      diffs.reduce(
+        (sum, d) =>
+          sum +
+          d.hunks.reduce(
+            (s, h) => s + h.lines.filter((l) => l.type === 'removed').length,
+            0
+          ),
+        0
+      ),
+    [diffs]
+  );
+
   if (isLoading) {
     return <p className="text-gray-500">Computing diffs...</p>;
   }
@@ -156,7 +184,31 @@ export default function LawDiffViewer({
   }
 
   return (
-    <div className="flex h-[calc(100vh-14rem)] gap-6">
+    <div className="flex flex-col gap-3">
+      {/* Summary bar — total lines added/removed */}
+      {(totalAdded > 0 || totalRemoved > 0) && (
+        <div className="flex items-center gap-3 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm">
+          <span className="font-medium text-gray-700">
+            {diffs.length} section{diffs.length !== 1 ? 's' : ''} changed
+          </span>
+          <span className="text-gray-300">·</span>
+          {totalAdded > 0 && (
+            <span className="font-mono font-medium text-green-600">
+              +{totalAdded} lines added
+            </span>
+          )}
+          {totalAdded > 0 && totalRemoved > 0 && (
+            <span className="text-gray-300">·</span>
+          )}
+          {totalRemoved > 0 && (
+            <span className="font-mono font-medium text-red-600">
+              −{totalRemoved} lines removed
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="flex h-[calc(100vh-17rem)] gap-6">
       {/* Left sidebar — affected sections tree (independently scrollable) */}
       <div className="hidden w-72 shrink-0 overflow-y-auto lg:block">
         <h2 className="sticky top-0 z-10 mb-2 bg-white px-3 pb-1 text-sm font-semibold text-gray-900">
@@ -190,6 +242,7 @@ export default function LawDiffViewer({
             <UnifiedDiffCard diff={diff} />
           </div>
         ))}
+      </div>
       </div>
     </div>
   );

--- a/frontend/src/components/law-viewer/UnifiedDiffCard.tsx
+++ b/frontend/src/components/law-viewer/UnifiedDiffCard.tsx
@@ -587,6 +587,16 @@ export default function UnifiedDiffCard({ diff }: UnifiedDiffCardProps) {
   // Deduplicate change types for badges
   const changeTypes = [...new Set(diff.amendments.map((a) => a.change_type))];
 
+  // Count added/removed lines from hunks
+  const linesAdded = diff.hunks.reduce(
+    (sum, h) => sum + h.lines.filter((l) => l.type === 'added').length,
+    0
+  );
+  const linesRemoved = diff.hunks.reduce(
+    (sum, h) => sum + h.lines.filter((l) => l.type === 'removed').length,
+    0
+  );
+
   // Build collapsed regions between/around hunks
   // Each region is identified by: regionIndex, startProvisionIdx, endProvisionIdx
   type Region =
@@ -683,6 +693,19 @@ export default function UnifiedDiffCard({ diff }: UnifiedDiffCardProps) {
         {diff.amendments.some((a) => a.needs_review) && (
           <span className="text-xs font-medium text-amber-600">
             Needs Review
+          </span>
+        )}
+        {(linesAdded > 0 || linesRemoved > 0) && (
+          <span className="ml-auto font-mono text-xs">
+            {linesAdded > 0 && (
+              <span className="text-green-600">+{linesAdded}</span>
+            )}
+            {linesAdded > 0 && linesRemoved > 0 && (
+              <span className="text-gray-400"> </span>
+            )}
+            {linesRemoved > 0 && (
+              <span className="text-red-600">−{linesRemoved}</span>
+            )}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary
This PR adds visual summary statistics to the law diff viewer, displaying total counts of added and removed lines across all sections and individual cards.

## Key Changes
- **LawDiffViewer.tsx**:
  - Added `totalAdded` and `totalRemoved` memos to compute aggregate line change counts across all diffs
  - Added a summary bar at the top displaying the number of changed sections and total lines added/removed
  - Adjusted layout structure to accommodate the new summary bar (changed outer div to flex-col and adjusted height calculation)

- **UnifiedDiffCard.tsx**:
  - Added `linesAdded` and `linesRemoved` calculations for individual diff cards
  - Added inline statistics display in the card header showing added/removed line counts in monospace font with color coding (green for additions, red for removals)

## Implementation Details
- Summary statistics are computed using `useMemo` hooks to avoid unnecessary recalculations
- Line counts are derived by filtering hunks for lines with `type === 'added'` or `type === 'removed'`
- Visual styling uses Tailwind classes with semantic coloring (green-600 for additions, red-600 for removals)
- Summary bar only renders when there are actual changes (totalAdded > 0 or totalRemoved > 0)
- Individual card statistics appear in the top-right corner of each card header

https://claude.ai/code/session_01LDfDPGMhK3GA5xqAs9w6ZX