### PR TITLE
fix: reduce bootstrap concurrency to 2 and increase seed job memory to 4Gi

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -249,8 +249,8 @@ jobs:
             --region "$GCP_REGION" \
             --set-secrets "DATABASE_URL=DATABASE_URL:latest,GCS_CACHE_BUCKET=GCS_CACHE_BUCKET:latest,GOVINFO_API_KEY=GOVINFO_API_KEY:latest,CONGRESS_API_KEY=CONGRESS_API_KEY:latest" \
             --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
-            --memory 2Gi \
-            --task-timeout 30m \
+            --memory 4Gi \
+            --task-timeout 60m \
             --command "bash" \
             --args "scripts/seed.sh" \
             --quiet

--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -174,14 +174,14 @@ class BootstrapService:
         downloader: OLRCDownloader,
         parser: USLMParser,
         session_factory: SessionFactory | None = None,
-        concurrency: int = 4,
+        concurrency: int = 2,
     ) -> None:
         self.session = session
         self.downloader = downloader
         self.parser = parser
-        # concurrency=4 keeps DB connection pressure low on Cloud Run's shared pool
-        # (each worker opens one connection). Raise to 8-10 if the pool allows it and
-        # ingestion bottlenecks on download I/O rather than DB writes.
+        # concurrency=2 balances parallelism against peak memory — large titles (e.g.
+        # 26, 42) hold substantial parsed XML in memory simultaneously. Raise if the
+        # Cloud Run job has more than 4Gi and ingestion bottlenecks on download I/O.
         self._concurrency = concurrency
 
         if session_factory is not None:


### PR DESCRIPTION
## Context

After #141 fixed the shared-session crash and parallelism started working correctly, the seed job hit an OOM on Cloud Run. With `concurrency=4`, up to 4 titles are parsed and held in memory simultaneously. Large titles (26 — Tax Code, 42 — Public Health) hold substantial parsed XML + normalized section data, pushing peak memory past the 2Gi job limit.

## Changes

- **`bootstrap.py`**: Lower `concurrency` default from 4 → 2. This halves peak memory while still providing a 2x speedup over the original sequential ingestion.
- **`cd.yml`**: Increase `--memory` from `2Gi` → `4Gi` to give headroom even at concurrency=2, and bump `--task-timeout` from `30m` → `60m` since the session-sharing bug is now fixed and titles actually run in parallel (the 30m timeout was hit before parallelism worked at all).

## To manually apply before the next PR merge

The Cloud Run job config needs to be updated immediately for the next manual seed run:

```bash
gcloud run jobs update cwlb-seed \
  --memory 4Gi \
  --task-timeout 3600 \
  --region us-central1
```