### PR TITLE
fix: get seed job running again (cpu/memory + change detection + logging)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -249,6 +249,7 @@ jobs:
             --region "$GCP_REGION" \
             --set-secrets "DATABASE_URL=DATABASE_URL:latest,GCS_CACHE_BUCKET=GCS_CACHE_BUCKET:latest,GOVINFO_API_KEY=GOVINFO_API_KEY:latest,CONGRESS_API_KEY=CONGRESS_API_KEY:latest" \
             --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
+            --cpu 4 \
             --memory 16Gi \
             --task-timeout 60m \
             --command "bash" \


### PR DESCRIPTION
## Summary

Three related changes to get the seed job deploying, running, and logging clearly:

1. **`fix: bump seed job to 4 CPU so 16Gi memory is allowed`** — Cloud Run rejected `--memory 16Gi` at the default 2 vCPU (2 CPU caps at 8Gi). Add `--cpu 4` to unlock the 16Gi tier. 4Gi previously OOMed at concurrency=2 (commit `ca2eded`); 16Gi keeps ample headroom until per-title commit resumability (#148) lands.

2. **`chore(ci): include cd.yml in seed change detection`** — Infrastructure changes to the seed job (memory, CPU, timeout, image args) live in `cd.yml`. Without including the workflow file in the `seed_needed` regex, edits like the `--cpu 4` change above silently skip the seed job's deploy + execute, leaving the deployed Cloud Run Job spec unchanged. False positives on this regex are cheap relative to a missed seed run.

3. **`feat(logging): name the source in downloader load messages (#137)`** — The downloader emitted `Title 4@113-21 ZIP from cache` followed by `Title 4@113-21 downloaded: ...`, where 'downloaded' implied a network fetch. An actual OLRC fetch produced the same final line, making cache hits and network fetches indistinguishable. Now logs `loaded from GCS cache` vs `loaded from OLRC`. Closes #137.

## Cost impact

Cloud Run Jobs bill only while running. ~+$0.09/run vs the (currently-broken) 2 CPU config — < $1/day at typical deploy cadence.

## Test plan

- [ ] CI green
- [ ] After merge, the `cwlb-seed` deploy step runs (no longer skipped — cd.yml change triggers `seed_needed=true`)
- [ ] `gcloud run jobs deploy cwlb-seed` succeeds with `--cpu 4 --memory 16Gi`
- [ ] Seed job execution completes without OOM
- [ ] Seed logs show `loaded from GCS cache` vs `loaded from OLRC` for repeat vs fresh title fetches

https://claude.ai/code/session_0169eViz6vYn1MkdX1u8sdXD