### PR TITLE
perf: eliminate sequential DB round trips in group hierarchy upsert (closes #140)

### DIFF
--- a/backend/alembic/versions/a8b9c0d1e2f3_section_group_uuid_primary_key.py
+++ b/backend/alembic/versions/a8b9c0d1e2f3_section_group_uuid_primary_key.py
@@ -1,0 +1,205 @@
+"""section_group: replace integer PK/FK with deterministic UUID
+
+Revision ID: a8b9c0d1e2f3
+Revises: f7a8b9c0d1e2
+Create Date: 2026-05-06
+
+Converts section_group.group_id (and all FK columns that reference it) from
+a DB-generated integer serial to an application-assigned UUID5.  The UUID is
+derived from the group's full hierarchy key (e.g. "title:17/chapter:1") using
+the fixed project namespace _GROUP_NS defined in group_service.py.
+
+For each existing row the key path is reconstructed via a recursive CTE, the
+UUID is computed in Python, and the new value is written back before the old
+integer columns are dropped.
+
+Column changes
+--------------
+section_group     : group_id  INTEGER PK → UUID PK
+                    parent_id INTEGER FK → UUID FK
+us_code_section   : group_id  INTEGER FK → UUID FK (nullable)
+section_snapshot  : group_id  INTEGER FK → UUID FK (nullable)
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers
+revision: str = "a8b9c0d1e2f3"
+down_revision: str = "f7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Must match pipeline/olrc/group_service.py _GROUP_NS — never change.
+_GROUP_NS = uuid.UUID("6f3a4b5c-2d1e-4f0a-9c8d-7e6f5d4c3b2a")
+
+
+def _build_id_map(conn: sa.engine.Connection) -> dict[int, uuid.UUID]:
+    """Reconstruct the hierarchy key for every section_group row and compute
+    its deterministic UUID.  Returns {old_integer_id: new_uuid}.
+    """
+    rows = conn.execute(
+        text("""
+            WITH RECURSIVE group_path AS (
+                SELECT group_id,
+                       group_type || ':' || number AS key_path
+                FROM   section_group
+                WHERE  parent_id IS NULL
+                UNION ALL
+                SELECT sg.group_id,
+                       gp.key_path || '/' || sg.group_type || ':' || sg.number
+                FROM   section_group sg
+                JOIN   group_path   gp ON sg.parent_id = gp.group_id
+            )
+            SELECT group_id, key_path FROM group_path
+        """)
+    ).fetchall()
+    return {row.group_id: uuid.uuid5(_GROUP_NS, row.key_path) for row in rows}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    id_map = _build_id_map(conn)
+
+    # ------------------------------------------------------------------ #
+    # 1. Add temporary UUID shadow columns (nullable for now)              #
+    # ------------------------------------------------------------------ #
+    op.add_column("section_group", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True))
+    op.add_column("section_group", sa.Column("_new_pid", UUID(as_uuid=True), nullable=True))
+    op.add_column("us_code_section", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True))
+    op.add_column("section_snapshot", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True))
+
+    # ------------------------------------------------------------------ #
+    # 2. Backfill shadow columns using the computed UUID mapping           #
+    # ------------------------------------------------------------------ #
+    if id_map:
+        # Use a temporary table for the bulk update — avoids giant IN() lists.
+        conn.execute(text(
+            "CREATE TEMPORARY TABLE _gid_map (old_id integer PRIMARY KEY, new_id uuid NOT NULL)"
+        ))
+        conn.execute(
+            text("INSERT INTO _gid_map VALUES (:old_id, :new_id)"),
+            [{"old_id": k, "new_id": str(v)} for k, v in id_map.items()],
+        )
+
+        conn.execute(text("""
+            UPDATE section_group sg
+            SET    _new_gid = m.new_id
+            FROM   _gid_map m
+            WHERE  sg.group_id = m.old_id
+        """))
+        conn.execute(text("""
+            UPDATE section_group sg
+            SET    _new_pid = m.new_id
+            FROM   _gid_map m
+            WHERE  sg.parent_id = m.old_id
+        """))
+        conn.execute(text("""
+            UPDATE us_code_section ucs
+            SET    _new_gid = m.new_id
+            FROM   _gid_map m
+            WHERE  ucs.group_id = m.old_id
+        """))
+        conn.execute(text("""
+            UPDATE section_snapshot ss
+            SET    _new_gid = m.new_id
+            FROM   _gid_map m
+            WHERE  ss.group_id = m.old_id
+        """))
+
+        conn.execute(text("DROP TABLE _gid_map"))
+
+    # ------------------------------------------------------------------ #
+    # 3. Drop FK constraints and indexes that reference the old columns    #
+    # ------------------------------------------------------------------ #
+    op.drop_constraint("fk_section_group_parent_id_section_group", "section_group", type_="foreignkey")
+    op.drop_constraint("fk_us_code_section_group_id_section_group", "us_code_section", type_="foreignkey")
+    # section_snapshot FK was added via add_column with inline ForeignKey,
+    # so PostgreSQL named it with the standard convention.
+    op.drop_constraint("section_snapshot_group_id_fkey", "section_snapshot", type_="foreignkey")
+
+    op.drop_constraint("uq_section_group_child", "section_group", type_="unique")
+    op.drop_index("idx_section_group_parent", "section_group")
+    op.drop_index("idx_section_group_sort", "section_group")
+    op.drop_index("idx_section_group", "us_code_section")
+    op.drop_index("idx_section_sort", "us_code_section")
+    op.drop_index("idx_section_snapshot_group", "section_snapshot")
+
+    # ------------------------------------------------------------------ #
+    # 4. Drop PK constraint so we can drop the old integer column          #
+    # ------------------------------------------------------------------ #
+    op.drop_constraint("pk_section_group", "section_group", type_="primary")
+
+    # ------------------------------------------------------------------ #
+    # 5. Drop old integer columns                                          #
+    # ------------------------------------------------------------------ #
+    op.drop_column("section_group", "group_id")
+    op.drop_column("section_group", "parent_id")
+    op.drop_column("us_code_section", "group_id")
+    op.drop_column("section_snapshot", "group_id")
+
+    # ------------------------------------------------------------------ #
+    # 6. Rename shadow columns to final names                              #
+    # ------------------------------------------------------------------ #
+    op.alter_column("section_group", "_new_gid", new_column_name="group_id")
+    op.alter_column("section_group", "_new_pid", new_column_name="parent_id")
+    op.alter_column("us_code_section", "_new_gid", new_column_name="group_id")
+    op.alter_column("section_snapshot", "_new_gid", new_column_name="group_id")
+
+    # ------------------------------------------------------------------ #
+    # 7. Add NOT NULL + PK on section_group.group_id                       #
+    # ------------------------------------------------------------------ #
+    op.alter_column("section_group", "group_id", nullable=False)
+    op.create_primary_key("pk_section_group", "section_group", ["group_id"])
+
+    # ------------------------------------------------------------------ #
+    # 8. Recreate FK constraints                                           #
+    # ------------------------------------------------------------------ #
+    op.create_foreign_key(
+        "fk_section_group_parent_id_section_group",
+        "section_group", "section_group",
+        ["parent_id"], ["group_id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_us_code_section_group_id_section_group",
+        "us_code_section", "section_group",
+        ["group_id"], ["group_id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_section_snapshot_group_id_section_group",
+        "section_snapshot", "section_group",
+        ["group_id"], ["group_id"],
+        ondelete="SET NULL",
+    )
+
+    # ------------------------------------------------------------------ #
+    # 9. Recreate unique constraint and indexes                            #
+    # ------------------------------------------------------------------ #
+    op.create_unique_constraint(
+        "uq_section_group_child", "section_group",
+        ["parent_id", "group_type", "number"],
+    )
+    op.create_index("idx_section_group_parent", "section_group", ["parent_id"])
+    op.create_index("idx_section_group_sort", "section_group", ["parent_id", "sort_order"])
+    op.create_index("idx_section_group", "us_code_section", ["group_id"])
+    op.create_index("idx_section_sort", "us_code_section", ["group_id", "sort_order"])
+    op.create_index("idx_section_snapshot_group", "section_snapshot", ["group_id"])
+
+
+def downgrade() -> None:
+    # Downgrade is intentionally not implemented: reverting a UUID→integer PK
+    # migration would require re-assigning sequential IDs and is not safe to
+    # do automatically.  Restore from a pre-migration backup instead.
+    raise NotImplementedError(
+        "Downgrade from UUID group_id is not supported. "
+        "Restore from a pre-migration backup."
+    )

--- a/backend/alembic/versions/a8b9c0d1e2f3_section_group_uuid_primary_key.py
+++ b/backend/alembic/versions/a8b9c0d1e2f3_section_group_uuid_primary_key.py
@@ -27,9 +27,10 @@ import uuid
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
 
 # revision identifiers
 revision: str = "a8b9c0d1e2f3"
@@ -71,59 +72,85 @@ def upgrade() -> None:
     # ------------------------------------------------------------------ #
     # 1. Add temporary UUID shadow columns (nullable for now)              #
     # ------------------------------------------------------------------ #
-    op.add_column("section_group", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True))
-    op.add_column("section_group", sa.Column("_new_pid", UUID(as_uuid=True), nullable=True))
-    op.add_column("us_code_section", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True))
-    op.add_column("section_snapshot", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True))
+    op.add_column(
+        "section_group", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True)
+    )
+    op.add_column(
+        "section_group", sa.Column("_new_pid", UUID(as_uuid=True), nullable=True)
+    )
+    op.add_column(
+        "us_code_section", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True)
+    )
+    op.add_column(
+        "section_snapshot", sa.Column("_new_gid", UUID(as_uuid=True), nullable=True)
+    )
 
     # ------------------------------------------------------------------ #
     # 2. Backfill shadow columns using the computed UUID mapping           #
     # ------------------------------------------------------------------ #
     if id_map:
         # Use a temporary table for the bulk update — avoids giant IN() lists.
-        conn.execute(text(
-            "CREATE TEMPORARY TABLE _gid_map (old_id integer PRIMARY KEY, new_id uuid NOT NULL)"
-        ))
+        conn.execute(
+            text(
+                "CREATE TEMPORARY TABLE _gid_map (old_id integer PRIMARY KEY, new_id uuid NOT NULL)"
+            )
+        )
         conn.execute(
             text("INSERT INTO _gid_map VALUES (:old_id, :new_id)"),
             [{"old_id": k, "new_id": str(v)} for k, v in id_map.items()],
         )
 
-        conn.execute(text("""
+        conn.execute(
+            text("""
             UPDATE section_group sg
             SET    _new_gid = m.new_id
             FROM   _gid_map m
             WHERE  sg.group_id = m.old_id
-        """))
-        conn.execute(text("""
+        """)
+        )
+        conn.execute(
+            text("""
             UPDATE section_group sg
             SET    _new_pid = m.new_id
             FROM   _gid_map m
             WHERE  sg.parent_id = m.old_id
-        """))
-        conn.execute(text("""
+        """)
+        )
+        conn.execute(
+            text("""
             UPDATE us_code_section ucs
             SET    _new_gid = m.new_id
             FROM   _gid_map m
             WHERE  ucs.group_id = m.old_id
-        """))
-        conn.execute(text("""
+        """)
+        )
+        conn.execute(
+            text("""
             UPDATE section_snapshot ss
             SET    _new_gid = m.new_id
             FROM   _gid_map m
             WHERE  ss.group_id = m.old_id
-        """))
+        """)
+        )
 
         conn.execute(text("DROP TABLE _gid_map"))
 
     # ------------------------------------------------------------------ #
     # 3. Drop FK constraints and indexes that reference the old columns    #
     # ------------------------------------------------------------------ #
-    op.drop_constraint("fk_section_group_parent_id_section_group", "section_group", type_="foreignkey")
-    op.drop_constraint("fk_us_code_section_group_id_section_group", "us_code_section", type_="foreignkey")
+    op.drop_constraint(
+        "fk_section_group_parent_id_section_group", "section_group", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "fk_us_code_section_group_id_section_group",
+        "us_code_section",
+        type_="foreignkey",
+    )
     # section_snapshot FK was added via add_column with inline ForeignKey,
     # so PostgreSQL named it with the standard convention.
-    op.drop_constraint("section_snapshot_group_id_fkey", "section_snapshot", type_="foreignkey")
+    op.drop_constraint(
+        "section_snapshot_group_id_fkey", "section_snapshot", type_="foreignkey"
+    )
 
     op.drop_constraint("uq_section_group_child", "section_group", type_="unique")
     op.drop_index("idx_section_group_parent", "section_group")
@@ -164,20 +191,26 @@ def upgrade() -> None:
     # ------------------------------------------------------------------ #
     op.create_foreign_key(
         "fk_section_group_parent_id_section_group",
-        "section_group", "section_group",
-        ["parent_id"], ["group_id"],
+        "section_group",
+        "section_group",
+        ["parent_id"],
+        ["group_id"],
         ondelete="CASCADE",
     )
     op.create_foreign_key(
         "fk_us_code_section_group_id_section_group",
-        "us_code_section", "section_group",
-        ["group_id"], ["group_id"],
+        "us_code_section",
+        "section_group",
+        ["group_id"],
+        ["group_id"],
         ondelete="SET NULL",
     )
     op.create_foreign_key(
         "fk_section_snapshot_group_id_section_group",
-        "section_snapshot", "section_group",
-        ["group_id"], ["group_id"],
+        "section_snapshot",
+        "section_group",
+        ["group_id"],
+        ["group_id"],
         ondelete="SET NULL",
     )
 
@@ -185,11 +218,14 @@ def upgrade() -> None:
     # 9. Recreate unique constraint and indexes                            #
     # ------------------------------------------------------------------ #
     op.create_unique_constraint(
-        "uq_section_group_child", "section_group",
+        "uq_section_group_child",
+        "section_group",
         ["parent_id", "group_type", "number"],
     )
     op.create_index("idx_section_group_parent", "section_group", ["parent_id"])
-    op.create_index("idx_section_group_sort", "section_group", ["parent_id", "sort_order"])
+    op.create_index(
+        "idx_section_group_sort", "section_group", ["parent_id", "sort_order"]
+    )
     op.create_index("idx_section_group", "us_code_section", ["group_id"])
     op.create_index("idx_section_sort", "us_code_section", ["group_id", "sort_order"])
     op.create_index("idx_section_snapshot_group", "section_snapshot", ["group_id"])

--- a/backend/app/crud/us_code.py
+++ b/backend/app/crud/us_code.py
@@ -5,6 +5,7 @@ revision parameter for time-travel queries. Group hierarchy comes from
 SectionGroup (populated by both ingestion and bootstrap).
 """
 
+import uuid
 from typing import Any
 
 from sqlalchemy import func, select, text, tuple_
@@ -76,7 +77,7 @@ def _build_section_summary(state: SectionState) -> SectionSummarySchema:
 
 def _build_group_tree(
     group: SectionGroup,
-    sections_by_group: dict[int, list[SectionState]],
+    sections_by_group: dict[uuid.UUID, list[SectionState]],
 ) -> SectionGroupTreeSchema:
     """Recursively build a SectionGroupTreeSchema from ORM objects."""
     child_trees = [
@@ -175,7 +176,7 @@ async def get_all_titles(
         .group_by(SectionGroup.parent_id)
     )
     child_counts_result = await session.execute(child_counts_stmt)
-    child_counts: dict[int | None, int] = {
+    child_counts: dict[uuid.UUID | None, int] = {
         row[0]: row[1] for row in child_counts_result.all()
     }
 
@@ -234,7 +235,7 @@ async def get_title_structure(
     all_groups = {g.group_id: g for g in groups_result.scalars().unique().all()}
 
     # Build parent->children mapping
-    children_by_parent: dict[int, list[SectionGroup]] = {}
+    children_by_parent: dict[uuid.UUID | None, list[SectionGroup]] = {}
     for g in all_groups.values():
         if g.parent_id is not None and g.parent_id in all_groups:
             children_by_parent.setdefault(g.parent_id, []).append(g)
@@ -250,7 +251,7 @@ async def get_title_structure(
     # text_content and normalized_provisions avoids transferring ~3-15MB
     # of unused data from the database.
     head_id, chain = await _resolve_head_and_chain(session, revision_id)
-    sections_by_group: dict[int, list[SectionState]] = {}
+    sections_by_group: dict[uuid.UUID, list[SectionState]] = {}
 
     if head_id is not None and chain:
         result = await session.execute(

--- a/backend/app/models/snapshot.py
+++ b/backend/app/models/snapshot.py
@@ -4,6 +4,7 @@ Only stores sections that changed at a given revision. For unchanged sections,
 walk the parent revision chain to find the most recent snapshot.
 """
 
+import uuid
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import (
@@ -13,7 +14,7 @@ from sqlalchemy import (
     String,
     Text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
@@ -79,8 +80,8 @@ class SectionSnapshot(Base, TimestampMixin):
         nullable=False,
         doc="True if the section was repealed/removed at this revision",
     )
-    group_id: Mapped[int | None] = mapped_column(
-        Integer,
+    group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
         ForeignKey("section_group.group_id", ondelete="SET NULL"),
         nullable=True,
         doc="SectionGroup this snapshot belongs to (for navigation)",

--- a/backend/app/models/us_code.py
+++ b/backend/app/models/us_code.py
@@ -1,5 +1,6 @@
 """US Code models: SectionGroup, Section, Line."""
 
+import uuid
 from datetime import date
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -14,7 +15,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
@@ -36,9 +37,11 @@ class SectionGroup(Base, TimestampMixin):
 
     __tablename__ = "section_group"
 
-    group_id: Mapped[int] = mapped_column(primary_key=True)
-    parent_id: Mapped[int | None] = mapped_column(
-        ForeignKey("section_group.group_id", ondelete="CASCADE"), nullable=True
+    group_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("section_group.group_id", ondelete="CASCADE"),
+        nullable=True,
     )
     group_type: Mapped[str] = mapped_column(String(50), nullable=False)
     number: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -92,8 +95,10 @@ class USCodeSection(Base, TimestampMixin):
     __tablename__ = "us_code_section"
 
     section_id: Mapped[int] = mapped_column(primary_key=True)
-    group_id: Mapped[int | None] = mapped_column(
-        ForeignKey("section_group.group_id", ondelete="SET NULL"), nullable=True
+    group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("section_group.group_id", ondelete="SET NULL"),
+        nullable=True,
     )
     title_number: Mapped[int] = mapped_column(Integer, nullable=False)
     section_number: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/backend/pipeline/olrc/group_service.py
+++ b/backend/pipeline/olrc/group_service.py
@@ -265,5 +265,5 @@ async def upsert_groups_from_parse_result(
             positive_law_date=row["positive_law_date"],
             positive_law_citation=g.positive_law_citation,
         )
-        for g, row in zip(groups, rows)
+        for g, row in zip(groups, rows, strict=True)
     }

--- a/backend/pipeline/olrc/group_service.py
+++ b/backend/pipeline/olrc/group_service.py
@@ -115,6 +115,18 @@ def _get_positive_law_date(title_number: int) -> date | None:
     return POSITIVE_LAW_DATES.get(title_number)
 
 
+def _compute_positive_law_date(parsed: ParsedGroup) -> date | None:
+    """Compute the positive_law_date value for a ParsedGroup."""
+    if parsed.group_type != "title":
+        return None
+    positive_law_date = None
+    if parsed.positive_law_date:
+        positive_law_date = _parse_citation_date(parsed.positive_law_date)
+    if parsed.is_positive_law and not positive_law_date:
+        positive_law_date = _get_positive_law_date(int(parsed.number))
+    return positive_law_date
+
+
 async def upsert_group(
     session: AsyncSession,
     parsed: ParsedGroup,
@@ -126,12 +138,7 @@ async def upsert_group(
     Returns:
         Tuple of (group record, was_created).
     """
-    positive_law_date = None
-    if parsed.group_type == "title":
-        if parsed.positive_law_date:
-            positive_law_date = _parse_citation_date(parsed.positive_law_date)
-        if parsed.is_positive_law and not positive_law_date:
-            positive_law_date = _get_positive_law_date(int(parsed.number))
+    positive_law_date = _compute_positive_law_date(parsed)
 
     if parent_id is not None:
         stmt = select(SectionGroup).where(
@@ -179,6 +186,11 @@ async def upsert_groups_from_parse_result(
 ) -> dict[str, SectionGroup]:
     """Upsert all groups from a parse result, resolving parent_key → parent_id.
 
+    Pre-loads all existing groups for the title hierarchy in a single recursive
+    CTE query to eliminate per-group SELECTs on re-runs. On fresh seeds the CTE
+    returns nothing and new groups are inserted one at a time (flush required to
+    obtain DB-generated group_id for child foreign keys).
+
     Args:
         session: Database session.
         groups: Parsed groups (parents-before-children order).
@@ -187,16 +199,60 @@ async def upsert_groups_from_parse_result(
     Returns:
         Dict mapping group key → SectionGroup record.
     """
+    if not groups:
+        return {}
+
+    # Pre-load the full group hierarchy for this title in one round-trip.
+    # Key: (parent_id, group_type, number) → SectionGroup
+    preloaded: dict[tuple[int | None, str, str], SectionGroup] = {}
+    root = next((g for g in groups if g.parent_key is None), None)
+    if root is not None:
+        sg_cte = (
+            select(SectionGroup.group_id)
+            .where(
+                SectionGroup.parent_id.is_(None),
+                SectionGroup.group_type == root.group_type,
+                SectionGroup.number == root.number,
+            )
+            .cte(name="sg_hierarchy", recursive=True)
+        )
+        sg_cte = sg_cte.union_all(
+            select(SectionGroup.group_id).where(
+                SectionGroup.parent_id == sg_cte.c.group_id
+            )
+        )
+        result = await session.execute(
+            select(SectionGroup).where(
+                SectionGroup.group_id.in_(select(sg_cte.c.group_id))
+            )
+        )
+        for sg in result.scalars():
+            preloaded[(sg.parent_id, sg.group_type, sg.number)] = sg
+
     group_lookup: dict[str, SectionGroup] = {}
 
     for parsed_group in groups:
-        parent_id = None
+        parent_id: int | None = None
         if parsed_group.parent_key:
             parent_record = group_lookup.get(parsed_group.parent_key)
             if parent_record:
                 parent_id = parent_record.group_id
 
-        group_record, _ = await upsert_group(session, parsed_group, parent_id, force)
+        cached = preloaded.get((parent_id, parsed_group.group_type, parsed_group.number))
+        if cached is not None:
+            if force:
+                cached.name = parsed_group.name
+                cached.sort_order = parsed_group.sort_order
+                cached.is_positive_law = parsed_group.is_positive_law
+                cached.positive_law_date = _compute_positive_law_date(parsed_group)
+                cached.positive_law_citation = parsed_group.positive_law_citation
+            group_record = cached
+        else:
+            # Group not yet in DB — insert and flush to materialise group_id
+            # so child groups can reference it as parent_id.
+            group_record, _ = await upsert_group(session, parsed_group, parent_id, force)
+            preloaded[(parent_id, parsed_group.group_type, parsed_group.number)] = group_record
+
         group_lookup[parsed_group.key] = group_record
 
     return group_lookup

--- a/backend/pipeline/olrc/group_service.py
+++ b/backend/pipeline/olrc/group_service.py
@@ -6,15 +6,33 @@ chapter → subchapter → …) from parsed USLM data.
 
 import logging
 import re
+import uuid
 from datetime import date
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.us_code import SectionGroup
 from pipeline.olrc.parser import ParsedGroup
 
 logger = logging.getLogger(__name__)
+
+# Fixed project namespace for deterministic group UUIDs.  Must never change
+# after first deployment — altering it would invalidate all stored group_ids.
+_GROUP_NS = uuid.UUID("6f3a4b5c-2d1e-4f0a-9c8d-7e6f5d4c3b2a")
+
+
+def group_id_from_key(key: str) -> uuid.UUID:
+    """Compute a stable UUID for a SectionGroup from its hierarchy key.
+
+    The key format (e.g. "title:17/chapter:1/subchapter:I") is derived
+    entirely from the US Code's XML structure and is stable across release
+    points for the same structural node.  UUID5 over a fixed project namespace
+    guarantees uniqueness and reproducibility without any DB round-trip.
+    """
+    return uuid.uuid5(_GROUP_NS, key)
+
 
 # Fallback positive law enactment dates for titles where XML doesn't provide the date.
 # Source: https://uscode.house.gov/codification/legislation.shtml
@@ -130,29 +148,23 @@ def _compute_positive_law_date(parsed: ParsedGroup) -> date | None:
 async def upsert_group(
     session: AsyncSession,
     parsed: ParsedGroup,
-    parent_id: int | None,
+    parent_id: uuid.UUID | None,
     force: bool = False,
 ) -> tuple[SectionGroup, bool]:
     """Insert or update a single SectionGroup record.
 
+    The group_id is computed deterministically from ``parsed.key`` via
+    UUID5 so no DB flush is needed to obtain it before inserting children.
+
     Returns:
         Tuple of (group record, was_created).
     """
+    gid = group_id_from_key(parsed.key)
     positive_law_date = _compute_positive_law_date(parsed)
 
-    if parent_id is not None:
-        stmt = select(SectionGroup).where(
-            SectionGroup.parent_id == parent_id,
-            SectionGroup.group_type == parsed.group_type,
-            SectionGroup.number == parsed.number,
-        )
-    else:
-        stmt = select(SectionGroup).where(
-            SectionGroup.parent_id.is_(None),
-            SectionGroup.group_type == parsed.group_type,
-            SectionGroup.number == parsed.number,
-        )
-    result = await session.execute(stmt)
+    result = await session.execute(
+        select(SectionGroup).where(SectionGroup.group_id == gid)
+    )
     existing = result.scalar_one_or_none()
 
     if existing:
@@ -165,6 +177,7 @@ async def upsert_group(
         return existing, False
 
     group = SectionGroup(
+        group_id=gid,
         parent_id=parent_id,
         group_type=parsed.group_type,
         number=parsed.number,
@@ -175,7 +188,7 @@ async def upsert_group(
         positive_law_citation=parsed.positive_law_citation,
     )
     session.add(group)
-    await session.flush()
+    # No flush needed — group_id is pre-computed, not DB-generated.
     return group, True
 
 
@@ -184,75 +197,73 @@ async def upsert_groups_from_parse_result(
     groups: list[ParsedGroup],
     force: bool = False,
 ) -> dict[str, SectionGroup]:
-    """Upsert all groups from a parse result, resolving parent_key → parent_id.
+    """Upsert all groups from a parse result in a single bulk statement.
 
-    Pre-loads all existing groups for the title hierarchy in a single recursive
-    CTE query to eliminate per-group SELECTs on re-runs. On fresh seeds the CTE
-    returns nothing and new groups are inserted one at a time (flush required to
-    obtain DB-generated group_id for child foreign keys).
+    Because group IDs are computed deterministically from the hierarchy key
+    (UUID5 over ``_GROUP_NS``), all parent_ids are known before any DB write.
+    The entire hierarchy is inserted in one ``INSERT … ON CONFLICT`` round-trip
+    with no intermediate flushes.
 
     Args:
         session: Database session.
         groups: Parsed groups (parents-before-children order).
-        force: If True, update existing records.
+        force: If True, update name/sort_order/positive-law fields on conflict.
 
     Returns:
-        Dict mapping group key → SectionGroup record.
+        Dict mapping group key → SectionGroup instance (transient — callers
+        should only read .group_id from these objects).
     """
     if not groups:
         return {}
 
-    # Pre-load the full group hierarchy for this title in one round-trip.
-    # Key: (parent_id, group_type, number) → SectionGroup
-    preloaded: dict[tuple[int | None, str, str], SectionGroup] = {}
-    root = next((g for g in groups if g.parent_key is None), None)
-    if root is not None:
-        sg_cte = (
-            select(SectionGroup.group_id)
-            .where(
-                SectionGroup.parent_id.is_(None),
-                SectionGroup.group_type == root.group_type,
-                SectionGroup.number == root.number,
-            )
-            .cte(name="sg_hierarchy", recursive=True)
+    rows = [
+        {
+            "group_id": group_id_from_key(g.key),
+            "parent_id": group_id_from_key(g.parent_key) if g.parent_key else None,
+            "group_type": g.group_type,
+            "number": g.number,
+            "name": g.name,
+            "sort_order": g.sort_order,
+            "is_positive_law": g.is_positive_law,
+            "positive_law_date": _compute_positive_law_date(g),
+            "positive_law_citation": g.positive_law_citation,
+        }
+        for g in groups
+    ]
+
+    stmt = pg_insert(SectionGroup).values(rows)
+    if force:
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["group_id"],
+            set_={
+                col: stmt.excluded[col]
+                for col in (
+                    "name",
+                    "sort_order",
+                    "is_positive_law",
+                    "positive_law_date",
+                    "positive_law_citation",
+                )
+            },
         )
-        sg_cte = sg_cte.union_all(
-            select(SectionGroup.group_id).where(
-                SectionGroup.parent_id == sg_cte.c.group_id
-            )
+    else:
+        stmt = stmt.on_conflict_do_nothing()
+
+    await session.execute(stmt)
+
+    # Build the lookup from computed data — no DB fetch needed because all
+    # group_ids are known from the UUID5 computation above.
+    return {
+        g.key: SectionGroup(
+            group_id=row["group_id"],
+            parent_id=row["parent_id"],
+            group_type=g.group_type,
+            number=g.number,
+            name=g.name,
+            sort_order=g.sort_order,
+            is_positive_law=g.is_positive_law,
+            positive_law_date=row["positive_law_date"],
+            positive_law_citation=g.positive_law_citation,
         )
-        result = await session.execute(
-            select(SectionGroup).where(
-                SectionGroup.group_id.in_(select(sg_cte.c.group_id))
-            )
-        )
-        for sg in result.scalars():
-            preloaded[(sg.parent_id, sg.group_type, sg.number)] = sg
-
-    group_lookup: dict[str, SectionGroup] = {}
-
-    for parsed_group in groups:
-        parent_id: int | None = None
-        if parsed_group.parent_key:
-            parent_record = group_lookup.get(parsed_group.parent_key)
-            if parent_record:
-                parent_id = parent_record.group_id
-
-        cached = preloaded.get((parent_id, parsed_group.group_type, parsed_group.number))
-        if cached is not None:
-            if force:
-                cached.name = parsed_group.name
-                cached.sort_order = parsed_group.sort_order
-                cached.is_positive_law = parsed_group.is_positive_law
-                cached.positive_law_date = _compute_positive_law_date(parsed_group)
-                cached.positive_law_citation = parsed_group.positive_law_citation
-            group_record = cached
-        else:
-            # Group not yet in DB — insert and flush to materialise group_id
-            # so child groups can reference it as parent_id.
-            group_record, _ = await upsert_group(session, parsed_group, parent_id, force)
-            preloaded[(parent_id, parsed_group.group_type, parsed_group.number)] = group_record
-
-        group_lookup[parsed_group.key] = group_record
-
-    return group_lookup
+        for g, row in zip(groups, rows)
+    }

--- a/backend/pipeline/olrc/ingestion.py
+++ b/backend/pipeline/olrc/ingestion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -164,7 +165,7 @@ class USCodeIngestionService:
 
         # Ingest sections
         for section in result.sections:
-            group_id = None
+            group_id: uuid.UUID | None = None
             if section.parent_group_key:
                 group_record = group_lookup.get(section.parent_group_key)
                 if group_record:
@@ -183,7 +184,7 @@ class USCodeIngestionService:
     async def _upsert_section(
         self,
         parsed: ParsedSection,
-        group_id: int | None,
+        group_id: uuid.UUID | None,
         title_number: int,
         force: bool = False,
     ) -> USCodeSection:

--- a/backend/pipeline/olrc/ingestion.py
+++ b/backend/pipeline/olrc/ingestion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import date, datetime
 from pathlib import Path
@@ -135,7 +136,7 @@ class USCodeIngestionService:
 
     async def _ingest_parse_result(
         self, result: USLMParseResult, force: bool = False
-    ) -> dict:
+    ) -> dict[str, int]:
         """Ingest parsed USLM data into the database.
 
         Args:
@@ -187,8 +188,9 @@ class USCodeIngestionService:
         force: bool = False,
     ) -> USCodeSection:
         """Insert or update a section record."""
-        # Normalize the parsed section to get structured data
-        normalized = normalize_parsed_section(parsed)
+        # Normalize the parsed section to get structured data (CPU-bound; offload
+        # to thread pool so the event loop stays free for concurrent DB work).
+        normalized = await asyncio.to_thread(normalize_parsed_section, parsed)
 
         # Extract text content (prefer normalized, fall back to raw)
         text_content = normalized.normalized_text or parsed.text_content

--- a/backend/pipeline/olrc/snapshot_service.py
+++ b/backend/pipeline/olrc/snapshot_service.py
@@ -7,6 +7,7 @@ These are used by the diff engine, API, and frontend.
 from __future__ import annotations
 
 import logging
+import uuid
 from dataclasses import dataclass
 from typing import Any
 
@@ -36,7 +37,7 @@ class SectionState:
     snapshot_id: int
     revision_id: int
     is_deleted: bool
-    group_id: int | None = None
+    group_id: uuid.UUID | None = None
     sort_order: int = 0
 
 

--- a/backend/tests/pipeline/test_structure_ingestion.py
+++ b/backend/tests/pipeline/test_structure_ingestion.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.models.us_code import SectionGroup
 from pipeline.olrc.group_service import (
     _GROUP_NS,
     group_id_from_key,
@@ -129,7 +128,9 @@ class TestUpsertGroup:
             parent_key="title:17",
             key="title:17/chapter:1",
         )
-        group, was_created = await upsert_group(mock_session, parsed, parent_id=parent_uuid)
+        group, was_created = await upsert_group(
+            mock_session, parsed, parent_id=parent_uuid
+        )
 
         assert was_created is True
         added = mock_session.add.call_args[0][0]
@@ -152,7 +153,9 @@ class TestUpsertGroup:
             parent_key="title:17/chapter:1",
             key="title:17/chapter:1/subchapter:I",
         )
-        group, was_created = await upsert_group(mock_session, parsed, parent_id=parent_uuid)
+        group, was_created = await upsert_group(
+            mock_session, parsed, parent_id=parent_uuid
+        )
 
         assert was_created is True
         added = mock_session.add.call_args[0][0]
@@ -316,9 +319,7 @@ class TestIngestParseResult:
         self, mock_session: AsyncMock, minimal_parse_result: USLMParseResult
     ) -> None:
         """All groups are inserted in exactly one session.execute call."""
-        await upsert_groups_from_parse_result(
-            mock_session, minimal_parse_result.groups
-        )
+        await upsert_groups_from_parse_result(mock_session, minimal_parse_result.groups)
         mock_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
@@ -363,9 +364,7 @@ class TestIngestParseResult:
         self, mock_session: AsyncMock, minimal_parse_result: USLMParseResult
     ) -> None:
         """No flush is ever needed — UUIDs are pre-computed."""
-        await upsert_groups_from_parse_result(
-            mock_session, minimal_parse_result.groups
-        )
+        await upsert_groups_from_parse_result(mock_session, minimal_parse_result.groups)
         mock_session.flush.assert_not_called()
 
     @pytest.mark.asyncio

--- a/backend/tests/pipeline/test_structure_ingestion.py
+++ b/backend/tests/pipeline/test_structure_ingestion.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.models.us_code import SectionGroup
 from pipeline.olrc.group_service import upsert_group, upsert_groups_from_parse_result
 from pipeline.olrc.parser import (
     ParsedGroup,
@@ -24,16 +25,26 @@ def mock_session():
 
 
 def _mock_not_found():
-    """Return a mock result where scalar_one_or_none returns None."""
+    """Return a mock result for scalar_one_or_none (None) and scalars (empty)."""
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalars.return_value = []
     return mock_result
 
 
 def _mock_found(record):
-    """Return a mock result where scalar_one_or_none returns a record."""
+    """Return a mock result for scalar_one_or_none and scalars with one record."""
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = record
+    mock_result.scalars.return_value = [record]
+    return mock_result
+
+
+def _mock_scalars(records: list) -> MagicMock:
+    """Return a mock result whose scalars() yields the given records."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = records
+    mock_result.scalar_one_or_none.return_value = None
     return mock_result
 
 
@@ -260,7 +271,9 @@ class TestIngestParseResult:
     async def test_end_to_end_orchestration(
         self, mock_session, minimal_parse_result
     ) -> None:
-        """Test that all groups are upserted."""
+        """Fresh seed: CTE returns nothing; all 3 groups are inserted."""
+        # First execute: CTE pre-load (empty — fresh seed)
+        # Subsequent executes: per-group SELECT in upsert_group (not found → insert)
         mock_session.execute.return_value = _mock_not_found()
 
         group_lookup = await upsert_groups_from_parse_result(
@@ -278,22 +291,19 @@ class TestIngestParseResult:
         assert len(group_lookup) == 0
 
     @pytest.mark.asyncio
-    async def test_created_vs_updated_stats(self, mock_session) -> None:
-        """Test that existing groups are returned without re-adding."""
-        existing_title = MagicMock()
+    async def test_preloads_existing_groups_on_rerun(self, mock_session) -> None:
+        """Re-run: CTE pre-loads all groups; no per-group SELECTs or inserts."""
+        existing_title = MagicMock(spec=SectionGroup)
         existing_title.group_id = 1
+        existing_title.parent_id = None
+        existing_title.group_type = "title"
+        existing_title.number = "17"
 
-        call_count = 0
-
-        async def side_effect(*_args, **_kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return _mock_found(existing_title)
-            else:
-                return _mock_not_found()
-
-        mock_session.execute = AsyncMock(side_effect=side_effect)
+        existing_chapter = MagicMock(spec=SectionGroup)
+        existing_chapter.group_id = 2
+        existing_chapter.parent_id = 1
+        existing_chapter.group_type = "chapter"
+        existing_chapter.number = "1"
 
         title_group = ParsedGroup(
             group_type="title",
@@ -309,10 +319,63 @@ class TestIngestParseResult:
             key="title:17/chapter:1",
         )
 
+        mock_session.execute.return_value = _mock_scalars(
+            [existing_title, existing_chapter]
+        )
+
+        group_lookup = await upsert_groups_from_parse_result(
+            mock_session, [title_group, chapter_group]
+        )
+
+        assert group_lookup["title:17"] is existing_title
+        assert group_lookup["title:17/chapter:1"] is existing_chapter
+        # Only the CTE pre-load query was issued; no per-group SELECTs or INSERTs
+        mock_session.execute.assert_called_once()
+        mock_session.add.assert_not_called()
+        mock_session.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_partial_rerun_inserts_missing_groups(self, mock_session) -> None:
+        """Partial re-run: pre-load has title but not chapter; chapter is inserted."""
+        existing_title = MagicMock(spec=SectionGroup)
+        existing_title.group_id = 1
+        existing_title.parent_id = None
+        existing_title.group_type = "title"
+        existing_title.number = "17"
+
+        title_group = ParsedGroup(
+            group_type="title",
+            number="17",
+            name="Copyrights",
+            key="title:17",
+        )
+        chapter_group = ParsedGroup(
+            group_type="chapter",
+            number="1",
+            name="Subject Matter",
+            parent_key="title:17",
+            key="title:17/chapter:1",
+        )
+
+        call_count = 0
+
+        async def side_effect(*_args, **_kwargs) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # CTE pre-load returns only the title
+                return _mock_scalars([existing_title])
+            else:
+                # Per-group SELECT for chapter: not found → insert
+                return _mock_not_found()
+
+        mock_session.execute = AsyncMock(side_effect=side_effect)
+
         group_lookup = await upsert_groups_from_parse_result(
             mock_session, [title_group, chapter_group], force=True
         )
 
         assert len(group_lookup) == 2
-        # Title was existing, chapter was new
         assert group_lookup["title:17"] is existing_title
+        # Chapter was missing from pre-load; one upsert_group SELECT was issued
+        assert mock_session.execute.call_count == 2

--- a/backend/tests/pipeline/test_structure_ingestion.py
+++ b/backend/tests/pipeline/test_structure_ingestion.py
@@ -1,12 +1,18 @@
 """Tests for structure upsert methods (unified SectionGroup model)."""
 
+import uuid
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app.models.us_code import SectionGroup
-from pipeline.olrc.group_service import upsert_group, upsert_groups_from_parse_result
+from pipeline.olrc.group_service import (
+    _GROUP_NS,
+    group_id_from_key,
+    upsert_group,
+    upsert_groups_from_parse_result,
+)
 from pipeline.olrc.parser import (
     ParsedGroup,
     ParsedSection,
@@ -24,36 +30,55 @@ def mock_session():
     return session
 
 
-def _mock_not_found():
-    """Return a mock result for scalar_one_or_none (None) and scalars (empty)."""
+def _mock_not_found() -> MagicMock:
+    """Return a mock execute result with no matching row."""
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = None
     mock_result.scalars.return_value = []
     return mock_result
 
 
-def _mock_found(record):
-    """Return a mock result for scalar_one_or_none and scalars with one record."""
+def _mock_found(record: object) -> MagicMock:
+    """Return a mock execute result containing one matching record."""
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = record
     mock_result.scalars.return_value = [record]
     return mock_result
 
 
-def _mock_scalars(records: list) -> MagicMock:
-    """Return a mock result whose scalars() yields the given records."""
-    mock_result = MagicMock()
-    mock_result.scalars.return_value = records
-    mock_result.scalar_one_or_none.return_value = None
-    return mock_result
+# ---------------------------------------------------------------------------
+# group_id_from_key
+# ---------------------------------------------------------------------------
+
+
+class TestGroupIdFromKey:
+    """Tests for the deterministic UUID helper."""
+
+    def test_same_key_same_uuid(self) -> None:
+        assert group_id_from_key("title:17") == group_id_from_key("title:17")
+
+    def test_different_keys_different_uuids(self) -> None:
+        assert group_id_from_key("title:17") != group_id_from_key("title:18")
+
+    def test_child_differs_from_parent(self) -> None:
+        assert group_id_from_key("title:17") != group_id_from_key("title:17/chapter:1")
+
+    def test_uses_project_namespace(self) -> None:
+        expected = uuid.uuid5(_GROUP_NS, "title:17")
+        assert group_id_from_key("title:17") == expected
+
+
+# ---------------------------------------------------------------------------
+# upsert_group
+# ---------------------------------------------------------------------------
 
 
 class TestUpsertGroup:
     """Tests for upsert_group function."""
 
     @pytest.mark.asyncio
-    async def test_new_title_insert(self, mock_session) -> None:
-        """Test inserting a new title group when none exists."""
+    async def test_new_title_insert(self, mock_session: AsyncMock) -> None:
+        """New title: session.add is called, was_created=True, group_id is a UUID."""
         mock_session.execute.return_value = _mock_not_found()
 
         parsed = ParsedGroup(
@@ -73,12 +98,29 @@ class TestUpsertGroup:
         assert added.number == "17"
         assert added.name == "Copyrights"
         assert added.is_positive_law is True
+        assert added.group_id == group_id_from_key("title:17")
 
     @pytest.mark.asyncio
-    async def test_new_chapter_insert(self, mock_session) -> None:
-        """Test inserting a new chapter group."""
+    async def test_new_group_does_not_flush(self, mock_session: AsyncMock) -> None:
+        """UUID is pre-computed — no flush needed after insert."""
         mock_session.execute.return_value = _mock_not_found()
 
+        parsed = ParsedGroup(
+            group_type="title",
+            number="17",
+            name="Copyrights",
+            key="title:17",
+        )
+        await upsert_group(mock_session, parsed, parent_id=None)
+
+        mock_session.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_new_chapter_insert(self, mock_session: AsyncMock) -> None:
+        """New chapter: parent_id is propagated as a UUID."""
+        mock_session.execute.return_value = _mock_not_found()
+
+        parent_uuid = group_id_from_key("title:17")
         parsed = ParsedGroup(
             group_type="chapter",
             number="1",
@@ -87,22 +129,21 @@ class TestUpsertGroup:
             parent_key="title:17",
             key="title:17/chapter:1",
         )
-        group, was_created = await upsert_group(mock_session, parsed, parent_id=100)
+        group, was_created = await upsert_group(mock_session, parsed, parent_id=parent_uuid)
 
         assert was_created is True
-        mock_session.add.assert_called_once()
         added = mock_session.add.call_args[0][0]
         assert added.group_type == "chapter"
         assert added.number == "1"
-        assert added.name == "Subject Matter and Scope of Copyright"
-        assert added.sort_order == 1
-        assert added.parent_id == 100
+        assert added.parent_id == parent_uuid
+        assert added.group_id == group_id_from_key("title:17/chapter:1")
 
     @pytest.mark.asyncio
-    async def test_new_subchapter_insert(self, mock_session) -> None:
-        """Test inserting a new subchapter group."""
+    async def test_new_subchapter_insert(self, mock_session: AsyncMock) -> None:
+        """New subchapter: correct UUID and parent propagation."""
         mock_session.execute.return_value = _mock_not_found()
 
+        parent_uuid = group_id_from_key("title:17/chapter:1")
         parsed = ParsedGroup(
             group_type="subchapter",
             number="I",
@@ -111,18 +152,17 @@ class TestUpsertGroup:
             parent_key="title:17/chapter:1",
             key="title:17/chapter:1/subchapter:I",
         )
-        group, was_created = await upsert_group(mock_session, parsed, parent_id=200)
+        group, was_created = await upsert_group(mock_session, parsed, parent_id=parent_uuid)
 
         assert was_created is True
-        mock_session.add.assert_called_once()
         added = mock_session.add.call_args[0][0]
         assert added.group_type == "subchapter"
         assert added.number == "I"
-        assert added.parent_id == 200
+        assert added.parent_id == parent_uuid
 
     @pytest.mark.asyncio
-    async def test_update_with_force(self, mock_session) -> None:
-        """Test updating an existing group with force=True."""
+    async def test_update_with_force(self, mock_session: AsyncMock) -> None:
+        """Existing group with force=True: record is updated in place."""
         existing = MagicMock()
         existing.name = "Old Name"
         existing.sort_order = 0
@@ -137,7 +177,7 @@ class TestUpsertGroup:
             key="title:17/chapter:1",
         )
         group, was_created = await upsert_group(
-            mock_session, parsed, parent_id=100, force=True
+            mock_session, parsed, parent_id=group_id_from_key("title:17"), force=True
         )
 
         assert was_created is False
@@ -147,8 +187,8 @@ class TestUpsertGroup:
         mock_session.add.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_skip_without_force(self, mock_session) -> None:
-        """Test skipping update when force=False and record exists."""
+    async def test_skip_without_force(self, mock_session: AsyncMock) -> None:
+        """Existing group with force=False: record is returned unchanged."""
         existing = MagicMock()
         existing.name = "Old Name"
         mock_session.execute.return_value = _mock_found(existing)
@@ -161,7 +201,7 @@ class TestUpsertGroup:
             key="title:17/chapter:1",
         )
         group, was_created = await upsert_group(
-            mock_session, parsed, parent_id=100, force=False
+            mock_session, parsed, parent_id=group_id_from_key("title:17"), force=False
         )
 
         assert was_created is False
@@ -169,8 +209,8 @@ class TestUpsertGroup:
         assert existing.name == "Old Name"
 
     @pytest.mark.asyncio
-    async def test_positive_law_with_parser_date(self, mock_session) -> None:
-        """Test positive law title uses parser-provided date."""
+    async def test_positive_law_with_parser_date(self, mock_session: AsyncMock) -> None:
+        """Positive-law title uses the date from the XML."""
         mock_session.execute.return_value = _mock_not_found()
 
         parsed = ParsedGroup(
@@ -181,14 +221,14 @@ class TestUpsertGroup:
             positive_law_date="July 30, 1947",
             key="title:17",
         )
-        group, _ = await upsert_group(mock_session, parsed, parent_id=None)
+        await upsert_group(mock_session, parsed, parent_id=None)
 
         added = mock_session.add.call_args[0][0]
         assert added.positive_law_date == date(1947, 7, 30)
 
     @pytest.mark.asyncio
-    async def test_positive_law_fallback_date(self, mock_session) -> None:
-        """Test positive law title falls back to hardcoded date when parser provides none."""
+    async def test_positive_law_fallback_date(self, mock_session: AsyncMock) -> None:
+        """Positive-law title falls back to hardcoded date when XML omits it."""
         mock_session.execute.return_value = _mock_not_found()
 
         parsed = ParsedGroup(
@@ -199,15 +239,14 @@ class TestUpsertGroup:
             positive_law_date=None,
             key="title:17",
         )
-        group, _ = await upsert_group(mock_session, parsed, parent_id=None)
+        await upsert_group(mock_session, parsed, parent_id=None)
 
         added = mock_session.add.call_args[0][0]
-        # Title 17 fallback date is 1947-07-30
         assert added.positive_law_date == date(1947, 7, 30)
 
     @pytest.mark.asyncio
-    async def test_non_positive_law(self, mock_session) -> None:
-        """Test non-positive law title has no positive_law_date."""
+    async def test_non_positive_law(self, mock_session: AsyncMock) -> None:
+        """Non-positive-law title has no positive_law_date."""
         mock_session.execute.return_value = _mock_not_found()
 
         parsed = ParsedGroup(
@@ -217,19 +256,24 @@ class TestUpsertGroup:
             is_positive_law=False,
             key="title:42",
         )
-        group, _ = await upsert_group(mock_session, parsed, parent_id=None)
+        await upsert_group(mock_session, parsed, parent_id=None)
 
         added = mock_session.add.call_args[0][0]
         assert added.positive_law_date is None
         assert added.is_positive_law is False
 
 
+# ---------------------------------------------------------------------------
+# upsert_groups_from_parse_result
+# ---------------------------------------------------------------------------
+
+
 class TestIngestParseResult:
-    """Tests for _ingest_parse_result orchestration via upsert_groups_from_parse_result."""
+    """Tests for upsert_groups_from_parse_result bulk behaviour."""
 
     @pytest.fixture
-    def minimal_parse_result(self):
-        """Create a minimal parse result with one of each entity."""
+    def minimal_parse_result(self) -> USLMParseResult:
+        """Three-level hierarchy: title → chapter → subchapter."""
         title_group = ParsedGroup(
             group_type="title",
             number="17",
@@ -268,114 +312,65 @@ class TestIngestParseResult:
         )
 
     @pytest.mark.asyncio
-    async def test_end_to_end_orchestration(
-        self, mock_session, minimal_parse_result
+    async def test_bulk_insert_single_round_trip(
+        self, mock_session: AsyncMock, minimal_parse_result: USLMParseResult
     ) -> None:
-        """Fresh seed: CTE returns nothing; all 3 groups are inserted."""
-        # First execute: CTE pre-load (empty — fresh seed)
-        # Subsequent executes: per-group SELECT in upsert_group (not found → insert)
-        mock_session.execute.return_value = _mock_not_found()
+        """All groups are inserted in exactly one session.execute call."""
+        await upsert_groups_from_parse_result(
+            mock_session, minimal_parse_result.groups
+        )
+        mock_session.execute.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_returns_all_groups(
+        self, mock_session: AsyncMock, minimal_parse_result: USLMParseResult
+    ) -> None:
+        """Lookup dict contains an entry for every group."""
         group_lookup = await upsert_groups_from_parse_result(
             mock_session, minimal_parse_result.groups
         )
-
-        # 3 groups (title + chapter + subchapter)
         assert len(group_lookup) == 3
 
     @pytest.mark.asyncio
-    async def test_empty_results(self, mock_session) -> None:
-        """Test upsert with no groups."""
-        group_lookup = await upsert_groups_from_parse_result(mock_session, [])
-
-        assert len(group_lookup) == 0
+    async def test_group_ids_are_deterministic_uuids(
+        self, mock_session: AsyncMock, minimal_parse_result: USLMParseResult
+    ) -> None:
+        """Returned group_ids match what group_id_from_key() would compute."""
+        group_lookup = await upsert_groups_from_parse_result(
+            mock_session, minimal_parse_result.groups
+        )
+        assert group_lookup["title:17"].group_id == group_id_from_key("title:17")
+        assert group_lookup["title:17/chapter:1"].group_id == group_id_from_key(
+            "title:17/chapter:1"
+        )
 
     @pytest.mark.asyncio
-    async def test_preloads_existing_groups_on_rerun(self, mock_session) -> None:
-        """Re-run: CTE pre-loads all groups; no per-group SELECTs or inserts."""
-        existing_title = MagicMock(spec=SectionGroup)
-        existing_title.group_id = 1
-        existing_title.parent_id = None
-        existing_title.group_type = "title"
-        existing_title.number = "17"
-
-        existing_chapter = MagicMock(spec=SectionGroup)
-        existing_chapter.group_id = 2
-        existing_chapter.parent_id = 1
-        existing_chapter.group_type = "chapter"
-        existing_chapter.number = "1"
-
-        title_group = ParsedGroup(
-            group_type="title",
-            number="17",
-            name="Copyrights",
-            key="title:17",
-        )
-        chapter_group = ParsedGroup(
-            group_type="chapter",
-            number="1",
-            name="Subject Matter",
-            parent_key="title:17",
-            key="title:17/chapter:1",
-        )
-
-        mock_session.execute.return_value = _mock_scalars(
-            [existing_title, existing_chapter]
-        )
-
+    async def test_parent_ids_resolved_from_keys(
+        self, mock_session: AsyncMock, minimal_parse_result: USLMParseResult
+    ) -> None:
+        """Child groups carry the parent's UUID as parent_id."""
         group_lookup = await upsert_groups_from_parse_result(
-            mock_session, [title_group, chapter_group]
+            mock_session, minimal_parse_result.groups
         )
+        chapter = group_lookup["title:17/chapter:1"]
+        assert chapter.parent_id == group_id_from_key("title:17")
 
-        assert group_lookup["title:17"] is existing_title
-        assert group_lookup["title:17/chapter:1"] is existing_chapter
-        # Only the CTE pre-load query was issued; no per-group SELECTs or INSERTs
-        mock_session.execute.assert_called_once()
-        mock_session.add.assert_not_called()
+        subchapter = group_lookup["title:17/chapter:1/subchapter:I"]
+        assert subchapter.parent_id == group_id_from_key("title:17/chapter:1")
+
+    @pytest.mark.asyncio
+    async def test_no_flush_called(
+        self, mock_session: AsyncMock, minimal_parse_result: USLMParseResult
+    ) -> None:
+        """No flush is ever needed — UUIDs are pre-computed."""
+        await upsert_groups_from_parse_result(
+            mock_session, minimal_parse_result.groups
+        )
         mock_session.flush.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_partial_rerun_inserts_missing_groups(self, mock_session) -> None:
-        """Partial re-run: pre-load has title but not chapter; chapter is inserted."""
-        existing_title = MagicMock(spec=SectionGroup)
-        existing_title.group_id = 1
-        existing_title.parent_id = None
-        existing_title.group_type = "title"
-        existing_title.number = "17"
-
-        title_group = ParsedGroup(
-            group_type="title",
-            number="17",
-            name="Copyrights",
-            key="title:17",
-        )
-        chapter_group = ParsedGroup(
-            group_type="chapter",
-            number="1",
-            name="Subject Matter",
-            parent_key="title:17",
-            key="title:17/chapter:1",
-        )
-
-        call_count = 0
-
-        async def side_effect(*_args, **_kwargs) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                # CTE pre-load returns only the title
-                return _mock_scalars([existing_title])
-            else:
-                # Per-group SELECT for chapter: not found → insert
-                return _mock_not_found()
-
-        mock_session.execute = AsyncMock(side_effect=side_effect)
-
-        group_lookup = await upsert_groups_from_parse_result(
-            mock_session, [title_group, chapter_group], force=True
-        )
-
-        assert len(group_lookup) == 2
-        assert group_lookup["title:17"] is existing_title
-        # Chapter was missing from pre-load; one upsert_group SELECT was issued
-        assert mock_session.execute.call_count == 2
+    async def test_empty_results(self, mock_session: AsyncMock) -> None:
+        """Empty input returns an empty dict without touching the DB."""
+        group_lookup = await upsert_groups_from_parse_result(mock_session, [])
+        assert group_lookup == {}
+        mock_session.execute.assert_not_called()


### PR DESCRIPTION
## Context

Issue #140 identified a performance bottleneck in the OLRC pipeline's group upsert: for a title with 300–500 groups (e.g. Title 16), the old code issued one `SELECT` + one `flush` per group — hundreds of sequential round trips that caused a multi-minute gap during fresh seed runs.

## Changes

### Commit 1 — CTE pre-load + async normalization

Intermediate fix that eliminated per-group `SELECT` queries on re-runs by pre-loading all existing groups in a single recursive CTE query, building an in-memory lookup, and only inserting genuinely new groups. Also offloaded CPU-bound `normalize_parsed_section` to `asyncio.to_thread` in `ingestion.py` so the event loop stays free during concurrent DB work.

### Commit 2 — Replace `section_group` integer PK with deterministic UUID

Root-cause fix that removes the need for any per-group `SELECT` or `flush` at all:

- **`group_service.py`**: Added `_GROUP_NS` (fixed UUID namespace) and `group_id_from_key(key) → uuid.UUID` (UUID5 of the hierarchy key, e.g. `"title:17/chapter:1"`). `upsert_groups_from_parse_result` now issues a **single bulk `INSERT … ON CONFLICT`** for the entire hierarchy — one DB round trip regardless of tree size.

- **Models** (`SectionGroup`, `USCodeSection`, `SectionSnapshot`): `group_id` and `parent_id` columns changed from DB-generated `Integer` to application-assigned `UUID(as_uuid=True)`.

- **Migration `a8b9c0d1e2f3`**: Backfills existing integer-keyed rows — reconstructs hierarchy key paths via recursive CTE, computes UUID5 in Python, bulk-updates via a temp table, then swaps columns, recreates all FK constraints, unique constraints, and indexes. `downgrade()` raises `NotImplementedError` (restore from backup).

- **Type fixes** in `snapshot_service.py`, `crud/us_code.py`, `ingestion.py`: all `int | None` group ID annotations updated to `uuid.UUID | None`.

- **Tests** (`tests/pipeline/test_structure_ingestion.py`): fully rewritten to verify UUID determinism, single `session.execute` call per bulk upsert, no `flush` calls, and correct parent-ID resolution from keys.

## Performance impact

| Scenario | Before | After |
|---|---|---|
| Fresh seed (Title 16, ~400 groups) | ~400 SELECT + ~400 flush | 1 bulk INSERT |
| Re-run (all groups exist) | ~400 SELECT | 1 bulk INSERT ON CONFLICT DO NOTHING |

All 625 tests pass, mypy clean.

https://claude.ai/code/session_01VsPpTRvdQacvWhFkkethJ2