### PR TITLE
perf: bump seed concurrency to 4 and timeout to 120m

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -251,7 +251,7 @@ jobs:
             --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
             --cpu 4 \
             --memory 16Gi \
-            --task-timeout 60m \
+            --task-timeout 120m \
             --command "bash" \
             --args "scripts/seed.sh" \
             --quiet

--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -231,13 +231,13 @@ class BootstrapService:
         session: AsyncSession,
         downloader: OLRCDownloader,
         session_factory: SessionFactory | None = None,
-        concurrency: int = 2,
+        concurrency: int = 4,
     ) -> None:
         self.session = session
         self.downloader = downloader
-        # concurrency=2 balances parallelism against peak memory — large titles (e.g.
-        # 26, 42) hold substantial parsed XML in memory simultaneously. Raise if the
-        # Cloud Run job has more than 4Gi and ingestion bottlenecks on download I/O.
+        # concurrency=4 — the 16Gi/4-CPU Cloud Run config (PR #152) showed
+        # peak utilization under 20% at concurrency=2, so 4 fits comfortably
+        # while halving wall-clock on the cold-cache first run.
         self._concurrency = concurrency
 
         if session_factory is not None:


### PR DESCRIPTION
## Summary

Two follow-ups from the latest seed run:

1. **`perf: bump bootstrap concurrency from 2 to 4`** (closes #155) — Last seed run showed CPU and memory utilization peaking **under 20%** at concurrency=2 on the 16Gi/4-CPU envelope from PR #152, comfortably below the 30% threshold from #155. Doubling concurrency should roughly halve wall-clock on the cold-cache first run while leaving ~50% memory headroom for big-title overlap (Titles 26 and 42).

2. **`ops: raise seed task-timeout from 60m to 120m`** — The previous run got to title 32 of 54 in 60 min on a cold GCS cache before hitting the timeout. That extrapolates to ~100 min for a full first run; 120m gives margin. Subsequent runs hit cached ZIPs and should still finish well under 60m.

Combined, these should let the next seed actually complete end-to-end. The `cd.yml` change in commit 2 will also trigger `seed_needed=true` so the new spec is applied and the seed re-runs automatically on merge.

## Test plan

- [ ] CI green
- [ ] After merge, seed runs to completion (all 54 titles ingested) within 120m
- [ ] Cloud Run metrics show p95 memory utilization stays well below 100% at concurrency=4

Closes #155

https://claude.ai/code/session_0169eViz6vYn1MkdX1u8sdXD

---
_Generated by [Claude Code](https://claude.ai/code/session_0169eViz6vYn1MkdX1u8sdXD)_