### PR TITLE
Parallelize Phase 1 title downloads using asyncio.gather

### DIFF
--- a/backend/pipeline/olrc/downloader.py
+++ b/backend/pipeline/olrc/downloader.py
@@ -200,11 +200,11 @@ class OLRCDownloader:
         Returns:
             Dictionary mapping title numbers to their XML file paths.
         """
-        results = {}
-        for title_number in PHASE_1_TITLES:
-            path = await self.download_title(title_number, force=force)
-            results[title_number] = path
-        return results
+        async def _one(n: int) -> tuple[int, Path | None]:
+            return n, await self.download_title(n, force=force)
+
+        pairs = await asyncio.gather(*[_one(n) for n in PHASE_1_TITLES])
+        return dict(pairs)
 
     def get_downloaded_titles(self) -> list[int]:
         """Get list of title numbers that have been downloaded.

--- a/backend/pipeline/olrc/downloader.py
+++ b/backend/pipeline/olrc/downloader.py
@@ -200,6 +200,7 @@ class OLRCDownloader:
         Returns:
             Dictionary mapping title numbers to their XML file paths.
         """
+
         async def _one(n: int) -> tuple[int, Path | None]:
             return n, await self.download_title(n, force=force)
 


### PR DESCRIPTION
## Summary
Refactored the `download_phase1_titles` method to use `asyncio.gather()` for concurrent downloads instead of sequential iteration, improving performance by downloading multiple titles in parallel.

## Key Changes
- Replaced sequential loop with `asyncio.gather()` to execute all title downloads concurrently
- Introduced internal `_one()` helper function to wrap individual download operations and return (title_number, path) tuples
- Simplified result aggregation by converting the list of tuples directly to a dictionary

## Implementation Details
- The change maintains the same return type and behavior (dictionary mapping title numbers to file paths)
- All downloads now execute in parallel rather than waiting for each to complete sequentially
- The helper function approach allows clean integration with `asyncio.gather()` while preserving the original logic

https://claude.ai/code/session_01GfbcffTt8hPjeyw5VYf7fD