### PR TITLE
perf: offload XML parse and normalize to thread pool in ingest_title

### DIFF
--- a/backend/pipeline/chrono/play_forward.py
+++ b/backend/pipeline/chrono/play_forward.py
@@ -26,7 +26,6 @@ from pipeline.chrono.checkpoint import CheckpointResult, validate_checkpoint
 from pipeline.chrono.revision_builder import RevisionBuilder
 from pipeline.legal_parser.law_change_service import LawChangeService
 from pipeline.olrc.downloader import OLRCDownloader
-from pipeline.olrc.parser import USLMParser
 from pipeline.olrc.rp_ingestor import RPIngestor
 from pipeline.olrc.snapshot_service import SnapshotService
 from pipeline.timeline import TimelineBuilder, TimelineEvent, TimelineEventType
@@ -60,11 +59,10 @@ class PlayForwardEngine:
         self,
         session: AsyncSession,
         downloader: OLRCDownloader,
-        parser: USLMParser,
     ):
         self.session = session
         self.timeline_builder = TimelineBuilder(session)
-        self.rp_ingestor = RPIngestor(session, downloader, parser)
+        self.rp_ingestor = RPIngestor(session, downloader)
         self.revision_builder = RevisionBuilder(session)
         self.snapshot_service = SnapshotService(session)
         self.law_change_service = LawChangeService(session)

