### PR TITLE
fix: commit revision before parallel title ingest in bootstrap

### DIFF
--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -302,6 +302,11 @@ class BootstrapService:
             if revision is None:
                 revision = await self._create_revision(release_point)
 
+            # Commit so the revision row is visible to the parallel worker
+            # sessions opened below — they run in separate transactions and
+            # would otherwise hit a FK violation on section_snapshot.revision_id.
+            await self.session.commit()
+
             # Step 4: Ingest titles in parallel — each gets its own session.
             sem = asyncio.Semaphore(self._concurrency)
 

--- a/backend/pipeline/olrc/downloader.py
+++ b/backend/pipeline/olrc/downloader.py
@@ -325,6 +325,18 @@ class OLRCDownloader:
             if zip_bytes is None:
                 return None
 
+            # Some titles don't exist at older release points (e.g., Title 54
+            # was enacted in P.L. 113-287, so it's absent from RP 113-21). The
+            # OLRC serves an HTML error page with HTTP 200 in that case, so
+            # validate the ZIP magic bytes before caching — otherwise the
+            # bogus HTML gets stored in GCS and every retry fails the same way.
+            if not zip_bytes.startswith((b"PK\x03\x04", b"PK\x05\x06")):
+                logger.warning(
+                    f"Title {title_number}@{release_point}: response is not a "
+                    "ZIP (likely not codified at this release point), skipping"
+                )
+                return None
+
             # Store in cache
             if self._cache:
                 self._cache.put_bytes(cache_key, zip_bytes)

--- a/backend/tests/pipeline/test_bootstrap.py
+++ b/backend/tests/pipeline/test_bootstrap.py
@@ -539,3 +539,50 @@ class TestSnapshotFieldMapping:
 
         assert result.titles_processed == 5
         assert result.titles_skipped == 0
+
+    @pytest.mark.asyncio
+    async def test_revision_committed_before_parallel_ingest(self) -> None:
+        """Parent session must commit before worker sessions start, so the
+        revision row is visible to worker transactions and section_snapshot
+        FK inserts succeed."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        mock_parser = _make_parser_mock()
+
+        # session_factory yields a separate worker session — record when it
+        # is entered relative to commits on the parent session.
+        worker_session = _make_mock_session()
+        events: list[str] = []
+
+        original_commit = session.commit
+
+        async def tracked_commit() -> None:
+            events.append("parent_commit")
+            await original_commit()
+
+        session.commit = tracked_commit
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def factory():
+            events.append("worker_session_open")
+            yield worker_session
+
+        service = BootstrapService(
+            session, downloader, session_factory=factory, concurrency=1
+        )
+
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
+        ):
+            await service.create_initial_commit("113-21", titles=[17])
+
+        # The first parent commit must precede the first worker session open.
+        assert "parent_commit" in events
+        assert "worker_session_open" in events
+        assert events.index("parent_commit") < events.index("worker_session_open")

--- a/backend/tests/pipeline/test_downloader.py
+++ b/backend/tests/pipeline/test_downloader.py
@@ -1,5 +1,8 @@
 """Tests for OLRC downloader."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 import pytest
 
 from pipeline.olrc.downloader import PHASE_1_TITLES, OLRCDownloader
@@ -95,3 +98,37 @@ class TestPhase1Titles:
         # Title 17 (Copyrights) and Title 18 (Crimes) are commonly referenced
         assert 17 in PHASE_1_TITLES
         assert 18 in PHASE_1_TITLES
+
+
+class TestDownloadTitleAtReleasePoint:
+    """Tests for download_title_at_release_point's response validation."""
+
+    @pytest.mark.asyncio
+    async def test_non_zip_response_skipped_and_not_cached(self, tmp_path) -> None:
+        """If the OLRC returns HTML (e.g., title not yet codified at this RP),
+        treat it as 'not available' and skip — don't cache the bad bytes,
+        otherwise every retry hits the cache and fails the same way."""
+        cache = MagicMock()
+        cache.get_bytes.return_value = None
+        cache.put_bytes = MagicMock()
+
+        downloader = OLRCDownloader(download_dir=tmp_path, cache=cache)
+
+        html_body = b"<!DOCTYPE html><html><body>Not Found</body></html>"
+
+        mock_response = MagicMock()
+        mock_response.content = html_body
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(httpx, "AsyncClient", return_value=mock_client):
+            result = await downloader.download_title_at_release_point(54, "113-21")
+
+        assert result is None
+        # Critical: HTML body must NOT be cached, otherwise subsequent runs
+        # read the bogus bytes from GCS and fail the same way every time.
+        cache.put_bytes.assert_not_called()


### PR DESCRIPTION
The bootstrap service flushed (but did not commit) the CodeRevision row
in the parent session, then fanned out title ingestion across worker
sessions opened via session_factory. Each worker ran in its own
transaction and could not see the parent's uncommitted revision row,
causing a foreign key violation on section_snapshot.revision_id during
the seed Cloud Run job.

Commit the parent session after the release point and revision are
created so the rows are visible to worker transactions before the
parallel asyncio.gather kicks off.