### PR TITLE
fix: pass session_factory to BootstrapService to prevent concurrent session sharing

### DIFF
--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -3286,7 +3286,9 @@ async def chrono_bootstrap_command(
     parser = USLMParser()
 
     async with async_session_maker() as session:
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(
+            session, downloader, parser, session_factory=async_session_maker
+        )
         result = await service.create_initial_commit(
             release_point, titles=titles, force=force
         )


### PR DESCRIPTION
## Context

`BootstrapService` was recently updated to ingest US Code titles concurrently using `asyncio.gather` with a semaphore. Each concurrent worker is expected to use its own isolated `AsyncSession` via an injected `session_factory`. However, the CLI call site (`pipeline/cli.py`) was not updated to pass `session_factory`, so all workers fell back to sharing the single session opened by the caller.

## Crash

With multiple coroutines sharing one `AsyncSession`, two workers would call `session.flush()` simultaneously, causing SQLAlchemy to raise:

```
sqlalchemy.exc.InvalidRequestError: Session is already flushing
```

This was preceded by a warning that surfaced first:

```
SAWarning: Usage of the 'Session.add()' operation is not currently supported
within the execution stage of the flush process.
```

Both are symptoms of the same root cause: concurrent async coroutines mutating a non-concurrency-safe session.

## Fix

Pass `async_session_maker` as `session_factory` when constructing `BootstrapService` in the CLI. Each parallel title worker now opens and closes its own session independently.

```python
# Before
service = BootstrapService(session, downloader, parser)

# After
service = BootstrapService(session, downloader, parser, session_factory=async_session_maker)
```

The outer `session` (passed as the first argument) is still used for the coordination work — idempotency checks, revision record creation, and the final commit — which must remain in a single transaction.