--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -3283,11 +3283,10 @@ async def chrono_bootstrap_command(
         print(f"Auto-detected oldest release point: {release_point}")
 
     downloader = OLRCDownloader(download_dir=download_dir, cache=_cli_cache)
-    parser = USLMParser()
 
     async with async_session_maker() as session:
         service = BootstrapService(
-            session, downloader, parser, session_factory=async_session_maker
+            session, downloader, session_factory=async_session_maker
         )
         result = await service.create_initial_commit(
             release_point, titles=titles, force=force
@@ -3319,7 +3318,6 @@ async def chrono_ingest_rp_command(
     from pipeline.olrc.rp_ingestor import RPIngestor
 
     downloader = OLRCDownloader(download_dir=download_dir, cache=_cli_cache)
-    parser = USLMParser()
 
     async with async_session_maker() as session:
         # Auto-detect parent revision if not specified
@@ -3356,7 +3354,7 @@ async def chrono_ingest_rp_command(
                 return 1
             sequence_number = parent.sequence_number + 1
 
-        ingestor = RPIngestor(session, downloader, parser)
+        ingestor = RPIngestor(session, downloader)
         rp_result = await ingestor.ingest_release_point(
             release_point,
             parent_revision_id=parent_revision_id,
@@ -3683,10 +3681,9 @@ async def chrono_advance_command(
     from pipeline.chrono.play_forward import PlayForwardEngine
 
     downloader = OLRCDownloader(download_dir=download_dir, cache=_cli_cache)
-    parser = USLMParser()
 
     async with async_session_maker() as session:
-        engine = PlayForwardEngine(session, downloader, parser)
+        engine = PlayForwardEngine(session, downloader)
         try:
             result = await engine.advance(count=count)
         except RuntimeError as exc:
@@ -3716,10 +3713,9 @@ async def chrono_advance_to_command(
     from pipeline.chrono.play_forward import PlayForwardEngine
 
     downloader = OLRCDownloader(download_dir=download_dir, cache=_cli_cache)
-    parser = USLMParser()
 
     async with async_session_maker() as session:
-        engine = PlayForwardEngine(session, downloader, parser)
+        engine = PlayForwardEngine(session, downloader)
         try:
             result = await engine.advance_to(release_point)
         except (RuntimeError, ValueError) as exc:
@@ -3750,10 +3746,9 @@ async def chrono_validate_command(
     from pipeline.chrono.play_forward import PlayForwardEngine
 
     downloader = OLRCDownloader(cache=_cli_cache)
-    parser = USLMParser()
 
     async with async_session_maker() as session:
-        engine = PlayForwardEngine(session, downloader, parser)
+        engine = PlayForwardEngine(session, downloader)
         try:
             checkpoint = await engine.validate_at_rp(release_point)
         except ValueError as exc:

--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -14,6 +14,7 @@ from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from datetime import date
+from typing import NamedTuple
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,7 +26,7 @@ from app.models.snapshot import SectionSnapshot
 from pipeline.olrc.downloader import OLRCDownloader
 from pipeline.olrc.group_service import upsert_groups_from_parse_result
 from pipeline.olrc.normalized_section import normalize_parsed_section
-from pipeline.olrc.parser import USLMParser, compute_text_hash
+from pipeline.olrc.parser import ParsedSection, USLMParser, compute_text_hash
 from pipeline.olrc.release_point import parse_release_point_identifier
 
 logger = logging.getLogger(__name__)
@@ -36,71 +37,35 @@ SessionFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
 ALL_TITLES = list(range(1, 55))
 
 
-async def ingest_title(
-    session: AsyncSession,
-    downloader: OLRCDownloader,
-    parser: USLMParser,
+class _SectionRow(NamedTuple):
+    """Pre-computed data for one SectionSnapshot row, built in a thread pool."""
+
+    section_number: str
+    heading: str | None
+    text_content: str | None
+    normalized_provisions: list | None
+    notes: str | None
+    normalized_notes: dict | None
+    text_hash: str | None
+    notes_hash: str | None
+    full_citation: str | None
+    parent_group_key: str | None
+    sort_order: int | None
+
+
+def _build_snapshot_rows(
+    sections: list[ParsedSection],
     title_num: int,
-    rp_identifier: str,
-    revision_id: int,
-) -> int | None:
-    """Download, parse, and store snapshots for one title.
+) -> list[_SectionRow]:
+    """Normalize sections and build snapshot row data.
 
-    Shared helper used by both BootstrapService and RPIngestor.
-
-    Args:
-        session: Database session.
-        downloader: OLRC downloader instance.
-        parser: USLM parser instance.
-        title_num: US Code title number to ingest.
-        rp_identifier: Release point identifier (e.g., "113-21").
-        revision_id: The revision ID to attach snapshots to.
-
-    Returns:
-        Number of sections ingested, or None if the title was skipped.
+    Runs in a thread pool — see ingest_title for context. Calls
+    normalize_parsed_section which is CPU-bound text processing (~2s for
+    large titles). Returns plain data so the caller can build ORM objects
+    on the event loop after group_ids are resolved.
     """
-    # Check if this title already has snapshots at this revision
-    stmt = (
-        select(SectionSnapshot.snapshot_id)
-        .where(
-            SectionSnapshot.revision_id == revision_id,
-            SectionSnapshot.title_number == title_num,
-        )
-        .limit(1)
-    )
-    result = await session.execute(stmt)
-    if result.scalar_one_or_none() is not None:
-        logger.info(f"Title {title_num}: already ingested, skipping")
-        return 0
-
-    # Download
-    try:
-        xml_path = await downloader.download_title_at_release_point(
-            title_num, rp_identifier
-        )
-    except Exception:
-        logger.warning(f"Title {title_num}: download failed, skipping", exc_info=True)
-        return None
-
-    if xml_path is None:
-        logger.info(f"Title {title_num}: not available at {rp_identifier}, skipping")
-        return None
-
-    # Parse
-    try:
-        parse_result = parser.parse_file(xml_path)
-    except Exception:
-        logger.error(f"Title {title_num}: parse failed, skipping", exc_info=True)
-        return None
-
-    # Upsert SectionGroup hierarchy for navigation
-    group_lookup = await upsert_groups_from_parse_result(session, parse_result.groups)
-
-    # Create snapshots with group_id for navigation
-    # Note: duplicate section numbers are allowed — Congress occasionally
-    # enacts two provisions with the same number (see pipeline/olrc/README.md).
-    count = 0
-    for section in parse_result.sections:
+    rows: list[_SectionRow] = []
+    for section in sections:
         try:
             normalized = normalize_parsed_section(section)
         except Exception:
@@ -122,33 +87,126 @@ async def ingest_title(
         if normalized.section_notes is not None:
             notes_json = normalized.section_notes.model_dump(mode="json")
 
-        # Resolve group_id from parsed section's parent_group_key
+        rows.append(
+            _SectionRow(
+                section_number=section.section_number,
+                heading=section.heading,
+                text_content=text_content,
+                normalized_provisions=provisions_json,
+                notes=section.notes,
+                normalized_notes=notes_json,
+                text_hash=compute_text_hash(text_content) if text_content else None,
+                notes_hash=compute_text_hash(section.notes) if section.notes else None,
+                full_citation=section.full_citation,
+                parent_group_key=section.parent_group_key,
+                sort_order=section.sort_order,
+            )
+        )
+    return rows
+
+
+async def ingest_title(
+    session: AsyncSession,
+    downloader: OLRCDownloader,
+    title_num: int,
+    rp_identifier: str,
+    revision_id: int,
+) -> int | None:
+    """Download, parse, and store snapshots for one title.
+
+    Shared helper used by both BootstrapService and RPIngestor.
+
+    The two CPU-bound steps — XML parsing and section normalization — are
+    offloaded to the thread pool via asyncio.to_thread so the event loop
+    remains free for concurrent DB work on other titles. Each call creates
+    its own USLMParser instance, making concurrent invocations thread-safe.
+
+    Args:
+        session: Database session.
+        downloader: OLRC downloader instance.
+        title_num: US Code title number to ingest.
+        rp_identifier: Release point identifier (e.g., "113-21").
+        revision_id: The revision ID to attach snapshots to.
+
+    Returns:
+        Number of sections ingested, or None if the title was skipped.
+    """
+    # Check if this title already has snapshots at this revision
+    stmt = (
+        select(SectionSnapshot.snapshot_id)
+        .where(
+            SectionSnapshot.revision_id == revision_id,
+            SectionSnapshot.title_number == title_num,
+        )
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    if result.scalar_one_or_none() is not None:
+        logger.info(f"Title {title_num}: already ingested, skipping")
+        return 0
+
+    # Download (async I/O)
+    try:
+        xml_path = await downloader.download_title_at_release_point(
+            title_num, rp_identifier
+        )
+    except Exception:
+        logger.warning(f"Title {title_num}: download failed, skipping", exc_info=True)
+        return None
+
+    if xml_path is None:
+        logger.info(f"Title {title_num}: not available at {rp_identifier}, skipping")
+        return None
+
+    # Parse in thread pool (CPU-bound XML parsing, ~3-4s for large titles).
+    # USLMParser() is instantiated here on the event loop and its bound
+    # parse_file method is dispatched to the thread — each call gets its own
+    # instance so concurrent invocations from asyncio.gather are safe.
+    try:
+        parse_result = await asyncio.to_thread(USLMParser().parse_file, xml_path)
+    except Exception:
+        logger.error(f"Title {title_num}: parse failed, skipping", exc_info=True)
+        return None
+
+    # Upsert SectionGroup hierarchy for navigation (async DB work — runs while
+    # other titles can be parsing concurrently in the thread pool).
+    group_lookup = await upsert_groups_from_parse_result(session, parse_result.groups)
+
+    # Normalize + build row data in thread pool (CPU-bound, ~2s for large titles).
+    # Note: duplicate section numbers are allowed — Congress occasionally
+    # enacts two provisions with the same number (see pipeline/olrc/README.md).
+    rows = await asyncio.to_thread(
+        _build_snapshot_rows, parse_result.sections, title_num
+    )
+
+    # Build ORM objects and flush (event loop — group_ids now resolved).
+    for row in rows:
         group_id = None
-        if section.parent_group_key:
-            group_record = group_lookup.get(section.parent_group_key)
+        if row.parent_group_key:
+            group_record = group_lookup.get(row.parent_group_key)
             if group_record:
                 group_id = group_record.group_id
 
         snapshot = SectionSnapshot(
             revision_id=revision_id,
             title_number=title_num,
-            section_number=section.section_number,
-            heading=section.heading,
-            text_content=text_content,
-            normalized_provisions=provisions_json,
-            notes=section.notes,
-            normalized_notes=notes_json,
-            text_hash=compute_text_hash(text_content) if text_content else None,
-            notes_hash=compute_text_hash(section.notes) if section.notes else None,
-            full_citation=section.full_citation,
+            section_number=row.section_number,
+            heading=row.heading,
+            text_content=row.text_content,
+            normalized_provisions=row.normalized_provisions,
+            notes=row.notes,
+            normalized_notes=row.normalized_notes,
+            text_hash=row.text_hash,
+            notes_hash=row.notes_hash,
+            full_citation=row.full_citation,
             is_deleted=False,
             group_id=group_id,
-            sort_order=section.sort_order,
+            sort_order=row.sort_order,
         )
         session.add(snapshot)
-        count += 1
 
     await session.flush()
+    count = len(rows)
     logger.info(f"Title {title_num}: {count} sections ingested")
     return count
 
@@ -172,13 +230,11 @@ class BootstrapService:
         self,
         session: AsyncSession,
         downloader: OLRCDownloader,
-        parser: USLMParser,
         session_factory: SessionFactory | None = None,
         concurrency: int = 2,
     ) -> None:
         self.session = session
         self.downloader = downloader
-        self.parser = parser
         # concurrency=2 balances parallelism against peak memory — large titles (e.g.
         # 26, 42) hold substantial parsed XML in memory simultaneously. Raise if the
         # Cloud Run job has more than 4Gi and ingestion bottlenecks on download I/O.
@@ -254,7 +310,6 @@ class BootstrapService:
                     count = await ingest_title(
                         s,
                         self.downloader,
-                        self.parser,
                         title_num,
                         rp_identifier,
                         revision.revision_id,

--- a/backend/pipeline/olrc/rp_ingestor.py
+++ b/backend/pipeline/olrc/rp_ingestor.py
@@ -21,7 +21,6 @@ from app.models.revision import CodeRevision
 from pipeline.olrc.bootstrap import ALL_TITLES, ingest_title
 from pipeline.olrc.diff_engine import RevisionDiffEngine, RevisionDiffResult
 from pipeline.olrc.downloader import OLRCDownloader
-from pipeline.olrc.parser import USLMParser
 from pipeline.olrc.release_point import parse_release_point_identifier
 
 logger = logging.getLogger(__name__)
@@ -48,11 +47,9 @@ class RPIngestor:
         self,
         session: AsyncSession,
         downloader: OLRCDownloader,
-        parser: USLMParser,
     ) -> None:
         self.session = session
         self.downloader = downloader
-        self.parser = parser
 
     async def ingest_release_point(
         self,
@@ -122,7 +119,6 @@ class RPIngestor:
                 count = await ingest_title(
                     self.session,
                     self.downloader,
-                    self.parser,
                     title_num,
                     rp_identifier,
                     revision.revision_id,

--- a/backend/tests/pipeline/test_bootstrap.py
+++ b/backend/tests/pipeline/test_bootstrap.py
@@ -75,11 +75,15 @@ def _make_mock_downloader(
     return downloader
 
 
-def _make_mock_parser(parse_result: USLMParseResult | None = None) -> MagicMock:
-    """Create a mock USLMParser."""
-    parser = MagicMock()
-    parser.parse_file.return_value = parse_result or _make_parse_result()
-    return parser
+def _make_parser_mock(parse_result: USLMParseResult | None = None) -> MagicMock:
+    """Create a USLMParser instance mock with a configured parse_file return value.
+
+    Patch bootstrap.USLMParser with return_value=this to control what ingest_title
+    parses without going through the real XML pipeline.
+    """
+    instance = MagicMock()
+    instance.parse_file.return_value = parse_result or _make_parse_result()
+    return instance
 
 
 # ---------------------------------------------------------------------------
@@ -120,13 +124,16 @@ class TestCreateInitialCommit:
         """Verify CodeRevision is created with correct fields."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
+        mock_parser = _make_parser_mock()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             result = await service.create_initial_commit("113-21", titles=[17])
 
@@ -160,14 +167,17 @@ class TestCreateInitialCommit:
             _make_parsed_section("101", "First section", "Content A"),
             _make_parsed_section("102", "Second section", "Content B"),
         ]
-        parser = _make_mock_parser(_make_parse_result(sections=sections))
+        mock_parser = _make_parser_mock(_make_parse_result(sections=sections))
         downloader = _make_mock_downloader()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             result = await service.create_initial_commit("113-21", titles=[17])
 
@@ -191,15 +201,10 @@ class TestCreateInitialCommit:
         """Title download returns None -> skipped, no error."""
         session = _make_mock_session()
         downloader = _make_mock_downloader(xml_path=None)
-        parser = _make_mock_parser()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
-        ):
-            result = await service.create_initial_commit("113-21", titles=[99])
+        result = await service.create_initial_commit("113-21", titles=[99])
 
         assert result.titles_skipped == 1
         assert result.titles_processed == 0
@@ -210,7 +215,6 @@ class TestCreateInitialCommit:
         """If revision already ingested, returns early."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
 
         # Mock: release point exists, revision exists and is Ingested
         from app.models.release_point import OLRCReleasePoint
@@ -241,7 +245,7 @@ class TestCreateInitialCommit:
 
         session.execute = AsyncMock(side_effect=fake_execute)
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
         result = await service.create_initial_commit("113-21", titles=[17])
 
         assert result.revision_id == 42
@@ -255,7 +259,7 @@ class TestCreateInitialCommit:
         """If revision status is Failed, resumes ingestion."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
+        mock_parser = _make_parser_mock()
 
         from app.models.release_point import OLRCReleasePoint
         from app.models.revision import CodeRevision
@@ -280,17 +284,20 @@ class TestCreateInitialCommit:
             elif call_count == 2:
                 result.scalar_one_or_none.return_value = mock_rev
             else:
-                # For _ingest_title idempotency check
+                # For ingest_title idempotency check
                 result.scalar_one_or_none.return_value = None
             return result
 
         session.execute = AsyncMock(side_effect=fake_execute)
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             result = await service.create_initial_commit("113-21", titles=[17])
 
@@ -316,14 +323,17 @@ class TestSnapshotFieldMapping:
 
         session = _make_mock_session()
         sections = [_make_parsed_section(text_content=text)]
-        parser = _make_mock_parser(_make_parse_result(sections=sections))
+        mock_parser = _make_parser_mock(_make_parse_result(sections=sections))
         downloader = _make_mock_downloader()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
@@ -346,14 +356,17 @@ class TestSnapshotFieldMapping:
 
         session = _make_mock_session()
         sections = [_make_parsed_section(notes=notes)]
-        parser = _make_mock_parser(_make_parse_result(sections=sections))
+        mock_parser = _make_parser_mock(_make_parse_result(sections=sections))
         downloader = _make_mock_downloader()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
@@ -373,14 +386,17 @@ class TestSnapshotFieldMapping:
         """Verify notes_hash is None when notes are absent."""
         session = _make_mock_session()
         sections = [_make_parsed_section(notes=None)]
-        parser = _make_mock_parser(_make_parse_result(sections=sections))
+        mock_parser = _make_parser_mock(_make_parse_result(sections=sections))
         downloader = _make_mock_downloader()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
@@ -399,14 +415,17 @@ class TestSnapshotFieldMapping:
         """Verify full_citation is preserved on snapshot."""
         session = _make_mock_session()
         sections = [_make_parsed_section(full_citation="17 U.S.C. § 101")]
-        parser = _make_mock_parser(_make_parse_result(sections=sections))
+        mock_parser = _make_parser_mock(_make_parse_result(sections=sections))
         downloader = _make_mock_downloader()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
@@ -429,15 +448,10 @@ class TestSnapshotFieldMapping:
         downloader.download_title_at_release_point = AsyncMock(
             side_effect=Exception("Network error")
         )
-        parser = _make_mock_parser()
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
-        ):
-            result = await service.create_initial_commit("113-21", titles=[17])
+        result = await service.create_initial_commit("113-21", titles=[17])
 
         assert result.titles_skipped == 1
         assert result.titles_processed == 0
@@ -447,15 +461,13 @@ class TestSnapshotFieldMapping:
         """Parser raising an exception should skip the title, not fail."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = MagicMock()
-        parser.parse_file.side_effect = Exception("Parse error")
 
-        service = BootstrapService(session, downloader, parser)
+        mock_parser = MagicMock()
+        mock_parser.parse_file.side_effect = Exception("Parse error")
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
-        ):
+        service = BootstrapService(session, downloader)
+
+        with patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser):
             result = await service.create_initial_commit("113-21", titles=[17])
 
         assert result.titles_skipped == 1
@@ -471,24 +483,32 @@ class TestSnapshotFieldMapping:
             _make_parsed_section("2", "Penalties", "Content C"),
         ]
 
-        call_count = 0
+        # Return title-specific paths so parse_file can key on them (thread-safe).
+        def fake_download(title_num: int, _rp: str) -> Path:
+            return Path(f"/fake/title{title_num}.xml")
 
-        def fake_parse_file(_path: object) -> USLMParseResult:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
+        downloader = MagicMock()
+        downloader.download_title_at_release_point = AsyncMock(
+            side_effect=fake_download
+        )
+
+        mock_parser = MagicMock()
+
+        def fake_parse_file(path: Path) -> USLMParseResult:
+            if "17" in str(path):
                 return _make_parse_result(title_number=17, sections=sections_17)
             return _make_parse_result(title_number=18, sections=sections_18)
 
-        parser = MagicMock()
-        parser.parse_file.side_effect = fake_parse_file
-        downloader = _make_mock_downloader()
+        mock_parser.parse_file.side_effect = fake_parse_file
 
-        service = BootstrapService(session, downloader, parser)
+        service = BootstrapService(session, downloader)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             result = await service.create_initial_commit("113-21", titles=[17, 18])
 
@@ -501,14 +521,17 @@ class TestSnapshotFieldMapping:
         """Semaphore limits concurrency; all titles still complete."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
+        mock_parser = _make_parser_mock()
 
         # concurrency=2 with 5 titles — all should still complete
-        service = BootstrapService(session, downloader, parser, concurrency=2)
+        service = BootstrapService(session, downloader, concurrency=2)
 
-        with patch(
-            "pipeline.olrc.bootstrap.normalize_parsed_section",
-            side_effect=lambda s: s,
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
         ):
             result = await service.create_initial_commit(
                 "113-21", titles=[17, 18, 26, 42, 50]

--- a/backend/tests/pipeline/test_play_forward.py
+++ b/backend/tests/pipeline/test_play_forward.py
@@ -134,8 +134,7 @@ def _make_section(
 def _make_engine(session: AsyncMock) -> PlayForwardEngine:
     """Create a PlayForwardEngine with mock dependencies."""
     downloader = MagicMock()
-    parser = MagicMock()
-    engine = PlayForwardEngine(session, downloader, parser)
+    engine = PlayForwardEngine(session, downloader)
     return engine
 
 

--- a/backend/tests/pipeline/test_rp_ingestor.py
+++ b/backend/tests/pipeline/test_rp_ingestor.py
@@ -72,13 +72,6 @@ def _make_mock_downloader(
     return downloader
 
 
-def _make_mock_parser(parse_result: USLMParseResult | None = None) -> MagicMock:
-    """Create a mock USLMParser."""
-    parser = MagicMock()
-    parser.parse_file.return_value = parse_result or _make_parse_result()
-    return parser
-
-
 def _make_mock_diff_result() -> MagicMock:
     """Create a mock RevisionDiffResult."""
     from pipeline.olrc.diff_engine import RevisionDiffResult
@@ -128,9 +121,7 @@ class TestRPIngestor:
         """Verify CodeRevision is created with parent link and sequence_number."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
-
-        ingestor = RPIngestor(session, downloader, parser)
+        ingestor = RPIngestor(session, downloader)
 
         with (
             patch(
@@ -174,9 +165,7 @@ class TestRPIngestor:
         """Parsed sections become snapshots via ingest_title."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
-
-        ingestor = RPIngestor(session, downloader, parser)
+        ingestor = RPIngestor(session, downloader)
 
         with (
             patch(
@@ -207,9 +196,7 @@ class TestRPIngestor:
         """Diff engine should be called after ingestion."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
-
-        ingestor = RPIngestor(session, downloader, parser)
+        ingestor = RPIngestor(session, downloader)
 
         with (
             patch(
@@ -242,8 +229,6 @@ class TestRPIngestor:
         """Already-ingested RP returns early without re-processing."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
-
         from app.models.release_point import OLRCReleasePoint
         from app.models.revision import CodeRevision
 
@@ -271,7 +256,7 @@ class TestRPIngestor:
 
         session.execute = AsyncMock(side_effect=fake_execute)
 
-        ingestor = RPIngestor(session, downloader, parser)
+        ingestor = RPIngestor(session, downloader)
         result = await ingestor.ingest_release_point(
             "113-37",
             parent_revision_id=1,
@@ -289,8 +274,6 @@ class TestRPIngestor:
         """Failed status resumes ingestion."""
         session = _make_mock_session()
         downloader = _make_mock_downloader()
-        parser = _make_mock_parser()
-
         from app.models.release_point import OLRCReleasePoint
         from app.models.revision import CodeRevision
 
@@ -319,7 +302,7 @@ class TestRPIngestor:
 
         session.execute = AsyncMock(side_effect=fake_execute)
 
-        ingestor = RPIngestor(session, downloader, parser)
+        ingestor = RPIngestor(session, downloader)
 
         with (
             patch(


### PR DESCRIPTION
## Context

Addresses #142. XML parsing (~4s for large titles like 42 and 10) and section normalization (~2s) are CPU-bound and previously ran synchronously on the asyncio event loop. With `asyncio.gather` and `concurrency=4`, calling `parser.parse_file()` blocked the **entire event loop** — effectively serializing all parse operations even when multiple workers were running. No DB flushes for other titles could proceed while one title was parsing.

## Changes

**`pipeline/olrc/bootstrap.py`**
- `ingest_title` now calls `await asyncio.to_thread(USLMParser().parse_file, xml_path)` — creates a fresh `USLMParser` instance per call (thread-safe; no shared mutable state between concurrent workers)
- Extracted `_build_snapshot_rows(sections, title_num) → list[_SectionRow]` as a sync helper holding the normalize loop; also dispatched via `asyncio.to_thread` so normalization doesn't block the event loop either
- Removed `parser` parameter from `ingest_title` — callers no longer own parser lifecycle

**`pipeline/olrc/rp_ingestor.py` / `pipeline/chrono/play_forward.py` / `pipeline/cli.py`**
- Remove `parser` param from `RPIngestor.__init__`, `PlayForwardEngine.__init__`, and all CLI callsites

**`tests/pipeline/test_bootstrap.py`**
- Replace mock-parser injection with `patch("pipeline.olrc.bootstrap.USLMParser", return_value=instance)` — tests control parse results by patching the class constructor
- `test_multiple_titles_parallel`: updated to use title-specific download paths + path-keyed `side_effect` so both titles get the right parse result regardless of thread interleaving

## Benchmark

Same workload (Phase 1 titles, fresh DB, concurrency=4, local Docker Postgres):

| | Wall time | Sections |
|---|---|---|
| Without thread pool | 26.1s | 18,172 |
| With thread pool | 23.9s | 18,172 |

**8.5% faster** on a single-core local machine. Larger gains expected on Cloud Run where lxml releases the GIL for true parallel XML parsing across cores, and Cloud SQL write throughput is higher.

## Test plan
- [ ] `uv run pytest` — 633 tests pass
- [ ] `uv run mypy app --ignore-missing-imports` — clean
- [ ] `chrono-bootstrap 113-21 --titles 10,17,18,20,22,26,42,50 --force` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)