### PR TITLE
chore(ci): trigger seed on cd.yml changes; clarify downloader logs (#137)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check seed-related file changes
         id: check
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qE '^backend/(alembic|pipeline)/|^backend/scripts/seed\.sh'; then
+          if git diff --name-only HEAD~1 HEAD | grep -qE '^backend/(alembic|pipeline)/|^backend/scripts/seed\.sh|^\.github/workflows/cd\.yml$'; then
             echo "seed_needed=true" >> "$GITHUB_OUTPUT"
           else
             echo "seed_needed=false" >> "$GITHUB_OUTPUT"

--- a/backend/pipeline/olrc/downloader.py
+++ b/backend/pipeline/olrc/downloader.py
@@ -127,26 +127,30 @@ class OLRCDownloader:
         Returns:
             Path to the extracted XML file, or None if download failed.
         """
-        # Check if already downloaded (extracted XML)
+        # Check if already extracted on local disk (no network, no GCS)
         xml_dir = self.download_dir / f"title{title_number}"
         if xml_dir.exists() and not force:
             xml_files = list(xml_dir.glob("*.xml"))
             if xml_files:
-                logger.info(f"Title {title_number} already downloaded: {xml_files[0]}")
+                logger.info(
+                    f"Title {title_number} already extracted on disk: {xml_files[0]}"
+                )
                 return xml_files[0]
 
         cache_key = f"olrc/downloads/title{title_number}@{self.release_point}.zip"
 
-        # Try GCS cache for the ZIP before hitting the OLRC API
+        # Try GCS cache for the ZIP before hitting the OLRC API. Track the
+        # source so the post-extract log line names where the bytes came from.
         zip_bytes: bytes | None = None
+        source = "OLRC"
         if self._cache and not force:
             zip_bytes = self._cache.get_bytes(cache_key)
             if zip_bytes:
-                logger.info(f"Title {title_number} ZIP from cache")
+                source = "GCS cache"
 
         if zip_bytes is None:
             url = self.get_title_url(title_number)
-            logger.info(f"Downloading Title {title_number} from {url}")
+            logger.info(f"Fetching Title {title_number} from OLRC: {url}")
 
             try:
                 async with httpx.AsyncClient(timeout=self.timeout) as client:
@@ -172,7 +176,9 @@ class OLRCDownloader:
 
             xml_files = list(xml_dir.glob("*.xml"))
             if xml_files:
-                logger.info(f"Title {title_number} downloaded: {xml_files[0]}")
+                logger.info(
+                    f"Title {title_number} loaded from {source}: {xml_files[0]}"
+                )
                 return xml_files[0]
             else:
                 logger.error(
@@ -262,19 +268,21 @@ class OLRCDownloader:
             xml_files = list(rp_dir.glob("*.xml"))
             if xml_files:
                 logger.info(
-                    f"Title {title_number}@{release_point} already downloaded: "
-                    f"{xml_files[0]}"
+                    f"Title {title_number}@{release_point} already extracted "
+                    f"on disk: {xml_files[0]}"
                 )
                 return xml_files[0]
 
         cache_key = f"olrc/downloads/title{title_number}@{release_point}.zip"
 
-        # Try GCS cache for the ZIP
+        # Try GCS cache for the ZIP. Track the source so the post-extract log
+        # line names where the bytes came from.
         zip_bytes: bytes | None = None
+        source = "OLRC"
         if self._cache and not force:
             zip_bytes = self._cache.get_bytes(cache_key)
             if zip_bytes:
-                logger.info(f"Title {title_number}@{release_point} ZIP from cache")
+                source = "GCS cache"
 
         if zip_bytes is None:
             # Parse the release point
@@ -287,7 +295,9 @@ class OLRCDownloader:
                 public_law=public_law,
                 title_number=title_number,
             )
-            logger.info(f"Downloading Title {title_number}@{release_point} from {url}")
+            logger.info(
+                f"Fetching Title {title_number}@{release_point} from OLRC: {url}"
+            )
 
             max_retries = 3
             for attempt in range(1, max_retries + 1):
@@ -350,7 +360,8 @@ class OLRCDownloader:
             xml_files = list(rp_dir.glob("*.xml"))
             if xml_files:
                 logger.info(
-                    f"Title {title_number}@{release_point} downloaded: {xml_files[0]}"
+                    f"Title {title_number}@{release_point} loaded from "
+                    f"{source}: {xml_files[0]}"
                 )
                 return xml_files[0]
             else:


### PR DESCRIPTION
## Summary

Two follow-ups that didn't make it into PR #152 (merged at the first commit only):

1. **`chore(ci): include cd.yml in seed change detection`** — Infrastructure changes to the seed job (memory, CPU, timeout, image args) live in `cd.yml`. Without including the workflow file in the `seed_needed` regex, edits like the `--cpu 4 --memory 16Gi` change from #152 silently skip the seed job's deploy + execute, leaving the deployed Cloud Run Job spec at the previous successfully-applied configuration. This is what happened after #152 merged — the new spec wasn't actually applied because nothing in `backend/pipeline/` changed.

2. **`feat(logging): name the source in downloader load messages`** (closes #137) — The downloader emitted `Title 4@113-21 ZIP from cache` followed by `Title 4@113-21 downloaded: ...`, where 'downloaded' implied a network fetch. An actual OLRC fetch produced the same final line, making cache hits and network fetches indistinguishable in logs. Now logs `loaded from GCS cache: ...` vs `loaded from OLRC: ...`, and renames the local-disk hit message to `already extracted on disk` and the network-fetch start to `Fetching from OLRC`.

Because commit 2 touches `backend/pipeline/`, merging this PR will trigger `seed_needed=true` and the seed job will deploy the `--cpu 4 --memory 16Gi` spec from #152 and execute it.

## Test plan

- [ ] CI green
- [ ] After merge, `cwlb-seed` deploy step runs (no longer skipped)
- [ ] `gcloud run jobs deploy cwlb-seed` succeeds with `--cpu 4 --memory 16Gi`
- [ ] Seed execution logs show `loaded from GCS cache` vs `loaded from OLRC` for repeat vs fresh title fetches

https://claude.ai/code/session_0169eViz6vYn1MkdX1u8sdXD

---
_Generated by [Claude Code](https://claude.ai/code/session_0169eViz6vYn1MkdX1u8sdXD)_