### PR TITLE
Add legislative history timeline and sponsors view for public laws

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_law_bill_action_and_law_sponsor.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_law_bill_action_and_law_sponsor.py
@@ -1,0 +1,97 @@
+"""Add law_bill_action and law_sponsor tables for caching legislative history.
+
+Revision ID: a1b2c3d4e5f6
+Revises: f7a8b9c0d1e2
+Create Date: 2026-05-06
+
+Adds two tables:
+  - law_bill_action: cached bill actions (timeline events) per public law
+  - law_sponsor: cached primary sponsor + cosponsors per public law
+
+Both are populated by the seed-law-history pipeline command so the History
+tab can serve responses from the DB instead of hitting Congress.gov on every
+request.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f7a8b9c0d1e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "law_bill_action",
+        sa.Column("action_id", sa.Integer(), nullable=False),
+        sa.Column("law_id", sa.Integer(), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False),
+        sa.Column("action_date", sa.Date(), nullable=True),
+        sa.Column("action_code", sa.String(length=50), nullable=True),
+        sa.Column("action_type", sa.String(length=100), nullable=True),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("chamber", sa.String(length=50), nullable=True),
+        sa.Column(
+            "congressional_record_refs",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("event_type", sa.String(length=50), nullable=False),
+        sa.Column("is_milestone", sa.Boolean(), nullable=False),
+        sa.Column("vote_yeas", sa.Integer(), nullable=True),
+        sa.Column("vote_nays", sa.Integer(), nullable=True),
+        sa.Column("vote_not_voting", sa.Integer(), nullable=True),
+        sa.Column("event_title", sa.String(length=300), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["law_id"],
+            ["public_law.law_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("action_id"),
+    )
+    op.create_index(
+        "idx_law_bill_action_law_id", "law_bill_action", ["law_id"], unique=False
+    )
+    op.create_index(
+        "idx_law_bill_action_sort",
+        "law_bill_action",
+        ["law_id", "sort_order"],
+        unique=False,
+    )
+
+    op.create_table(
+        "law_sponsor",
+        sa.Column("sponsor_id", sa.Integer(), nullable=False),
+        sa.Column("law_id", sa.Integer(), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("party", sa.String(length=20), nullable=True),
+        sa.Column("state", sa.String(length=10), nullable=True),
+        sa.Column("bioguide_id", sa.String(length=20), nullable=True),
+        sa.Column("is_primary", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["law_id"],
+            ["public_law.law_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("sponsor_id"),
+    )
+    op.create_index(
+        "idx_law_sponsor_law_id", "law_sponsor", ["law_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_law_sponsor_law_id", table_name="law_sponsor")
+    op.drop_table("law_sponsor")
+    op.drop_index("idx_law_bill_action_sort", table_name="law_bill_action")
+    op.drop_index("idx_law_bill_action_law_id", table_name="law_bill_action")
+    op.drop_table("law_bill_action")

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_law_bill_action_and_law_sponsor.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_law_bill_action_and_law_sponsor.py
@@ -14,8 +14,9 @@ request.
 """
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
+
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a1b2c3d4e5f6"
@@ -84,9 +85,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("sponsor_id"),
     )
-    op.create_index(
-        "idx_law_sponsor_law_id", "law_sponsor", ["law_id"], unique=False
-    )
+    op.create_index("idx_law_sponsor_law_id", "law_sponsor", ["law_id"], unique=False)
 
 
 def downgrade() -> None:

--- a/backend/app/api/v1/laws.py
+++ b/backend/app/api/v1/laws.py
@@ -7,12 +7,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.public_law import (
     compute_law_diffs,
+    get_law_history,
     get_law_metadata,
     get_law_text,
     get_laws_list,
     parse_law_amendments,
 )
 from app.models.base import get_async_session
+from app.schemas.law_history import LegislativeHistorySchema
 from app.schemas.law_viewer import (
     LawSummarySchema,
     LawTextSchema,
@@ -86,3 +88,24 @@ async def read_law_diffs(
 ) -> list[SectionDiffSchema]:
     """Compute per-section unified diffs for a law's amendments."""
     return await compute_law_diffs(session, congress, law_number)
+
+
+@router.get("/{congress}/{law_number}/history")
+async def read_law_history(
+    congress: int,
+    law_number: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> LegislativeHistorySchema:
+    """Return the legislative history timeline for a public law.
+
+    Aggregates bill actions, sponsors, and vote data from the Congress.gov API
+    and maps them to a PR-conversation-style timeline. Requires CONGRESS_API_KEY
+    to be configured; returns 503 if the API is unavailable.
+    """
+    result = await get_law_history(session, congress, law_number)
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Law PL {congress}-{law_number} not found",
+        )
+    return result

--- a/backend/app/core/law_history_helpers.py
+++ b/backend/app/core/law_history_helpers.py
@@ -1,0 +1,85 @@
+"""Pure helper functions for classifying and titling legislative history events.
+
+Shared between app/crud/public_law.py (live API path) and
+pipeline/congress/law_history_ingestion.py (DB seeding path).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Matches vote tallies like "392 - 17 - 26" or "95 - 0" in action text.
+VOTE_TALLY_RE = re.compile(r"(\d+)\s*[-–]\s*(\d+)(?:\s*[-–]\s*(\d+))?")
+
+PASSAGE_KEYWORDS = frozenset(["passed", "agreed to", "adopted", "concurred in"])
+
+
+def parse_vote_tally(text: str) -> tuple[int | None, int | None, int | None]:
+    """Extract yeas, nays, not_voting from action text. Returns (None,None,None) on miss."""
+    m = VOTE_TALLY_RE.search(text)
+    if not m:
+        return None, None, None
+    yeas = int(m.group(1))
+    nays = int(m.group(2))
+    not_voting = int(m.group(3)) if m.group(3) is not None else None
+    return yeas, nays, not_voting
+
+
+def is_passage_text(text: str) -> bool:
+    lower = text.lower()
+    return any(kw in lower for kw in PASSAGE_KEYWORDS)
+
+
+def classify_action(
+    action_type: str | None,
+    text: str,
+    chamber: str | None,
+    seen_intro: bool,
+    seen_committee: bool,
+) -> tuple[str, bool]:
+    """Map a Congress.gov action to (event_type, is_milestone)."""
+    lower = text.lower()
+    atype = (action_type or "").lower()
+
+    if atype == "president":
+        return "presidential_action", True
+
+    if atype == "introreferral":
+        if "introduced" in lower:
+            return "introduced", not seen_intro
+        if "referred" in lower:
+            return "committee_referral", not seen_committee
+        return "other", False
+
+    if atype == "committee":
+        return "committee_referral", not seen_committee
+
+    if atype == "floor":
+        if chamber == "House" and is_passage_text(lower):
+            return "house_vote", True
+        if chamber == "Senate" and is_passage_text(lower):
+            return "senate_vote", True
+        return "other", False
+
+    return "other", False
+
+
+def build_event_title(event_type: str, text: str, chamber: str | None) -> str:
+    """Build a short human-readable title for a timeline event."""
+    if event_type == "introduced":
+        ch = f" in the {chamber}" if chamber else ""
+        return f"Bill introduced{ch}"
+    if event_type == "committee_referral":
+        return "Referred to committee"
+    if event_type == "house_vote":
+        return "Passed the House"
+    if event_type == "senate_vote":
+        return "Passed the Senate"
+    if event_type == "presidential_action":
+        lower = text.lower()
+        if "vetoed" in lower or "veto" in lower:
+            return "Vetoed by the President"
+        if "signed" in lower or "became" in lower:
+            return "Signed into law"
+        return "Presidential action"
+    return text[:80] if text else "Legislative action"

--- a/backend/app/core/president_lookup.py
+++ b/backend/app/core/president_lookup.py
@@ -1,0 +1,66 @@
+"""Static lookup for US presidents by date of service.
+
+Used to annotate presidential signature events with the president's name
+when the PublicLaw.president field is not populated.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+# (start_date, end_date, full_name) — ordered chronologically.
+# Start date is the inauguration/succession date (inclusive).
+# End date is the last day in office — i.e. one day before the successor's
+# start (so inauguration day belongs to the incoming president, not the
+# outgoing one). For mid-term successions the successor's start equals the
+# departure date (e.g. Ford started the same day Nixon resigned).
+_PRESIDENTS: list[tuple[date, date, str]] = [
+    (date(1961, 1, 20), date(1963, 11, 21), "John F. Kennedy"),
+    (date(1963, 11, 22), date(1969, 1, 19), "Lyndon B. Johnson"),
+    (date(1969, 1, 20), date(1974, 8, 8), "Richard Nixon"),
+    (date(1974, 8, 9), date(1977, 1, 19), "Gerald Ford"),
+    (date(1977, 1, 20), date(1981, 1, 19), "Jimmy Carter"),
+    (date(1981, 1, 20), date(1989, 1, 19), "Ronald Reagan"),
+    (date(1989, 1, 20), date(1993, 1, 19), "George H.W. Bush"),
+    (date(1993, 1, 20), date(2001, 1, 19), "Bill Clinton"),
+    (date(2001, 1, 20), date(2009, 1, 19), "George W. Bush"),
+    (date(2009, 1, 20), date(2017, 1, 19), "Barack Obama"),
+    (date(2017, 1, 20), date(2021, 1, 19), "Donald Trump"),
+    (date(2021, 1, 20), date(2025, 1, 19), "Joe Biden"),
+    (date(2025, 1, 20), date(2029, 1, 19), "Donald Trump"),
+]
+
+
+def get_president_by_date(enacted_date: date) -> str:
+    """Return the full name of the US president serving on a given date.
+
+    Args:
+        enacted_date: The date to look up (e.g. a law's enactment date).
+
+    Returns:
+        Full name string (e.g. "Barack Obama"), or "Unknown" if the date
+        falls outside the covered range.
+    """
+    for start, end, name in _PRESIDENTS:
+        if start <= enacted_date <= end:
+            return name
+    return "Unknown"
+
+
+def get_president_title(full_name: str) -> str:
+    """Return the display title for a president (e.g. "President Obama").
+
+    Uses the last word of the full name as the surname. Handles hyphenated
+    last names (e.g. "George H.W. Bush" → "President Bush").
+
+    Args:
+        full_name: Full name as returned by get_president_by_date().
+
+    Returns:
+        Display string like "President Obama" or "Unknown" if full_name
+        is "Unknown".
+    """
+    if full_name == "Unknown":
+        return "Unknown"
+    surname = full_name.rsplit(" ", 1)[-1]
+    return f"President {surname}"

--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -209,7 +209,6 @@ def _find_line_number(provisions: list[dict[str, Any]], old_text: str) -> int | 
     Normalises whitespace for matching since amendment text and provision
     content may differ in spacing.
     """
-    import re
 
     def normalise(s: str) -> str:
         return re.sub(r"\s+", " ", s).strip().lower()
@@ -400,7 +399,6 @@ def _parse_redesignation(text: str) -> list[tuple[int, str]] | None:
 
     Returns None if the text doesn't match a redesignation pattern.
     """
-    import re
 
     ORDINALS = {
         "first": 0,
@@ -452,7 +450,6 @@ def _parse_struck_subsections(full_match: str) -> list[str] | None:
     Returns a list of single-letter/number markers like ['a', 'b'], or None
     if the instruction doesn't match this pattern.
     """
-    import re
 
     # Match patterns like:
     #   "striking subsections (a) and (b)"
@@ -478,7 +475,6 @@ def _find_subsection_range(
     same-level marker that is NOT in the target set.  "Same-level" means
     the same marker style as the struck markers (e.g. lowercase letters).
     """
-    import re
 
     marker_set = {f"({m})" for m in markers}
 
@@ -543,7 +539,6 @@ def _apply_amendments_to_provisions(
        to those subsections and replaces them with new_text lines.
     """
     import copy
-    import re
 
     patched = copy.deepcopy(provisions)
 
@@ -727,7 +722,6 @@ def _strip_leading_marker(content: str) -> str:
 
     E.g. "(a) Each preliminary…" → "Each preliminary…"
     """
-    import re
 
     return re.sub(r"^\([a-zA-Z0-9]+\)\s*", "", content)
 
@@ -1094,7 +1088,10 @@ async def _resolve_bill_type_and_number(
 async def _load_history_from_db(
     session: AsyncSession,
     law_id: int,
-) -> tuple[list[TimelineEventSchema], list[SponsorSchema], list[ChamberVoteSchema]] | None:
+) -> (
+    tuple[list[TimelineEventSchema], list[SponsorSchema], list[ChamberVoteSchema]]
+    | None
+):
     """Return (timeline, sponsors, chamber_votes) from cached DB rows, or None if empty."""
     action_stmt = (
         select(LawBillAction)
@@ -1127,8 +1124,13 @@ async def _load_history_from_db(
             )
         )
 
-        if row.event_type in ("house_vote", "senate_vote") and row.vote_yeas is not None:
-            ch = row.chamber or ("House" if row.event_type == "house_vote" else "Senate")
+        if (
+            row.event_type in ("house_vote", "senate_vote")
+            and row.vote_yeas is not None
+        ):
+            ch = row.chamber or (
+                "House" if row.event_type == "house_vote" else "Senate"
+            )
             vote_by_chamber[ch] = ChamberVoteSchema(
                 chamber=ch,
                 yeas=row.vote_yeas,

--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -12,7 +12,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.public_law import Bill, PublicLaw
+from app.core.law_history_helpers import (
+    build_event_title,
+    classify_action,
+    parse_vote_tally,
+)
+from app.models.public_law import Bill, LawBillAction, LawSponsor, PublicLaw
 from app.schemas.law_history import (
     ChamberVoteSchema,
     LegislativeHistorySchema,
@@ -1038,85 +1043,6 @@ def _build_note_hunks(
 # Legislative history
 # ---------------------------------------------------------------------------
 
-# Matches vote tallies like "392 - 17 - 26" or "95 - 0" in action text.
-_VOTE_TALLY_RE = re.compile(r"(\d+)\s*[-–]\s*(\d+)(?:\s*[-–]\s*(\d+))?")
-
-_PASSAGE_KEYWORDS = frozenset(["passed", "agreed to", "adopted", "concurred in"])
-
-
-def _parse_vote_tally(text: str) -> tuple[int | None, int | None, int | None]:
-    """Extract yeas, nays, not_voting from action text. Returns (None,None,None) on miss."""
-    m = _VOTE_TALLY_RE.search(text)
-    if not m:
-        return None, None, None
-    yeas = int(m.group(1))
-    nays = int(m.group(2))
-    not_voting = int(m.group(3)) if m.group(3) is not None else None
-    return yeas, nays, not_voting
-
-
-def _is_passage_text(text: str) -> bool:
-    lower = text.lower()
-    return any(kw in lower for kw in _PASSAGE_KEYWORDS)
-
-
-def _classify_action(
-    action_type: str | None,
-    text: str,
-    chamber: str | None,
-    seen_intro: bool,
-    seen_committee: bool,
-) -> tuple[
-    str,  # event_type
-    bool,  # is_milestone
-]:
-    """Map a Congress.gov action to an event_type and milestone flag."""
-    lower = text.lower()
-    atype = (action_type or "").lower()
-
-    if atype == "president":
-        return "presidential_action", True
-
-    if atype == "introreferral":
-        if "introduced" in lower:
-            return "introduced", not seen_intro
-        if "referred" in lower:
-            return "committee_referral", not seen_committee
-        return "other", False
-
-    if atype == "committee":
-        return "committee_referral", not seen_committee
-
-    if atype == "floor":
-        if chamber == "House" and _is_passage_text(lower):
-            return "house_vote", True
-        if chamber == "Senate" and _is_passage_text(lower):
-            return "senate_vote", True
-        return "other", False
-
-    return "other", False
-
-
-def _build_event_title(event_type: str, text: str, chamber: str | None) -> str:
-    """Build a short human-readable title for a timeline event."""
-    if event_type == "introduced":
-        ch = f" in the {chamber}" if chamber else ""
-        return f"Bill introduced{ch}"
-    if event_type == "committee_referral":
-        return "Referred to committee"
-    if event_type == "house_vote":
-        return "Passed the House"
-    if event_type == "senate_vote":
-        return "Passed the Senate"
-    if event_type == "presidential_action":
-        lower = text.lower()
-        if "vetoed" in lower or "veto" in lower:
-            return "Vetoed by the President"
-        if "signed" in lower or "became" in lower:
-            return "Signed into law"
-        return "Presidential action"
-    return text[:80] if text else "Legislative action"
-
 
 async def _resolve_bill_type_and_number(
     law: PublicLaw,
@@ -1165,6 +1091,73 @@ async def _resolve_bill_type_and_number(
         return None
 
 
+async def _load_history_from_db(
+    session: AsyncSession,
+    law_id: int,
+) -> tuple[list[TimelineEventSchema], list[SponsorSchema], list[ChamberVoteSchema]] | None:
+    """Return (timeline, sponsors, chamber_votes) from cached DB rows, or None if empty."""
+    action_stmt = (
+        select(LawBillAction)
+        .where(LawBillAction.law_id == law_id)
+        .order_by(LawBillAction.sort_order)
+    )
+    action_result = await session.execute(action_stmt)
+    cached_actions = action_result.scalars().all()
+
+    if not cached_actions:
+        return None
+
+    timeline_events: list[TimelineEventSchema] = []
+    vote_by_chamber: dict[str, ChamberVoteSchema] = {}
+
+    for row in cached_actions:
+        date_str: str | None = row.action_date.isoformat() if row.action_date else None
+        timeline_events.append(
+            TimelineEventSchema(
+                event_type=row.event_type,
+                date=date_str,
+                title=row.event_title,
+                description=row.text,
+                chamber=row.chamber,
+                is_milestone=row.is_milestone,
+                vote_yeas=row.vote_yeas,
+                vote_nays=row.vote_nays,
+                vote_not_voting=row.vote_not_voting,
+                congressional_record_refs=list(row.congressional_record_refs or []),
+            )
+        )
+
+        if row.event_type in ("house_vote", "senate_vote") and row.vote_yeas is not None:
+            ch = row.chamber or ("House" if row.event_type == "house_vote" else "Senate")
+            vote_by_chamber[ch] = ChamberVoteSchema(
+                chamber=ch,
+                yeas=row.vote_yeas,
+                nays=row.vote_nays or 0,
+                not_voting=row.vote_not_voting or 0,
+            )
+
+    sponsor_stmt = (
+        select(LawSponsor)
+        .where(LawSponsor.law_id == law_id)
+        .order_by(LawSponsor.sort_order)
+    )
+    sponsor_result = await session.execute(sponsor_stmt)
+    cached_sponsors = sponsor_result.scalars().all()
+
+    sponsors: list[SponsorSchema] = [
+        SponsorSchema(
+            name=s.name,
+            party=s.party,
+            state=s.state,
+            bioguide_id=s.bioguide_id,
+            is_primary=s.is_primary,
+        )
+        for s in cached_sponsors
+    ]
+
+    return timeline_events, sponsors, list(vote_by_chamber.values())
+
+
 async def get_law_history(
     session: AsyncSession,
     congress: int,
@@ -1172,11 +1165,9 @@ async def get_law_history(
 ) -> LegislativeHistorySchema | None:
     """Fetch the legislative history for a public law.
 
-    Queries the DB for the law + its linked bill, then calls the Congress.gov
-    API to fetch bill actions and sponsors. Maps actions to timeline events
-    and returns a structured history response.
-
-    Returns None if the law is not found in the database.
+    Checks cached DB rows (law_bill_action / law_sponsor) first; falls back to
+    the live Congress.gov API if the cache is empty. Returns None if the law is
+    not found in the database.
     """
     from app.core.president_lookup import get_president_by_date
 
@@ -1193,111 +1184,113 @@ async def get_law_history(
     if law is None:
         return None
 
-    # Instantiate Congress.gov client (may raise ValueError if no API key)
-    try:
-        congress_mod = importlib.import_module("pipeline.congress.client")
-        congress_client = congress_mod.CongressClient()
-    except (ValueError, ImportError) as exc:
-        logger.warning(f"Congress.gov API unavailable: {exc}")
-        congress_client = None
-
-    # --- Fetch actions and sponsors ------------------------------------------
+    # --- Try DB cache first --------------------------------------------------
     timeline_events: list[TimelineEventSchema] = []
     sponsors: list[SponsorSchema] = []
     chamber_votes: list[ChamberVoteSchema] = []
 
-    if congress_client is not None:
-        bill_ref = await _resolve_bill_type_and_number(law, congress_client)
-        if bill_ref is not None:
-            bill_type_lower, bill_number_int = bill_ref
+    cached = await _load_history_from_db(session, law.law_id)
+    if cached is not None:
+        timeline_events, sponsors, chamber_votes = cached
+    else:
+        # --- Fall back to live Congress.gov API ------------------------------
+        try:
+            congress_mod = importlib.import_module("pipeline.congress.client")
+            congress_client = congress_mod.CongressClient()
+        except (ValueError, ImportError) as exc:
+            logger.warning(f"Congress.gov API unavailable: {exc}")
+            congress_client = None
 
-            try:
-                raw_actions = await congress_client.get_bill_actions(
-                    congress, bill_type_lower, bill_number_int
-                )
-            except Exception as exc:
-                logger.warning(f"Failed to fetch bill actions: {exc}")
-                raw_actions = []
+        if congress_client is not None:
+            bill_ref = await _resolve_bill_type_and_number(law, congress_client)
+            if bill_ref is not None:
+                bill_type_lower, bill_number_int = bill_ref
 
-            # Map actions → TimelineEventSchema
-            seen_intro = False
-            seen_committee = False
-            vote_by_chamber: dict[str, ChamberVoteSchema] = {}
-
-            for action in raw_actions:
-                event_type, is_milestone = _classify_action(
-                    action.action_type,
-                    action.text,
-                    action.chamber,
-                    seen_intro,
-                    seen_committee,
-                )
-
-                if event_type == "introduced":
-                    seen_intro = True
-                if event_type == "committee_referral":
-                    seen_committee = True
-
-                yeas, nays, not_voting = _parse_vote_tally(action.text)
-                title = _build_event_title(event_type, action.text, action.chamber)
-
-                # Track chamber vote aggregates for the sidebar
-                if event_type in ("house_vote", "senate_vote") and yeas is not None:
-                    ch = action.chamber or (
-                        "House" if event_type == "house_vote" else "Senate"
+                try:
+                    raw_actions = await congress_client.get_bill_actions(
+                        congress, bill_type_lower, bill_number_int
                     )
-                    vote_by_chamber[ch] = ChamberVoteSchema(
-                        chamber=ch,
-                        yeas=yeas,
-                        nays=nays or 0,
-                        not_voting=not_voting or 0,
+                except Exception as exc:
+                    logger.warning(f"Failed to fetch bill actions: {exc}")
+                    raw_actions = []
+
+                seen_intro = False
+                seen_committee = False
+                vote_by_chamber: dict[str, ChamberVoteSchema] = {}
+
+                for action in raw_actions:
+                    event_type, is_milestone = classify_action(
+                        action.action_type,
+                        action.text,
+                        action.chamber,
+                        seen_intro,
+                        seen_committee,
                     )
 
-                timeline_events.append(
-                    TimelineEventSchema(
-                        event_type=event_type,
-                        date=action.action_date,
-                        title=title,
-                        description=action.text,
-                        chamber=action.chamber,
-                        is_milestone=is_milestone,
-                        vote_yeas=yeas,
-                        vote_nays=nays,
-                        vote_not_voting=not_voting,
-                        congressional_record_refs=action.congressional_record_refs,
-                    )
-                )
+                    if event_type == "introduced":
+                        seen_intro = True
+                    if event_type == "committee_referral":
+                        seen_committee = True
 
-            chamber_votes = list(vote_by_chamber.values())
+                    yeas, nays, not_voting = parse_vote_tally(action.text)
+                    title = build_event_title(event_type, action.text, action.chamber)
 
-            try:
-                sponsor_info, cosponsors = await congress_client.get_bill_sponsors(
-                    congress, bill_type_lower, bill_number_int
-                )
-            except Exception as exc:
-                logger.warning(f"Failed to fetch sponsors: {exc}")
-                sponsor_info, cosponsors = None, []
+                    if event_type in ("house_vote", "senate_vote") and yeas is not None:
+                        ch = action.chamber or (
+                            "House" if event_type == "house_vote" else "Senate"
+                        )
+                        vote_by_chamber[ch] = ChamberVoteSchema(
+                            chamber=ch,
+                            yeas=yeas,
+                            nays=nays or 0,
+                            not_voting=not_voting or 0,
+                        )
 
-            if sponsor_info:
-                sponsors.append(
-                    SponsorSchema(
-                        name=sponsor_info.full_name,
-                        party=sponsor_info.party,
-                        state=sponsor_info.state,
-                        bioguide_id=sponsor_info.bioguide_id,
-                        is_primary=True,
+                    timeline_events.append(
+                        TimelineEventSchema(
+                            event_type=event_type,
+                            date=action.action_date,
+                            title=title,
+                            description=action.text,
+                            chamber=action.chamber,
+                            is_milestone=is_milestone,
+                            vote_yeas=yeas,
+                            vote_nays=nays,
+                            vote_not_voting=not_voting,
+                            congressional_record_refs=action.congressional_record_refs,
+                        )
                     )
-                )
-            for cs in cosponsors:
-                sponsors.append(
-                    SponsorSchema(
-                        name=cs.full_name,
-                        party=cs.party,
-                        state=cs.state,
-                        bioguide_id=cs.bioguide_id,
-                        is_primary=False,
+
+                chamber_votes = list(vote_by_chamber.values())
+
+                try:
+                    sponsor_info, cosponsors = await congress_client.get_bill_sponsors(
+                        congress, bill_type_lower, bill_number_int
                     )
-                )
+                except Exception as exc:
+                    logger.warning(f"Failed to fetch sponsors: {exc}")
+                    sponsor_info, cosponsors = None, []
+
+                if sponsor_info:
+                    sponsors.append(
+                        SponsorSchema(
+                            name=sponsor_info.full_name,
+                            party=sponsor_info.party,
+                            state=sponsor_info.state,
+                            bioguide_id=sponsor_info.bioguide_id,
+                            is_primary=True,
+                        )
+                    )
+                for cs in cosponsors:
+                    sponsors.append(
+                        SponsorSchema(
+                            name=cs.full_name,
+                            party=cs.party,
+                            state=cs.state,
+                            bioguide_id=cs.bioguide_id,
+                            is_primary=False,
+                        )
+                    )
 
     # --- Determine status and president --------------------------------------
     presidential_action = law.presidential_action

--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import importlib
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
-from app.models.public_law import PublicLaw
+from app.models.public_law import Bill, PublicLaw
+from app.schemas.law_history import (
+    ChamberVoteSchema,
+    LegislativeHistorySchema,
+    SponsorSchema,
+    TimelineEventSchema,
+)
 from app.schemas.law_viewer import (
     DiffHunkSchema,
     DiffLineSchema,
@@ -1024,3 +1032,294 @@ def _build_note_hunks(
             lines=lines,
         )
     ]
+
+
+# ---------------------------------------------------------------------------
+# Legislative history
+# ---------------------------------------------------------------------------
+
+# Matches vote tallies like "392 - 17 - 26" or "95 - 0" in action text.
+_VOTE_TALLY_RE = re.compile(r"(\d+)\s*[-–]\s*(\d+)(?:\s*[-–]\s*(\d+))?")
+
+_PASSAGE_KEYWORDS = frozenset(["passed", "agreed to", "adopted", "concurred in"])
+
+
+def _parse_vote_tally(text: str) -> tuple[int | None, int | None, int | None]:
+    """Extract yeas, nays, not_voting from action text. Returns (None,None,None) on miss."""
+    m = _VOTE_TALLY_RE.search(text)
+    if not m:
+        return None, None, None
+    yeas = int(m.group(1))
+    nays = int(m.group(2))
+    not_voting = int(m.group(3)) if m.group(3) is not None else None
+    return yeas, nays, not_voting
+
+
+def _is_passage_text(text: str) -> bool:
+    lower = text.lower()
+    return any(kw in lower for kw in _PASSAGE_KEYWORDS)
+
+
+def _classify_action(
+    action_type: str | None,
+    text: str,
+    chamber: str | None,
+    seen_intro: bool,
+    seen_committee: bool,
+) -> tuple[
+    str,  # event_type
+    bool,  # is_milestone
+]:
+    """Map a Congress.gov action to an event_type and milestone flag."""
+    lower = text.lower()
+    atype = (action_type or "").lower()
+
+    if atype == "president":
+        return "presidential_action", True
+
+    if atype == "introreferral":
+        if "introduced" in lower:
+            return "introduced", not seen_intro
+        if "referred" in lower:
+            return "committee_referral", not seen_committee
+        return "other", False
+
+    if atype == "committee":
+        return "committee_referral", not seen_committee
+
+    if atype == "floor":
+        if chamber == "House" and _is_passage_text(lower):
+            return "house_vote", True
+        if chamber == "Senate" and _is_passage_text(lower):
+            return "senate_vote", True
+        return "other", False
+
+    return "other", False
+
+
+def _build_event_title(event_type: str, text: str, chamber: str | None) -> str:
+    """Build a short human-readable title for a timeline event."""
+    if event_type == "introduced":
+        ch = f" in the {chamber}" if chamber else ""
+        return f"Bill introduced{ch}"
+    if event_type == "committee_referral":
+        return "Referred to committee"
+    if event_type == "house_vote":
+        return "Passed the House"
+    if event_type == "senate_vote":
+        return "Passed the Senate"
+    if event_type == "presidential_action":
+        lower = text.lower()
+        if "vetoed" in lower or "veto" in lower:
+            return "Vetoed by the President"
+        if "signed" in lower or "became" in lower:
+            return "Signed into law"
+        return "Presidential action"
+    return text[:80] if text else "Legislative action"
+
+
+async def _resolve_bill_type_and_number(
+    law: PublicLaw,
+    congress_client: Any,
+) -> tuple[str, int] | None:
+    """Return (bill_type_lower, bill_number_int) for making Congress.gov API calls.
+
+    Tries origin_bill relationship first, then falls back to get_law_bill_info().
+    Returns None if neither source has the data.
+    """
+    bill: Bill | None = law.origin_bill
+    if bill is not None and bill.bill_number:
+        bill_type = bill.bill_type.value.lower()
+        try:
+            return bill_type, int(bill.bill_number)
+        except ValueError:
+            pass
+
+    # Fallback: ask Congress.gov for the originating bill
+    try:
+        law_number_int = int(law.law_number)
+        data = await congress_client.get_law_bill_info(
+            law.congress, law_number_int, "pub"
+        )
+    except Exception:
+        return None
+
+    if data is None:
+        return None
+
+    # Response shape: {"congress": {..., "originChamberCode": ..., ...},
+    #                  "request": {...}}  — the law endpoint returns bill ref inline
+    # The actual bill reference is nested under "congress" key as "bills" list
+    congress_data = data.get("congress", {})
+    bills = congress_data.get("bills", [])
+    if not bills:
+        return None
+    bill_ref = bills[0]
+    b_type = (bill_ref.get("type") or "").lower()
+    b_number = bill_ref.get("number")
+    if not b_type or not b_number:
+        return None
+    try:
+        return b_type, int(b_number)
+    except (ValueError, TypeError):
+        return None
+
+
+async def get_law_history(
+    session: AsyncSession,
+    congress: int,
+    law_number: int,
+) -> LegislativeHistorySchema | None:
+    """Fetch the legislative history for a public law.
+
+    Queries the DB for the law + its linked bill, then calls the Congress.gov
+    API to fetch bill actions and sponsors. Maps actions to timeline events
+    and returns a structured history response.
+
+    Returns None if the law is not found in the database.
+    """
+    from app.core.president_lookup import get_president_by_date
+
+    stmt = (
+        select(PublicLaw)
+        .where(
+            PublicLaw.congress == congress,
+            PublicLaw.law_number == str(law_number),
+        )
+        .options(selectinload(PublicLaw.origin_bill))
+    )
+    result = await session.execute(stmt)
+    law: PublicLaw | None = result.scalar_one_or_none()
+    if law is None:
+        return None
+
+    # Instantiate Congress.gov client (may raise ValueError if no API key)
+    try:
+        congress_mod = importlib.import_module("pipeline.congress.client")
+        congress_client = congress_mod.CongressClient()
+    except (ValueError, ImportError) as exc:
+        logger.warning(f"Congress.gov API unavailable: {exc}")
+        congress_client = None
+
+    # --- Fetch actions and sponsors ------------------------------------------
+    timeline_events: list[TimelineEventSchema] = []
+    sponsors: list[SponsorSchema] = []
+    chamber_votes: list[ChamberVoteSchema] = []
+
+    if congress_client is not None:
+        bill_ref = await _resolve_bill_type_and_number(law, congress_client)
+        if bill_ref is not None:
+            bill_type_lower, bill_number_int = bill_ref
+
+            try:
+                raw_actions = await congress_client.get_bill_actions(
+                    congress, bill_type_lower, bill_number_int
+                )
+            except Exception as exc:
+                logger.warning(f"Failed to fetch bill actions: {exc}")
+                raw_actions = []
+
+            # Map actions → TimelineEventSchema
+            seen_intro = False
+            seen_committee = False
+            vote_by_chamber: dict[str, ChamberVoteSchema] = {}
+
+            for action in raw_actions:
+                event_type, is_milestone = _classify_action(
+                    action.action_type,
+                    action.text,
+                    action.chamber,
+                    seen_intro,
+                    seen_committee,
+                )
+
+                if event_type == "introduced":
+                    seen_intro = True
+                if event_type == "committee_referral":
+                    seen_committee = True
+
+                yeas, nays, not_voting = _parse_vote_tally(action.text)
+                title = _build_event_title(event_type, action.text, action.chamber)
+
+                # Track chamber vote aggregates for the sidebar
+                if event_type in ("house_vote", "senate_vote") and yeas is not None:
+                    ch = action.chamber or (
+                        "House" if event_type == "house_vote" else "Senate"
+                    )
+                    vote_by_chamber[ch] = ChamberVoteSchema(
+                        chamber=ch,
+                        yeas=yeas,
+                        nays=nays or 0,
+                        not_voting=not_voting or 0,
+                    )
+
+                timeline_events.append(
+                    TimelineEventSchema(
+                        event_type=event_type,
+                        date=action.action_date,
+                        title=title,
+                        description=action.text,
+                        chamber=action.chamber,
+                        is_milestone=is_milestone,
+                        vote_yeas=yeas,
+                        vote_nays=nays,
+                        vote_not_voting=not_voting,
+                        congressional_record_refs=action.congressional_record_refs,
+                    )
+                )
+
+            chamber_votes = list(vote_by_chamber.values())
+
+            try:
+                sponsor_info, cosponsors = await congress_client.get_bill_sponsors(
+                    congress, bill_type_lower, bill_number_int
+                )
+            except Exception as exc:
+                logger.warning(f"Failed to fetch sponsors: {exc}")
+                sponsor_info, cosponsors = None, []
+
+            if sponsor_info:
+                sponsors.append(
+                    SponsorSchema(
+                        name=sponsor_info.full_name,
+                        party=sponsor_info.party,
+                        state=sponsor_info.state,
+                        bioguide_id=sponsor_info.bioguide_id,
+                        is_primary=True,
+                    )
+                )
+            for cs in cosponsors:
+                sponsors.append(
+                    SponsorSchema(
+                        name=cs.full_name,
+                        party=cs.party,
+                        state=cs.state,
+                        bioguide_id=cs.bioguide_id,
+                        is_primary=False,
+                    )
+                )
+
+    # --- Determine status and president --------------------------------------
+    presidential_action = law.presidential_action
+    president_name = law.president
+
+    if president_name is None and law.enacted_date:
+        president_name = get_president_by_date(law.enacted_date)
+
+    if law.veto_date and not law.veto_override_date:
+        status: str = "vetoed"
+    elif law.enacted_date:
+        status = "enacted"
+    else:
+        status = "pending"
+
+    return LegislativeHistorySchema(
+        timeline=timeline_events,
+        sponsors=sponsors,
+        chamber_votes=chamber_votes,
+        presidential_action=presidential_action,
+        president_name=president_name,
+        enacted_date=law.enacted_date,
+        status=status,
+        congress_url=law.congress_url,
+    )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -29,7 +29,14 @@ from app.models.legislator import (
     Sponsorship,
     Vote,
 )
-from app.models.public_law import Bill, LawChange, ProposedChange, PublicLaw
+from app.models.public_law import (
+    Bill,
+    LawBillAction,
+    LawChange,
+    LawSponsor,
+    ProposedChange,
+    PublicLaw,
+)
 from app.models.release_point import OLRCReleasePoint
 from app.models.revision import CodeRevision
 from app.models.snapshot import SectionSnapshot
@@ -84,6 +91,8 @@ __all__ = [
     "PublicLaw",
     "Bill",
     "LawChange",
+    "LawBillAction",
+    "LawSponsor",
     "ProposedChange",
     # Legislator
     "Legislator",

--- a/backend/app/models/public_law.py
+++ b/backend/app/models/public_law.py
@@ -312,9 +312,7 @@ class LawSponsor(Base, TimestampMixin):
 
     law: Mapped["PublicLaw"] = relationship(back_populates="cached_sponsors")
 
-    __table_args__ = (
-        Index("idx_law_sponsor_law_id", "law_id"),
-    )
+    __table_args__ = (Index("idx_law_sponsor_law_id", "law_id"),)
 
     def __repr__(self) -> str:
         return f"<LawSponsor(law={self.law_id}, name={self.name!r}, primary={self.is_primary})>"

--- a/backend/app/models/public_law.py
+++ b/backend/app/models/public_law.py
@@ -4,6 +4,7 @@ from datetime import date
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     Date,
     ForeignKey,
@@ -13,6 +14,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, enum_column
@@ -82,6 +84,16 @@ class PublicLaw(Base, TimestampMixin):
         back_populates="law",
         primaryjoin="PublicLaw.law_id == Vote.law_id",
         cascade="all, delete-orphan",
+    )
+    bill_actions: Mapped[list["LawBillAction"]] = relationship(
+        back_populates="law",
+        cascade="all, delete-orphan",
+        order_by="LawBillAction.sort_order",
+    )
+    cached_sponsors: Mapped[list["LawSponsor"]] = relationship(
+        back_populates="law",
+        cascade="all, delete-orphan",
+        order_by="LawSponsor.sort_order",
     )
 
     __table_args__ = (
@@ -234,3 +246,75 @@ class ProposedChange(Base, TimestampMixin):
 
     def __repr__(self) -> str:
         return f"<ProposedChange({self.change_type.value} by bill {self.bill_id})>"
+
+
+class LawBillAction(Base, TimestampMixin):
+    """A cached bill action (timeline event) for a public law.
+
+    Populated by the seed-law-history pipeline command so the History tab
+    can serve responses from the DB instead of hitting the Congress.gov API
+    on every request.
+    """
+
+    __tablename__ = "law_bill_action"
+
+    action_id: Mapped[int] = mapped_column(primary_key=True)
+    law_id: Mapped[int] = mapped_column(
+        ForeignKey("public_law.law_id", ondelete="CASCADE"), nullable=False
+    )
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    action_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    action_code: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    action_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    chamber: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    congressional_record_refs: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    is_milestone: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    vote_yeas: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    vote_nays: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    vote_not_voting: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    event_title: Mapped[str] = mapped_column(String(300), nullable=False)
+
+    law: Mapped["PublicLaw"] = relationship(back_populates="bill_actions")
+
+    __table_args__ = (
+        Index("idx_law_bill_action_law_id", "law_id"),
+        Index("idx_law_bill_action_sort", "law_id", "sort_order"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<LawBillAction(law={self.law_id}, type={self.event_type}, order={self.sort_order})>"
+
+
+class LawSponsor(Base, TimestampMixin):
+    """A cached sponsor or cosponsor for a public law.
+
+    Populated by the seed-law-history pipeline command. Stored separately
+    from the Sponsorship model (which requires a full Legislator FK) so we
+    can cache sponsor display data without first ingesting all legislators.
+    """
+
+    __tablename__ = "law_sponsor"
+
+    sponsor_id: Mapped[int] = mapped_column(primary_key=True)
+    law_id: Mapped[int] = mapped_column(
+        ForeignKey("public_law.law_id", ondelete="CASCADE"), nullable=False
+    )
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    party: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    state: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    bioguide_id: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    is_primary: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    law: Mapped["PublicLaw"] = relationship(back_populates="cached_sponsors")
+
+    __table_args__ = (
+        Index("idx_law_sponsor_law_id", "law_id"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<LawSponsor(law={self.law_id}, name={self.name!r}, primary={self.is_primary})>"

--- a/backend/app/schemas/law_history.py
+++ b/backend/app/schemas/law_history.py
@@ -1,0 +1,62 @@
+"""Pydantic schemas for the legislative history API endpoint."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class TimelineEventSchema(BaseModel):
+    """A single event in a bill's legislative timeline."""
+
+    event_type: Literal[
+        "introduced",
+        "committee_referral",
+        "house_vote",
+        "senate_vote",
+        "presidential_action",
+        "other",
+    ]
+    date: date | None
+    title: str
+    description: str
+    chamber: str | None
+    is_milestone: bool
+    vote_yeas: int | None = None
+    vote_nays: int | None = None
+    vote_not_voting: int | None = None
+    congressional_record_refs: list[str] = []
+
+
+class SponsorSchema(BaseModel):
+    """A bill sponsor or cosponsor."""
+
+    name: str
+    party: str | None
+    state: str | None
+    bioguide_id: str | None
+    is_primary: bool
+
+
+class ChamberVoteSchema(BaseModel):
+    """Aggregated vote totals for one chamber's final passage vote."""
+
+    chamber: str
+    yeas: int
+    nays: int
+    not_voting: int
+
+
+class LegislativeHistorySchema(BaseModel):
+    """Full legislative history response for a public law."""
+
+    timeline: list[TimelineEventSchema]
+    sponsors: list[SponsorSchema]
+    chamber_votes: list[ChamberVoteSchema]
+    presidential_action: str | None  # "signed", "vetoed", "pocket_vetoed", etc.
+    president_name: str | None
+    enacted_date: date | None
+    status: Literal["enacted", "vetoed", "pending"]
+    congress_url: str | None

--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -2731,6 +2731,43 @@ Examples:
         help="Release point identifier to validate against (e.g., '113-37')",
     )
 
+    seed_law_history_parser = subparsers.add_parser(
+        "seed-law-history",
+        help="Seed bill actions and sponsors for a single public law into the DB",
+    )
+    seed_law_history_parser.add_argument(
+        "congress",
+        type=int,
+        help="Congress number (e.g. 117)",
+    )
+    seed_law_history_parser.add_argument(
+        "law_number",
+        type=int,
+        help="Public law number (e.g. 169)",
+    )
+    seed_law_history_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Delete existing rows and re-fetch from Congress.gov",
+    )
+
+    seed_congress_law_history_parser = subparsers.add_parser(
+        "seed-congress-law-history",
+        help="Seed bill actions and sponsors for all public laws in a congress",
+    )
+    seed_congress_law_history_parser.add_argument(
+        "congress",
+        type=int,
+        help="Congress number (e.g. 117)",
+    )
+    seed_congress_law_history_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Delete existing rows and re-fetch from Congress.gov",
+    )
+
     args = parser.parse_args()
 
     # Initialize shared pipeline cache (local-only unless GCS_CACHE_BUCKET is set)
@@ -3121,9 +3158,84 @@ Examples:
             )
         )
 
+    elif args.command == "seed-law-history":
+        return asyncio.run(
+            seed_law_history_command(
+                congress=args.congress,
+                law_number=args.law_number,
+                force=args.force,
+            )
+        )
+
+    elif args.command == "seed-congress-law-history":
+        return asyncio.run(
+            seed_congress_law_history_command(
+                congress=args.congress,
+                force=args.force,
+            )
+        )
+
     else:
         parser.print_help()
         return 1
+
+
+async def seed_law_history_command(
+    congress: int,
+    law_number: int,
+    force: bool = False,
+) -> int:
+    """Seed bill actions and sponsors for a single public law.
+
+    Args:
+        congress: Congress number.
+        law_number: Public law number.
+        force: If True, delete existing rows and re-fetch.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    from app.models.base import async_session_maker
+    from pipeline.congress.law_history_ingestion import LawHistoryIngestionService
+
+    async with async_session_maker() as session:
+        service = LawHistoryIngestionService(session, cache=_cli_cache)
+        log = await service.seed_law(congress, law_number, force=force)
+
+        if log.status in ("completed", "skipped"):
+            logger.info(f"PL {congress}-{law_number}: {log.status} — {log.details}")
+            return 0
+        else:
+            logger.error(f"PL {congress}-{law_number}: {log.error_message}")
+            return 1
+
+
+async def seed_congress_law_history_command(
+    congress: int,
+    force: bool = False,
+) -> int:
+    """Seed bill actions and sponsors for all public laws in a congress.
+
+    Args:
+        congress: Congress number.
+        force: If True, delete existing rows and re-fetch.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    from app.models.base import async_session_maker
+    from pipeline.congress.law_history_ingestion import LawHistoryIngestionService
+
+    async with async_session_maker() as session:
+        service = LawHistoryIngestionService(session, cache=_cli_cache)
+        log = await service.seed_congress(congress, force=force)
+
+        if log.status in ("completed", "skipped"):
+            logger.info(f"Congress {congress}: {log.status} — {log.details}")
+            return 0
+        else:
+            logger.error(f"Congress {congress}: {log.error_message}")
+            return 1
 
 
 async def chrono_timeline_command(

--- a/backend/pipeline/congress/client.py
+++ b/backend/pipeline/congress/client.py
@@ -6,8 +6,9 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -330,6 +331,90 @@ class MemberVoteInfo:
             party=data.get("voteParty"),
             state=data.get("voteState"),
             vote_cast=data.get("voteCast", ""),
+        )
+
+
+# Matches "CR 2/12/2013 H439-440" or "CR H481" or "CR S1234-1235"
+_CR_REF_PATTERN = re.compile(r"CR\s+(?:(\d{1,2}/\d{1,2}/\d{4})\s+)?([A-Z]\d+(?:-\d+)?)")
+
+
+def _parse_cr_refs(text: str) -> list[str]:
+    """Extract Congressional Record page citations from an action text string.
+
+    Returns a list of raw citation strings like "CR H439-440" or
+    "CR 2/12/2013 H439-440", suitable for constructing deep links to
+    congress.gov or GPO govinfo.
+    """
+    return [m.group(0) for m in _CR_REF_PATTERN.finditer(text)]
+
+
+@dataclass
+class RecordedVote:
+    """A recorded (roll call) vote linked from a bill action."""
+
+    chamber: str | None
+    congress: int | None
+    date: str | None  # ISO date string from API
+    roll_number: int | None
+    session: int | None
+    url: str | None  # Full URL to the vote record
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any]) -> RecordedVote:
+        return cls(
+            chamber=data.get("chamber"),
+            congress=_safe_int(data.get("congress")),
+            date=data.get("date"),
+            roll_number=_safe_int(data.get("rollNumber")),
+            session=_safe_int(data.get("session")),
+            url=data.get("url"),
+        )
+
+
+@dataclass
+class BillAction:
+    """A single action from a bill's action history (Congress.gov /actions endpoint)."""
+
+    action_date: date | None
+    action_code: str | None
+    action_type: str | None  # e.g. "President", "Floor", "Committee"
+    text: str
+    chamber: str | None  # "House", "Senate", or None
+    congressional_record_refs: list[str]  # parsed CR citations from text
+    recorded_votes: list[RecordedVote] = field(default_factory=list)
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any]) -> BillAction:
+        action_date: date | None = None
+        date_str = data.get("actionDate", "")
+        if date_str:
+            with contextlib.suppress(ValueError):
+                action_date = date.fromisoformat(date_str)
+
+        text = data.get("text", "")
+        cr_refs = _parse_cr_refs(text)
+
+        # Derive chamber from sourceSystem when not explicitly provided
+        chamber: str | None = None
+        source = data.get("sourceSystem", {})
+        source_name = (source.get("name") or "").lower()
+        if "senate" in source_name:
+            chamber = "Senate"
+        elif "house" in source_name:
+            chamber = "House"
+
+        recorded_votes = [
+            RecordedVote.from_api_response(v) for v in data.get("recordedVotes", [])
+        ]
+
+        return cls(
+            action_date=action_date,
+            action_code=data.get("actionCode"),
+            action_type=data.get("type"),
+            text=text,
+            chamber=chamber,
+            congressional_record_refs=cr_refs,
+            recorded_votes=recorded_votes,
         )
 
 
@@ -677,6 +762,65 @@ class CongressClient:
                     logger.warning(f"Law PL {congress}-{law_number} not found")
                     return None
                 raise
+
+    async def get_bill_actions(
+        self,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> list[BillAction]:
+        """Fetch all actions for a bill from Congress.gov.
+
+        Actions represent the chronological history of a bill: introduction,
+        committee referrals, floor votes, presidential action, etc.
+
+        Args:
+            congress: Congress number (e.g., 113).
+            bill_type: Bill type code (e.g., "hr", "s", "hjres").
+            bill_number: Bill number.
+            page_size: Results per page (max 250).
+
+        Returns:
+            List of BillAction objects in chronological order.
+        """
+        url = (
+            f"{self.base_url}/bill/{congress}/{bill_type.lower()}/{bill_number}/actions"
+        )
+        results: list[BillAction] = []
+        offset = 0
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            while True:
+                params: dict[str, Any] = {
+                    "api_key": self.api_key,
+                    "format": "json",
+                    "limit": page_size,
+                    "offset": offset,
+                }
+                logger.info(
+                    f"Fetching bill actions for {congress}/{bill_type}/{bill_number} "
+                    f"(offset={offset})"
+                )
+                response = await self._request_with_retry(
+                    client, "GET", url, params=params
+                )
+                data = response.json()
+
+                actions = data.get("actions", [])
+                for action_data in actions:
+                    results.append(BillAction.from_api_response(action_data))
+
+                pagination = data.get("pagination", {})
+                count = pagination.get("count", 0)
+                if offset + page_size >= count or not actions:
+                    break
+                offset += page_size
+
+        logger.info(
+            f"Fetched {len(results)} actions for {bill_type.upper()} {bill_number}"
+        )
+        return results
 
     async def get_house_votes(
         self,

--- a/backend/pipeline/congress/law_history_ingestion.py
+++ b/backend/pipeline/congress/law_history_ingestion.py
@@ -1,0 +1,366 @@
+"""Pipeline service for seeding legislative history into the DB.
+
+Fetches bill actions and sponsors from Congress.gov and stores them in the
+law_bill_action and law_sponsor tables so the History tab can serve responses
+from the DB instead of hitting the live API on every request.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.law_history_helpers import (
+    build_event_title,
+    classify_action,
+    parse_vote_tally,
+)
+from app.models.public_law import LawBillAction, LawSponsor, PublicLaw
+from app.models.supporting import DataIngestionLog
+
+if TYPE_CHECKING:
+    from pipeline.cache import PipelineCache
+
+logger = logging.getLogger(__name__)
+
+
+class LawHistoryIngestionService:
+    """Fetches and persists legislative history (actions + sponsors) for public laws."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        cache: PipelineCache | None = None,
+    ) -> None:
+        self.session = session
+        self.cache = cache
+
+    async def seed_law(
+        self,
+        congress: int,
+        law_number: int,
+        force: bool = False,
+    ) -> DataIngestionLog:
+        """Seed bill actions and sponsors for a single law.
+
+        Args:
+            congress: Congress number (e.g. 117).
+            law_number: Public law number (e.g. 169).
+            force: If True, delete existing rows and re-fetch.
+
+        Returns:
+            DataIngestionLog with status and counts.
+        """
+        log = DataIngestionLog(
+            operation=f"seed-law-history-{congress}-{law_number}",
+            status="started",
+            records_processed=0,
+            records_created=0,
+            records_updated=0,
+        )
+        self.session.add(log)
+
+        try:
+            law = await self._fetch_law(congress, law_number)
+            if law is None:
+                log.status = "failed"
+                log.error_message = f"Law PL {congress}-{law_number} not found in DB"
+                await self.session.commit()
+                return log
+
+            # Skip if already seeded and not forced
+            if not force:
+                existing = await self._count_existing(law.law_id)
+                if existing > 0:
+                    log.status = "skipped"
+                    log.details = f"Already seeded ({existing} actions). Use --force to re-seed."
+                    await self.session.commit()
+                    return log
+
+            congress_client = self._make_client()
+            if congress_client is None:
+                log.status = "failed"
+                log.error_message = "Congress.gov API key not configured"
+                await self.session.commit()
+                return log
+
+            bill_ref = await self._resolve_bill_ref(law, congress_client)
+            if bill_ref is None:
+                log.status = "failed"
+                log.error_message = f"Could not resolve bill reference for PL {congress}-{law_number}"
+                await self.session.commit()
+                return log
+
+            bill_type, bill_number_int = bill_ref
+
+            # Delete existing rows if forcing
+            if force:
+                await self.session.execute(
+                    delete(LawBillAction).where(LawBillAction.law_id == law.law_id)
+                )
+                await self.session.execute(
+                    delete(LawSponsor).where(LawSponsor.law_id == law.law_id)
+                )
+
+            actions_created = await self._ingest_actions(
+                law.law_id, congress, bill_type, bill_number_int, congress_client
+            )
+            sponsors_created = await self._ingest_sponsors(
+                law.law_id, congress, bill_type, bill_number_int, congress_client
+            )
+
+            total = actions_created + sponsors_created
+            log.status = "completed"
+            log.records_processed = total
+            log.records_created = total
+            log.details = f"{actions_created} actions, {sponsors_created} sponsors"
+            await self.session.commit()
+
+        except Exception as exc:
+            await self.session.rollback()
+            log.status = "failed"
+            log.error_message = str(exc)
+            logger.exception(
+                "Failed to seed law history for PL %d-%d", congress, law_number
+            )
+            self.session.add(log)
+            await self.session.commit()
+
+        return log
+
+    async def seed_congress(
+        self,
+        congress: int,
+        force: bool = False,
+    ) -> DataIngestionLog:
+        """Seed bill actions and sponsors for all laws in a congress.
+
+        Args:
+            congress: Congress number.
+            force: If True, re-seed even if data already exists.
+
+        Returns:
+            Aggregate DataIngestionLog.
+        """
+        log = DataIngestionLog(
+            operation=f"seed-congress-law-history-{congress}",
+            status="started",
+            records_processed=0,
+            records_created=0,
+            records_updated=0,
+        )
+        self.session.add(log)
+        await self.session.flush()
+
+        stmt = select(PublicLaw).where(PublicLaw.congress == congress)
+        result = await self.session.execute(stmt)
+        laws = result.scalars().all()
+
+        total_created = 0
+        total_processed = 0
+        failed = 0
+
+        for law in laws:
+            child_log = await self.seed_law(law.congress, int(law.law_number), force=force)
+            total_processed += child_log.records_processed or 0
+            total_created += child_log.records_created or 0
+            if child_log.status == "failed":
+                failed += 1
+                logger.warning(
+                    "Failed to seed PL %d-%s: %s",
+                    law.congress,
+                    law.law_number,
+                    child_log.error_message,
+                )
+
+        log.status = "failed" if failed > 0 and total_created == 0 else "completed"
+        log.records_processed = total_processed
+        log.records_created = total_created
+        log.details = (
+            f"{len(laws)} laws processed, {failed} failed, {total_created} rows created"
+        )
+        await self.session.commit()
+        return log
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _fetch_law(self, congress: int, law_number: int) -> PublicLaw | None:
+        stmt = (
+            select(PublicLaw)
+            .where(
+                PublicLaw.congress == congress,
+                PublicLaw.law_number == str(law_number),
+            )
+            .options(selectinload(PublicLaw.origin_bill))
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def _count_existing(self, law_id: int) -> int:
+        from sqlalchemy import func
+
+        stmt = select(func.count()).select_from(LawBillAction).where(
+            LawBillAction.law_id == law_id
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one()
+
+    def _make_client(self) -> Any | None:
+        import importlib
+
+        try:
+            mod = importlib.import_module("pipeline.congress.client")
+            return mod.CongressClient(cache=self.cache)
+        except (ValueError, ImportError) as exc:
+            logger.warning("Congress.gov API unavailable: %s", exc)
+            return None
+
+    async def _resolve_bill_ref(
+        self, law: PublicLaw, congress_client: Any
+    ) -> tuple[str, int] | None:
+        """Return (bill_type_lower, bill_number_int) or None."""
+        bill = law.origin_bill
+        if bill is not None and bill.bill_number:
+            bill_type = bill.bill_type.value.lower()
+            try:
+                return bill_type, int(bill.bill_number)
+            except ValueError:
+                pass
+
+        try:
+            law_number_int = int(law.law_number)
+            data = await congress_client.get_law_bill_info(
+                law.congress, law_number_int, "pub"
+            )
+        except Exception:
+            return None
+
+        if data is None:
+            return None
+
+        congress_data = data.get("congress", {})
+        bills = congress_data.get("bills", [])
+        if not bills:
+            return None
+        bill_ref = bills[0]
+        b_type = (bill_ref.get("type") or "").lower()
+        b_number = bill_ref.get("number")
+        if not b_type or not b_number:
+            return None
+        try:
+            return b_type, int(b_number)
+        except (ValueError, TypeError):
+            return None
+
+    async def _ingest_actions(
+        self,
+        law_id: int,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+        congress_client: Any,
+    ) -> int:
+        try:
+            raw_actions = await congress_client.get_bill_actions(
+                congress, bill_type, bill_number
+            )
+        except Exception as exc:
+            logger.warning("Failed to fetch bill actions: %s", exc)
+            return 0
+
+        seen_intro = False
+        seen_committee = False
+        created = 0
+
+        for sort_order, action in enumerate(raw_actions):
+            event_type, is_milestone = classify_action(
+                action.action_type,
+                action.text,
+                action.chamber,
+                seen_intro,
+                seen_committee,
+            )
+
+            if event_type == "introduced":
+                seen_intro = True
+            if event_type == "committee_referral":
+                seen_committee = True
+
+            yeas, nays, not_voting = parse_vote_tally(action.text)
+            title = build_event_title(event_type, action.text, action.chamber)
+
+            row = LawBillAction(
+                law_id=law_id,
+                sort_order=sort_order,
+                action_date=action.action_date,
+                action_code=action.action_code,
+                action_type=action.action_type,
+                text=action.text,
+                chamber=action.chamber,
+                congressional_record_refs=action.congressional_record_refs,
+                event_type=event_type,
+                is_milestone=is_milestone,
+                vote_yeas=yeas,
+                vote_nays=nays,
+                vote_not_voting=not_voting,
+                event_title=title,
+            )
+            self.session.add(row)
+            created += 1
+
+        return created
+
+    async def _ingest_sponsors(
+        self,
+        law_id: int,
+        congress: int,
+        bill_type: str,
+        bill_number: int,
+        congress_client: Any,
+    ) -> int:
+        try:
+            sponsor_info, cosponsors = await congress_client.get_bill_sponsors(
+                congress, bill_type, bill_number
+            )
+        except Exception as exc:
+            logger.warning("Failed to fetch sponsors: %s", exc)
+            return 0
+
+        created = 0
+        sort_order = 0
+
+        if sponsor_info:
+            row = LawSponsor(
+                law_id=law_id,
+                sort_order=sort_order,
+                name=sponsor_info.full_name,
+                party=sponsor_info.party,
+                state=sponsor_info.state,
+                bioguide_id=sponsor_info.bioguide_id,
+                is_primary=True,
+            )
+            self.session.add(row)
+            created += 1
+            sort_order += 1
+
+        for cs in cosponsors:
+            row = LawSponsor(
+                law_id=law_id,
+                sort_order=sort_order,
+                name=cs.full_name,
+                party=cs.party,
+                state=cs.state,
+                bioguide_id=cs.bioguide_id,
+                is_primary=False,
+            )
+            self.session.add(row)
+            created += 1
+            sort_order += 1
+
+        return created

--- a/backend/pipeline/congress/law_history_ingestion.py
+++ b/backend/pipeline/congress/law_history_ingestion.py
@@ -77,7 +77,9 @@ class LawHistoryIngestionService:
                 existing = await self._count_existing(law.law_id)
                 if existing > 0:
                     log.status = "skipped"
-                    log.details = f"Already seeded ({existing} actions). Use --force to re-seed."
+                    log.details = (
+                        f"Already seeded ({existing} actions). Use --force to re-seed."
+                    )
                     await self.session.commit()
                     return log
 
@@ -91,7 +93,9 @@ class LawHistoryIngestionService:
             bill_ref = await self._resolve_bill_ref(law, congress_client)
             if bill_ref is None:
                 log.status = "failed"
-                log.error_message = f"Could not resolve bill reference for PL {congress}-{law_number}"
+                log.error_message = (
+                    f"Could not resolve bill reference for PL {congress}-{law_number}"
+                )
                 await self.session.commit()
                 return log
 
@@ -165,7 +169,9 @@ class LawHistoryIngestionService:
         failed = 0
 
         for law in laws:
-            child_log = await self.seed_law(law.congress, int(law.law_number), force=force)
+            child_log = await self.seed_law(
+                law.congress, int(law.law_number), force=force
+            )
             total_processed += child_log.records_processed or 0
             total_created += child_log.records_created or 0
             if child_log.status == "failed":
@@ -205,8 +211,10 @@ class LawHistoryIngestionService:
     async def _count_existing(self, law_id: int) -> int:
         from sqlalchemy import func
 
-        stmt = select(func.count()).select_from(LawBillAction).where(
-            LawBillAction.law_id == law_id
+        stmt = (
+            select(func.count())
+            .select_from(LawBillAction)
+            .where(LawBillAction.law_id == law_id)
         )
         result = await self.session.execute(stmt)
         return result.scalar_one()

--- a/backend/pipeline/olrc/group_service.py
+++ b/backend/pipeline/olrc/group_service.py
@@ -8,7 +8,7 @@ import logging
 import re
 from datetime import date
 
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.us_code import SectionGroup
@@ -172,12 +172,30 @@ async def upsert_group(
     return group, True
 
 
+def _compute_positive_law_date(parsed: ParsedGroup) -> date | None:
+    """Compute the positive law enactment date for a title group."""
+    if parsed.group_type != "title":
+        return None
+    if parsed.positive_law_date:
+        return _parse_citation_date(parsed.positive_law_date)
+    if parsed.is_positive_law:
+        try:
+            return _get_positive_law_date(int(parsed.number))
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
 async def upsert_groups_from_parse_result(
     session: AsyncSession,
     groups: list[ParsedGroup],
     force: bool = False,
 ) -> dict[str, SectionGroup]:
     """Upsert all groups from a parse result, resolving parent_key → parent_id.
+
+    Processes groups level-by-level (one bulk SELECT + one flush per tree depth)
+    instead of one round-trip per group, which is critical on cloud deployments
+    where each DB round-trip adds ~10-20ms of latency.
 
     Args:
         session: Database session.
@@ -187,16 +205,96 @@ async def upsert_groups_from_parse_result(
     Returns:
         Dict mapping group key → SectionGroup record.
     """
+    if not groups:
+        return {}
+
     group_lookup: dict[str, SectionGroup] = {}
 
-    for parsed_group in groups:
-        parent_id = None
-        if parsed_group.parent_key:
-            parent_record = group_lookup.get(parsed_group.parent_key)
-            if parent_record:
-                parent_id = parent_record.group_id
+    # Assign tree depth to each group.  Parents appear before children per contract,
+    # so by the time we process group G its parent_key is already in key_to_depth.
+    key_to_depth: dict[str, int] = {}
+    for g in groups:
+        key_to_depth[g.key] = (
+            0 if not g.parent_key else key_to_depth.get(g.parent_key, -1) + 1
+        )
 
-        group_record, _ = await upsert_group(session, parsed_group, parent_id, force)
-        group_lookup[parsed_group.key] = group_record
+    # Bucket groups by depth so we can batch SELECT + flush per level.
+    depth_to_groups: dict[int, list[ParsedGroup]] = {}
+    for g in groups:
+        depth_to_groups.setdefault(key_to_depth[g.key], []).append(g)
+
+    for depth in sorted(depth_to_groups.keys()):
+        level_groups = depth_to_groups[depth]
+
+        # Resolve parent_ids — all depth-(d-1) records are already flushed.
+        resolved: list[tuple[int | None, ParsedGroup]] = []
+        for pg in level_groups:
+            parent_id: int | None = None
+            if pg.parent_key:
+                parent_rec = group_lookup.get(pg.parent_key)
+                if parent_rec:
+                    parent_id = parent_rec.group_id
+            resolved.append((parent_id, pg))
+
+        # ---- Bulk SELECT for this level ----------------------------------------
+        # Split into null-parent groups (titles) and non-null-parent groups, because
+        # PostgreSQL's tuple-IN syntax cannot match NULLs.
+
+        null_pairs = [(pg.group_type, pg.number) for pid, pg in resolved if pid is None]
+        non_null_triples = [
+            (pid, pg.group_type, pg.number) for pid, pg in resolved if pid is not None
+        ]
+
+        existing_by_key: dict[tuple[int | None, str, str], SectionGroup] = {}
+
+        if null_pairs:
+            stmt = select(SectionGroup).where(
+                SectionGroup.parent_id.is_(None),
+                tuple_(SectionGroup.group_type, SectionGroup.number).in_(null_pairs),
+            )
+            result = await session.execute(stmt)
+            for rec in result.scalars():
+                existing_by_key[(None, rec.group_type, rec.number)] = rec
+
+        if non_null_triples:
+            stmt = select(SectionGroup).where(
+                tuple_(
+                    SectionGroup.parent_id,
+                    SectionGroup.group_type,
+                    SectionGroup.number,
+                ).in_(non_null_triples)
+            )
+            result = await session.execute(stmt)
+            for rec in result.scalars():
+                existing_by_key[(rec.parent_id, rec.group_type, rec.number)] = rec
+
+        # ---- Upsert each group at this level ------------------------------------
+        for parent_id, pg in resolved:
+            existing = existing_by_key.get((parent_id, pg.group_type, pg.number))
+
+            if existing:
+                if force:
+                    existing.name = pg.name
+                    existing.sort_order = pg.sort_order
+                    existing.is_positive_law = pg.is_positive_law
+                    existing.positive_law_date = _compute_positive_law_date(pg)
+                    existing.positive_law_citation = pg.positive_law_citation
+                group_lookup[pg.key] = existing
+            else:
+                new_group = SectionGroup(
+                    parent_id=parent_id,
+                    group_type=pg.group_type,
+                    number=pg.number,
+                    name=pg.name,
+                    sort_order=pg.sort_order,
+                    is_positive_law=pg.is_positive_law,
+                    positive_law_date=_compute_positive_law_date(pg),
+                    positive_law_citation=pg.positive_law_citation,
+                )
+                session.add(new_group)
+                group_lookup[pg.key] = new_group
+
+        # One flush per level assigns PKs that the next depth's parent_ids need.
+        await session.flush()
 
     return group_lookup

--- a/backend/pipeline/olrc/group_service.py
+++ b/backend/pipeline/olrc/group_service.py
@@ -8,7 +8,7 @@ import logging
 import re
 from datetime import date
 
-from sqlalchemy import select, tuple_
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.us_code import SectionGroup
@@ -172,30 +172,12 @@ async def upsert_group(
     return group, True
 
 
-def _compute_positive_law_date(parsed: ParsedGroup) -> date | None:
-    """Compute the positive law enactment date for a title group."""
-    if parsed.group_type != "title":
-        return None
-    if parsed.positive_law_date:
-        return _parse_citation_date(parsed.positive_law_date)
-    if parsed.is_positive_law:
-        try:
-            return _get_positive_law_date(int(parsed.number))
-        except (ValueError, TypeError):
-            pass
-    return None
-
-
 async def upsert_groups_from_parse_result(
     session: AsyncSession,
     groups: list[ParsedGroup],
     force: bool = False,
 ) -> dict[str, SectionGroup]:
     """Upsert all groups from a parse result, resolving parent_key → parent_id.
-
-    Processes groups level-by-level (one bulk SELECT + one flush per tree depth)
-    instead of one round-trip per group, which is critical on cloud deployments
-    where each DB round-trip adds ~10-20ms of latency.
 
     Args:
         session: Database session.
@@ -205,96 +187,16 @@ async def upsert_groups_from_parse_result(
     Returns:
         Dict mapping group key → SectionGroup record.
     """
-    if not groups:
-        return {}
-
     group_lookup: dict[str, SectionGroup] = {}
 
-    # Assign tree depth to each group.  Parents appear before children per contract,
-    # so by the time we process group G its parent_key is already in key_to_depth.
-    key_to_depth: dict[str, int] = {}
-    for g in groups:
-        key_to_depth[g.key] = (
-            0 if not g.parent_key else key_to_depth.get(g.parent_key, -1) + 1
-        )
+    for parsed_group in groups:
+        parent_id = None
+        if parsed_group.parent_key:
+            parent_record = group_lookup.get(parsed_group.parent_key)
+            if parent_record:
+                parent_id = parent_record.group_id
 
-    # Bucket groups by depth so we can batch SELECT + flush per level.
-    depth_to_groups: dict[int, list[ParsedGroup]] = {}
-    for g in groups:
-        depth_to_groups.setdefault(key_to_depth[g.key], []).append(g)
-
-    for depth in sorted(depth_to_groups.keys()):
-        level_groups = depth_to_groups[depth]
-
-        # Resolve parent_ids — all depth-(d-1) records are already flushed.
-        resolved: list[tuple[int | None, ParsedGroup]] = []
-        for pg in level_groups:
-            parent_id: int | None = None
-            if pg.parent_key:
-                parent_rec = group_lookup.get(pg.parent_key)
-                if parent_rec:
-                    parent_id = parent_rec.group_id
-            resolved.append((parent_id, pg))
-
-        # ---- Bulk SELECT for this level ----------------------------------------
-        # Split into null-parent groups (titles) and non-null-parent groups, because
-        # PostgreSQL's tuple-IN syntax cannot match NULLs.
-
-        null_pairs = [(pg.group_type, pg.number) for pid, pg in resolved if pid is None]
-        non_null_triples = [
-            (pid, pg.group_type, pg.number) for pid, pg in resolved if pid is not None
-        ]
-
-        existing_by_key: dict[tuple[int | None, str, str], SectionGroup] = {}
-
-        if null_pairs:
-            stmt = select(SectionGroup).where(
-                SectionGroup.parent_id.is_(None),
-                tuple_(SectionGroup.group_type, SectionGroup.number).in_(null_pairs),
-            )
-            result = await session.execute(stmt)
-            for rec in result.scalars():
-                existing_by_key[(None, rec.group_type, rec.number)] = rec
-
-        if non_null_triples:
-            stmt = select(SectionGroup).where(
-                tuple_(
-                    SectionGroup.parent_id,
-                    SectionGroup.group_type,
-                    SectionGroup.number,
-                ).in_(non_null_triples)
-            )
-            result = await session.execute(stmt)
-            for rec in result.scalars():
-                existing_by_key[(rec.parent_id, rec.group_type, rec.number)] = rec
-
-        # ---- Upsert each group at this level ------------------------------------
-        for parent_id, pg in resolved:
-            existing = existing_by_key.get((parent_id, pg.group_type, pg.number))
-
-            if existing:
-                if force:
-                    existing.name = pg.name
-                    existing.sort_order = pg.sort_order
-                    existing.is_positive_law = pg.is_positive_law
-                    existing.positive_law_date = _compute_positive_law_date(pg)
-                    existing.positive_law_citation = pg.positive_law_citation
-                group_lookup[pg.key] = existing
-            else:
-                new_group = SectionGroup(
-                    parent_id=parent_id,
-                    group_type=pg.group_type,
-                    number=pg.number,
-                    name=pg.name,
-                    sort_order=pg.sort_order,
-                    is_positive_law=pg.is_positive_law,
-                    positive_law_date=_compute_positive_law_date(pg),
-                    positive_law_citation=pg.positive_law_citation,
-                )
-                session.add(new_group)
-                group_lookup[pg.key] = new_group
-
-        # One flush per level assigns PKs that the next depth's parent_ids need.
-        await session.flush()
+        group_record, _ = await upsert_group(session, parsed_group, parent_id, force)
+        group_lookup[parsed_group.key] = group_record
 
     return group_lookup

--- a/backend/tests/pipeline/test_congress.py
+++ b/backend/tests/pipeline/test_congress.py
@@ -1,11 +1,12 @@
 """Tests for Congress.gov API client."""
 
-from datetime import UTC, datetime
-from unittest.mock import patch
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from pipeline.congress.client import (
+    BillAction,
     CongressClient,
     HouseVoteDetail,
     HouseVoteInfo,
@@ -14,6 +15,7 @@ from pipeline.congress.client import (
     MemberTerm,
     MemberVoteInfo,
     SponsorInfo,
+    _parse_cr_refs,
 )
 
 
@@ -429,3 +431,236 @@ class TestMemberVoteInfo:
         info = MemberVoteInfo.from_api_response(data)
 
         assert info.vote_cast == "Not Voting"
+
+
+class TestParseCRRefs:
+    """Tests for Congressional Record reference parsing."""
+
+    def test_no_refs(self) -> None:
+        """Text without CR citations returns empty list."""
+        assert _parse_cr_refs("Signed by President.") == []
+
+    def test_ref_without_date(self) -> None:
+        """Parse CR reference with page only."""
+        result = _parse_cr_refs("Considered in House. CR H481.")
+        assert result == ["CR H481"]
+
+    def test_ref_with_date(self) -> None:
+        """Parse CR reference with date and page range."""
+        result = _parse_cr_refs("Debate. CR 2/12/2013 H439-440.")
+        assert result == ["CR 2/12/2013 H439-440"]
+
+    def test_senate_page(self) -> None:
+        """Parse Senate CR page reference."""
+        result = _parse_cr_refs("Senate debate. CR S1234.")
+        assert result == ["CR S1234"]
+
+    def test_multiple_refs(self) -> None:
+        """Parse multiple CR references from one text string."""
+        text = "Debate in House CR H439-440. Senate CR S567."
+        result = _parse_cr_refs(text)
+        assert len(result) == 2
+        assert "CR H439-440" in result
+        assert "CR S567" in result
+
+    def test_empty_text(self) -> None:
+        """Empty text returns empty list."""
+        assert _parse_cr_refs("") == []
+
+
+class TestBillAction:
+    """Tests for BillAction dataclass."""
+
+    def test_from_api_response_presidential_signature(self) -> None:
+        """Parse a presidential signature action."""
+        data = {
+            "actionCode": "36000",
+            "actionDate": "2013-08-09",
+            "type": "President",
+            "text": "Signed by President.",
+            "sourceSystem": {"code": 2, "name": "House floor actions"},
+        }
+
+        action = BillAction.from_api_response(data)
+
+        assert action.action_date == date(2013, 8, 9)
+        assert action.action_code == "36000"
+        assert action.action_type == "President"
+        assert action.text == "Signed by President."
+        assert action.chamber == "House"
+        assert action.congressional_record_refs == []
+
+    def test_from_api_response_with_cr_refs(self) -> None:
+        """Parse action that includes Congressional Record citations."""
+        data = {
+            "actionDate": "2013-02-12",
+            "type": "Floor",
+            "text": "Considered in House. CR 2/12/2013 H439-440.",
+            "sourceSystem": {"code": 2, "name": "House floor actions"},
+        }
+
+        action = BillAction.from_api_response(data)
+
+        assert action.action_date == date(2013, 2, 12)
+        assert action.congressional_record_refs == ["CR 2/12/2013 H439-440"]
+        assert action.chamber == "House"
+
+    def test_from_api_response_senate_chamber(self) -> None:
+        """Chamber is inferred as Senate from sourceSystem."""
+        data = {
+            "actionDate": "2013-07-31",
+            "type": "Floor",
+            "text": "Passed Senate without amendment.",
+            "sourceSystem": {"code": 0, "name": "Senate"},
+        }
+
+        action = BillAction.from_api_response(data)
+
+        assert action.chamber == "Senate"
+
+    def test_from_api_response_with_recorded_vote(self) -> None:
+        """Parse action that includes a recorded vote link."""
+        data = {
+            "actionDate": "2013-02-13",
+            "type": "Floor",
+            "text": "On passage Passed by the Yeas and Nays.",
+            "sourceSystem": {"code": 2, "name": "House floor actions"},
+            "recordedVotes": [
+                {
+                    "chamber": "House",
+                    "congress": 113,
+                    "date": "2013-02-13T17:38:00Z",
+                    "rollNumber": 47,
+                    "session": 1,
+                    "url": "http://clerk.house.gov/evs/2013/roll047.xml",
+                }
+            ],
+        }
+
+        action = BillAction.from_api_response(data)
+
+        assert len(action.recorded_votes) == 1
+        vote = action.recorded_votes[0]
+        assert vote.chamber == "House"
+        assert vote.roll_number == 47
+        assert vote.session == 1
+
+    def test_from_api_response_missing_date(self) -> None:
+        """Action with missing date sets action_date to None."""
+        data = {
+            "type": "IntroReferral",
+            "text": "Referred to committee.",
+            "sourceSystem": {},
+        }
+
+        action = BillAction.from_api_response(data)
+
+        assert action.action_date is None
+        assert action.congressional_record_refs == []
+
+    def test_from_api_response_unknown_source_system(self) -> None:
+        """Unknown sourceSystem leaves chamber as None."""
+        data = {
+            "actionDate": "2013-01-03",
+            "type": "IntroReferral",
+            "text": "Introduced in House.",
+            "sourceSystem": {"code": 9, "name": "Library of Congress"},
+        }
+
+        action = BillAction.from_api_response(data)
+
+        assert action.chamber is None
+
+
+class TestGetBillActions:
+    """Tests for CongressClient.get_bill_actions()."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_all_pages(self) -> None:
+        """get_bill_actions fetches all pages when results exceed page size."""
+        page1 = {
+            "actions": [
+                {
+                    "actionDate": "2013-01-03",
+                    "type": "IntroReferral",
+                    "text": "Introduced in House.",
+                    "sourceSystem": {"name": "House floor actions"},
+                }
+            ],
+            "pagination": {"count": 2},
+        }
+        page2 = {
+            "actions": [
+                {
+                    "actionDate": "2013-08-09",
+                    "actionCode": "36000",
+                    "type": "President",
+                    "text": "Signed by President.",
+                    "sourceSystem": {"name": "House floor actions"},
+                }
+            ],
+            "pagination": {"count": 2},
+        }
+
+        mock_response1 = MagicMock()
+        mock_response1.json.return_value = page1
+        mock_response1.raise_for_status = MagicMock()
+
+        mock_response2 = MagicMock()
+        mock_response2.json.return_value = page2
+        mock_response2.raise_for_status = MagicMock()
+
+        with patch(
+            "pipeline.congress.client.CongressClient._request_with_retry",
+            new=AsyncMock(side_effect=[mock_response1, mock_response2]),
+        ):
+            client = CongressClient(api_key="test-key")
+            actions = await client.get_bill_actions(113, "hr", 267, page_size=1)
+
+        assert len(actions) == 2
+        assert actions[0].action_type == "IntroReferral"
+        assert actions[1].action_type == "President"
+        assert actions[1].action_code == "36000"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_actions(self) -> None:
+        """get_bill_actions returns empty list when API returns no actions."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"actions": [], "pagination": {"count": 0}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "pipeline.congress.client.CongressClient._request_with_retry",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            client = CongressClient(api_key="test-key")
+            actions = await client.get_bill_actions(113, "hr", 267)
+
+        assert actions == []
+
+    @pytest.mark.asyncio
+    async def test_cr_refs_parsed_in_actions(self) -> None:
+        """CR references in action text are parsed correctly."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "actions": [
+                {
+                    "actionDate": "2013-02-12",
+                    "type": "Floor",
+                    "text": "Debate. CR 2/12/2013 H439-440. CR H481.",
+                    "sourceSystem": {"name": "House floor actions"},
+                }
+            ],
+            "pagination": {"count": 1},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "pipeline.congress.client.CongressClient._request_with_retry",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            client = CongressClient(api_key="test-key")
+            actions = await client.get_bill_actions(113, "hr", 267)
+
+        assert len(actions) == 1
+        assert len(actions[0].congressional_record_refs) == 2

--- a/backend/tests/pipeline/test_structure_ingestion.py
+++ b/backend/tests/pipeline/test_structure_ingestion.py
@@ -37,6 +37,13 @@ def _mock_found(record):
     return mock_result
 
 
+def _mock_scalars_result(records: list):
+    """Return a mock result where .scalars() returns the given records."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = records
+    return mock_result
+
+
 class TestUpsertGroup:
     """Tests for upsert_group function."""
 
@@ -260,8 +267,9 @@ class TestIngestParseResult:
     async def test_end_to_end_orchestration(
         self, mock_session, minimal_parse_result
     ) -> None:
-        """Test that all groups are upserted."""
-        mock_session.execute.return_value = _mock_not_found()
+        """Test that all groups are upserted (one bulk SELECT per depth level)."""
+        # 3 groups at 3 depths → 3 SELECT calls, each returning nothing (all new)
+        mock_session.execute.return_value = _mock_scalars_result([])
 
         group_lookup = await upsert_groups_from_parse_result(
             mock_session, minimal_parse_result.groups
@@ -269,6 +277,8 @@ class TestIngestParseResult:
 
         # 3 groups (title + chapter + subchapter)
         assert len(group_lookup) == 3
+        # One flush per depth level (3 levels)
+        assert mock_session.flush.call_count == 3
 
     @pytest.mark.asyncio
     async def test_empty_results(self, mock_session) -> None:
@@ -282,16 +292,19 @@ class TestIngestParseResult:
         """Test that existing groups are returned without re-adding."""
         existing_title = MagicMock()
         existing_title.group_id = 1
+        existing_title.parent_id = None
+        existing_title.group_type = "title"
+        existing_title.number = "17"
 
         call_count = 0
 
         async def side_effect(*_args, **_kwargs):
             nonlocal call_count
             call_count += 1
-            if call_count == 1:
-                return _mock_found(existing_title)
-            else:
-                return _mock_not_found()
+            if call_count == 1:  # depth 0: title found
+                return _mock_scalars_result([existing_title])
+            else:  # depth 1: chapter not found
+                return _mock_scalars_result([])
 
         mock_session.execute = AsyncMock(side_effect=side_effect)
 
@@ -316,3 +329,6 @@ class TestIngestParseResult:
         assert len(group_lookup) == 2
         # Title was existing, chapter was new
         assert group_lookup["title:17"] is existing_title
+        # One SELECT per depth level (2 levels), one flush per level
+        assert mock_session.execute.call_count == 2
+        assert mock_session.flush.call_count == 2

--- a/backend/tests/pipeline/test_structure_ingestion.py
+++ b/backend/tests/pipeline/test_structure_ingestion.py
@@ -37,13 +37,6 @@ def _mock_found(record):
     return mock_result
 
 
-def _mock_scalars_result(records: list):
-    """Return a mock result where .scalars() returns the given records."""
-    mock_result = MagicMock()
-    mock_result.scalars.return_value = records
-    return mock_result
-
-
 class TestUpsertGroup:
     """Tests for upsert_group function."""
 
@@ -267,9 +260,8 @@ class TestIngestParseResult:
     async def test_end_to_end_orchestration(
         self, mock_session, minimal_parse_result
     ) -> None:
-        """Test that all groups are upserted (one bulk SELECT per depth level)."""
-        # 3 groups at 3 depths → 3 SELECT calls, each returning nothing (all new)
-        mock_session.execute.return_value = _mock_scalars_result([])
+        """Test that all groups are upserted."""
+        mock_session.execute.return_value = _mock_not_found()
 
         group_lookup = await upsert_groups_from_parse_result(
             mock_session, minimal_parse_result.groups
@@ -277,8 +269,6 @@ class TestIngestParseResult:
 
         # 3 groups (title + chapter + subchapter)
         assert len(group_lookup) == 3
-        # One flush per depth level (3 levels)
-        assert mock_session.flush.call_count == 3
 
     @pytest.mark.asyncio
     async def test_empty_results(self, mock_session) -> None:
@@ -292,19 +282,16 @@ class TestIngestParseResult:
         """Test that existing groups are returned without re-adding."""
         existing_title = MagicMock()
         existing_title.group_id = 1
-        existing_title.parent_id = None
-        existing_title.group_type = "title"
-        existing_title.number = "17"
 
         call_count = 0
 
         async def side_effect(*_args, **_kwargs):
             nonlocal call_count
             call_count += 1
-            if call_count == 1:  # depth 0: title found
-                return _mock_scalars_result([existing_title])
-            else:  # depth 1: chapter not found
-                return _mock_scalars_result([])
+            if call_count == 1:
+                return _mock_found(existing_title)
+            else:
+                return _mock_not_found()
 
         mock_session.execute = AsyncMock(side_effect=side_effect)
 
@@ -329,6 +316,3 @@ class TestIngestParseResult:
         assert len(group_lookup) == 2
         # Title was existing, chapter was new
         assert group_lookup["title:17"] is existing_title
-        # One SELECT per depth level (2 levels), one flush per level
-        assert mock_session.execute.call_count == 2
-        assert mock_session.flush.call_count == 2

--- a/backend/tests/test_president_lookup.py
+++ b/backend/tests/test_president_lookup.py
@@ -1,0 +1,69 @@
+"""Tests for president-by-date lookup utility."""
+
+from datetime import date
+
+from app.core.president_lookup import get_president_by_date, get_president_title
+
+
+class TestGetPresidentByDate:
+    """Tests for get_president_by_date()."""
+
+    def test_obama_signing_date(self) -> None:
+        """Pub. L. 113-23 signed 2013-08-09 — Obama was president."""
+        assert get_president_by_date(date(2013, 8, 9)) == "Barack Obama"
+
+    def test_obama_start_boundary(self) -> None:
+        """First day of Obama's first term."""
+        assert get_president_by_date(date(2009, 1, 20)) == "Barack Obama"
+
+    def test_george_w_bush_last_day(self) -> None:
+        """Last full day of George W. Bush's presidency is Jan 19 2009."""
+        assert get_president_by_date(date(2009, 1, 19)) == "George W. Bush"
+
+    def test_clinton_mid_term(self) -> None:
+        """Mid-term Clinton date."""
+        assert get_president_by_date(date(1997, 6, 15)) == "Bill Clinton"
+
+    def test_reagan_era(self) -> None:
+        """Reagan-era date."""
+        assert get_president_by_date(date(1985, 3, 1)) == "Ronald Reagan"
+
+    def test_nixon_resignation_date(self) -> None:
+        """Nixon resigned Aug 9 1974; Ford took over same day."""
+        assert get_president_by_date(date(1974, 8, 9)) == "Gerald Ford"
+
+    def test_nixon_day_before_resignation(self) -> None:
+        """Aug 8 1974 Nixon was still president."""
+        assert get_president_by_date(date(1974, 8, 8)) == "Richard Nixon"
+
+    def test_biden_first_day(self) -> None:
+        """Biden's inauguration day."""
+        assert get_president_by_date(date(2021, 1, 20)) == "Joe Biden"
+
+    def test_trump_second_term_start(self) -> None:
+        """Trump's second term start."""
+        assert get_president_by_date(date(2025, 1, 20)) == "Donald Trump"
+
+    def test_before_covered_range_returns_unknown(self) -> None:
+        """Date before 1961 is outside covered range."""
+        assert get_president_by_date(date(1960, 1, 1)) == "Unknown"
+
+    def test_far_future_returns_unknown(self) -> None:
+        """Date far past the last covered term returns Unknown."""
+        assert get_president_by_date(date(2035, 1, 1)) == "Unknown"
+
+
+class TestGetPresidentTitle:
+    """Tests for get_president_title()."""
+
+    def test_obama(self) -> None:
+        assert get_president_title("Barack Obama") == "President Obama"
+
+    def test_george_hw_bush(self) -> None:
+        assert get_president_title("George H.W. Bush") == "President Bush"
+
+    def test_johnson(self) -> None:
+        assert get_president_title("Lyndon B. Johnson") == "President Johnson"
+
+    def test_unknown(self) -> None:
+        assert get_president_title("Unknown") == "Unknown"

--- a/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
+++ b/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
-import { useLawMeta, useLawText, useLawDiffs, useLawHistory } from '@/hooks/useLaw';
+import {
+  useLawMeta,
+  useLawText,
+  useLawDiffs,
+  useLawHistory,
+} from '@/hooks/useLaw';
 import { fetchLawText } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import TabBar from '@/components/ui/TabBar';

--- a/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
+++ b/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
@@ -3,16 +3,18 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
-import { useLawMeta, useLawText, useLawDiffs } from '@/hooks/useLaw';
+import { useLawMeta, useLawText, useLawDiffs, useLawHistory } from '@/hooks/useLaw';
 import { fetchLawText } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import TabBar from '@/components/ui/TabBar';
 import LawTextViewer from '@/components/law-viewer/LawTextViewer';
 import LawDiffViewer from '@/components/law-viewer/LawDiffViewer';
+import LegislativeHistoryTab from '@/components/law-viewer/LegislativeHistoryTab';
 import LawLine from '@/components/ui/LawLine';
 
 const TABS = [
   { id: 'diff', label: 'Amendments' },
+  { id: 'history', label: 'History' },
   { id: 'htm', label: 'HTM' },
   { id: 'xml', label: 'XML' },
 ];
@@ -65,6 +67,13 @@ export default function LawViewerPage() {
     congress,
     lawNumber,
     activeTab === 'diff'
+  );
+
+  // History fetched lazily when the History tab is active
+  const { data: history, isLoading: historyLoading } = useLawHistory(
+    congress,
+    lawNumber,
+    activeTab === 'history'
   );
 
   if (metaLoading) return <p className="text-gray-500">Loading law text...</p>;
@@ -132,6 +141,17 @@ export default function LawViewerPage() {
         {activeTab === 'diff' && (
           <LawDiffViewer diffs={diffs ?? []} isLoading={diffsLoading} />
         )}
+
+        {activeTab === 'history' &&
+          (historyLoading ? (
+            <p className="text-gray-500">Loading legislative history...</p>
+          ) : history ? (
+            <LegislativeHistoryTab history={history} />
+          ) : (
+            <p className="py-8 text-center text-sm text-gray-500">
+              No legislative history available for this law.
+            </p>
+          ))}
       </div>
     </div>
   );

--- a/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
+++ b/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
@@ -1,0 +1,86 @@
+import type { LegislativeHistory } from '@/lib/types';
+import LegislativeHistoryTimeline from './LegislativeHistoryTimeline';
+import SponsorsSidebar from './SponsorsSidebar';
+import VotesSidebar from './VotesSidebar';
+
+interface LegislativeHistoryTabProps {
+    history: LegislativeHistory;
+}
+
+function formatDate(dateStr: string | null): string {
+    if (!dateStr) return '—';
+    const [year, month, day] = dateStr.split('-');
+    return `${year}.${month}.${day}`;
+}
+
+function PresidentialActionCard({
+    history,
+}: {
+    history: LegislativeHistory;
+}) {
+    const { presidential_action, president_name, enacted_date, status } = history;
+    if (!presidential_action && !president_name) return null;
+
+    const isEnacted = status === 'enacted';
+    const isVetoed = status === 'vetoed';
+
+    return (
+        <div
+            className={`rounded-md border px-4 py-3 ${
+                isVetoed
+                    ? 'border-red-200 bg-red-50'
+                    : isEnacted
+                      ? 'border-green-200 bg-green-50'
+                      : 'border-gray-200 bg-white'
+            }`}
+        >
+            <div className="flex items-start gap-2">
+                {/* White House icon */}
+                <svg
+                    className={`mt-0.5 h-4 w-4 shrink-0 ${isVetoed ? 'text-red-600' : isEnacted ? 'text-green-600' : 'text-gray-400'}`}
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                >
+                    <path d="M3 12 L3 7 L8 3 L13 7 L13 12 Z" />
+                    <rect x="6" y="9" width="4" height="3" />
+                </svg>
+                <div className="min-w-0 flex-1">
+                    <p className={`text-xs font-semibold ${isVetoed ? 'text-red-700' : isEnacted ? 'text-green-700' : 'text-gray-700'}`}>
+                        {presidential_action ?? (isEnacted ? 'Signed into law' : 'Presidential action')}
+                    </p>
+                    {president_name && (
+                        <p className="mt-0.5 text-[11px] text-gray-500">
+                            {president_name}
+                        </p>
+                    )}
+                    {enacted_date && (
+                        <p className="mt-0.5 font-mono text-[11px] text-gray-400">
+                            {formatDate(enacted_date)}
+                        </p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/** 2-column (2:1) layout: timeline left, presidential card + votes + sponsors right. */
+export default function LegislativeHistoryTab({ history }: LegislativeHistoryTabProps) {
+    return (
+        <div className="grid grid-cols-3 gap-6">
+            {/* Left column — timeline (2/3 width) */}
+            <div className="col-span-2 overflow-y-auto">
+                <LegislativeHistoryTimeline events={history.timeline} />
+            </div>
+
+            {/* Right column — sidebar cards (1/3 width) */}
+            <div className="col-span-1 flex flex-col gap-4">
+                <PresidentialActionCard history={history} />
+                <VotesSidebar votes={history.chamber_votes} />
+                <SponsorsSidebar sponsors={history.sponsors} />
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
+++ b/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
@@ -4,117 +4,128 @@ import SponsorsSidebar from './SponsorsSidebar';
 import VotesSidebar from './VotesSidebar';
 
 interface LegislativeHistoryTabProps {
-    history: LegislativeHistory;
+  history: LegislativeHistory;
 }
 
 function formatDate(dateStr: string | null): string {
-    if (!dateStr) return '—';
-    const [year, month, day] = dateStr.split('-');
-    return `${year}.${month}.${day}`;
+  if (!dateStr) return '—';
+  const [year, month, day] = dateStr.split('-');
+  return `${year}.${month}.${day}`;
 }
 
-function PresidentialActionCard({
-    history,
-}: {
-    history: LegislativeHistory;
-}) {
-    const { presidential_action, president_name, enacted_date, status } = history;
-    if (!presidential_action && !president_name) return null;
+function PresidentialActionCard({ history }: { history: LegislativeHistory }) {
+  const { presidential_action, president_name, enacted_date, status } = history;
+  if (!presidential_action && !president_name) return null;
 
-    const isEnacted = status === 'enacted';
-    const isVetoed = status === 'vetoed';
+  const isEnacted = status === 'enacted';
+  const isVetoed = status === 'vetoed';
 
-    return (
-        <div
-            className={`rounded-md border px-4 py-3 ${
-                isVetoed
-                    ? 'border-red-200 bg-red-50'
-                    : isEnacted
-                      ? 'border-green-200 bg-green-50'
-                      : 'border-gray-200 bg-white'
-            }`}
+  return (
+    <div
+      className={`rounded-md border px-4 py-3 ${
+        isVetoed
+          ? 'border-red-200 bg-red-50'
+          : isEnacted
+            ? 'border-green-200 bg-green-50'
+            : 'border-gray-200 bg-white'
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        {/* White House icon */}
+        <svg
+          className={`mt-0.5 h-4 w-4 shrink-0 ${isVetoed ? 'text-red-600' : isEnacted ? 'text-green-600' : 'text-gray-400'}`}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
         >
-            <div className="flex items-start gap-2">
-                {/* White House icon */}
-                <svg
-                    className={`mt-0.5 h-4 w-4 shrink-0 ${isVetoed ? 'text-red-600' : isEnacted ? 'text-green-600' : 'text-gray-400'}`}
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                >
-                    <path d="M3 12 L3 7 L8 3 L13 7 L13 12 Z" />
-                    <rect x="6" y="9" width="4" height="3" />
-                </svg>
-                <div className="min-w-0 flex-1">
-                    <p className={`text-xs font-semibold ${isVetoed ? 'text-red-700' : isEnacted ? 'text-green-700' : 'text-gray-700'}`}>
-                        {presidential_action ?? (isEnacted ? 'Signed into law' : 'Presidential action')}
-                    </p>
-                    {president_name && (
-                        <p className="mt-0.5 text-[11px] text-gray-500">
-                            {president_name}
-                        </p>
-                    )}
-                    {enacted_date && (
-                        <p className="mt-0.5 font-mono text-[11px] text-gray-400">
-                            {formatDate(enacted_date)}
-                        </p>
-                    )}
-                </div>
-            </div>
+          <path d="M3 12 L3 7 L8 3 L13 7 L13 12 Z" />
+          <rect x="6" y="9" width="4" height="3" />
+        </svg>
+        <div className="min-w-0 flex-1">
+          <p
+            className={`text-xs font-semibold ${isVetoed ? 'text-red-700' : isEnacted ? 'text-green-700' : 'text-gray-700'}`}
+          >
+            {presidential_action ??
+              (isEnacted ? 'Signed into law' : 'Presidential action')}
+          </p>
+          {president_name && (
+            <p className="mt-0.5 text-[11px] text-gray-500">{president_name}</p>
+          )}
+          {enacted_date && (
+            <p className="mt-0.5 font-mono text-[11px] text-gray-400">
+              {formatDate(enacted_date)}
+            </p>
+          )}
         </div>
-    );
+      </div>
+    </div>
+  );
 }
 
 function StatusBanner({ status }: { status: LegislativeHistory['status'] }) {
-    if (status === 'enacted') return null;
+  if (status === 'enacted') return null;
 
-    if (status === 'vetoed') {
-        return (
-            <div className="mb-4 flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-4 py-2.5">
-                <svg className="h-4 w-4 shrink-0 text-red-600" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <circle cx="8" cy="8" r="6" />
-                    <line x1="5" y1="8" x2="11" y2="8" />
-                </svg>
-                <p className="text-sm font-semibold text-red-700">
-                    This bill was vetoed and did not become law.
-                </p>
-            </div>
-        );
-    }
-
+  if (status === 'vetoed') {
     return (
-        <div className="mb-4 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-2.5">
-            <svg className="h-4 w-4 shrink-0 text-amber-600" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <circle cx="8" cy="8" r="6" />
-                <line x1="8" y1="5" x2="8" y2="9" />
-                <circle cx="8" cy="11" r="0.75" fill="currentColor" stroke="none" />
-            </svg>
-            <p className="text-sm font-medium text-amber-700">
-                This bill is pending — it has not yet been enacted or vetoed.
-            </p>
-        </div>
+      <div className="mb-4 flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-4 py-2.5">
+        <svg
+          className="h-4 w-4 shrink-0 text-red-600"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <circle cx="8" cy="8" r="6" />
+          <line x1="5" y1="8" x2="11" y2="8" />
+        </svg>
+        <p className="text-sm font-semibold text-red-700">
+          This bill was vetoed and did not become law.
+        </p>
+      </div>
     );
+  }
+
+  return (
+    <div className="mb-4 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-2.5">
+      <svg
+        className="h-4 w-4 shrink-0 text-amber-600"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <circle cx="8" cy="8" r="6" />
+        <line x1="8" y1="5" x2="8" y2="9" />
+        <circle cx="8" cy="11" r="0.75" fill="currentColor" stroke="none" />
+      </svg>
+      <p className="text-sm font-medium text-amber-700">
+        This bill is pending — it has not yet been enacted or vetoed.
+      </p>
+    </div>
+  );
 }
 
 /** 2-column (2:1) layout: timeline left, presidential card + votes + sponsors right. */
-export default function LegislativeHistoryTab({ history }: LegislativeHistoryTabProps) {
-    return (
-        <div>
-            <StatusBanner status={history.status} />
-            <div className="grid grid-cols-3 gap-6">
-                {/* Left column — timeline (2/3 width) */}
-                <div className="col-span-2 overflow-y-auto">
-                    <LegislativeHistoryTimeline events={history.timeline} />
-                </div>
-
-                {/* Right column — sidebar cards (1/3 width) */}
-                <div className="col-span-1 flex flex-col gap-4">
-                    <PresidentialActionCard history={history} />
-                    <VotesSidebar votes={history.chamber_votes} />
-                    <SponsorsSidebar sponsors={history.sponsors} />
-                </div>
-            </div>
+export default function LegislativeHistoryTab({
+  history,
+}: LegislativeHistoryTabProps) {
+  return (
+    <div>
+      <StatusBanner status={history.status} />
+      <div className="grid grid-cols-3 gap-6">
+        {/* Left column — timeline (2/3 width) */}
+        <div className="col-span-2 overflow-y-auto">
+          <LegislativeHistoryTimeline events={history.timeline} />
         </div>
-    );
+
+        {/* Right column — sidebar cards (1/3 width) */}
+        <div className="col-span-1 flex flex-col gap-4">
+          <PresidentialActionCard history={history} />
+          <VotesSidebar votes={history.chamber_votes} />
+          <SponsorsSidebar sponsors={history.sponsors} />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
+++ b/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
@@ -66,20 +66,54 @@ function PresidentialActionCard({
     );
 }
 
+function StatusBanner({ status }: { status: LegislativeHistory['status'] }) {
+    if (status === 'enacted') return null;
+
+    if (status === 'vetoed') {
+        return (
+            <div className="mb-4 flex items-center gap-2 rounded-md border border-red-200 bg-red-50 px-4 py-2.5">
+                <svg className="h-4 w-4 shrink-0 text-red-600" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <circle cx="8" cy="8" r="6" />
+                    <line x1="5" y1="8" x2="11" y2="8" />
+                </svg>
+                <p className="text-sm font-semibold text-red-700">
+                    This bill was vetoed and did not become law.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="mb-4 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-2.5">
+            <svg className="h-4 w-4 shrink-0 text-amber-600" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="8" cy="8" r="6" />
+                <line x1="8" y1="5" x2="8" y2="9" />
+                <circle cx="8" cy="11" r="0.75" fill="currentColor" stroke="none" />
+            </svg>
+            <p className="text-sm font-medium text-amber-700">
+                This bill is pending — it has not yet been enacted or vetoed.
+            </p>
+        </div>
+    );
+}
+
 /** 2-column (2:1) layout: timeline left, presidential card + votes + sponsors right. */
 export default function LegislativeHistoryTab({ history }: LegislativeHistoryTabProps) {
     return (
-        <div className="grid grid-cols-3 gap-6">
-            {/* Left column — timeline (2/3 width) */}
-            <div className="col-span-2 overflow-y-auto">
-                <LegislativeHistoryTimeline events={history.timeline} />
-            </div>
+        <div>
+            <StatusBanner status={history.status} />
+            <div className="grid grid-cols-3 gap-6">
+                {/* Left column — timeline (2/3 width) */}
+                <div className="col-span-2 overflow-y-auto">
+                    <LegislativeHistoryTimeline events={history.timeline} />
+                </div>
 
-            {/* Right column — sidebar cards (1/3 width) */}
-            <div className="col-span-1 flex flex-col gap-4">
-                <PresidentialActionCard history={history} />
-                <VotesSidebar votes={history.chamber_votes} />
-                <SponsorsSidebar sponsors={history.sponsors} />
+                {/* Right column — sidebar cards (1/3 width) */}
+                <div className="col-span-1 flex flex-col gap-4">
+                    <PresidentialActionCard history={history} />
+                    <VotesSidebar votes={history.chamber_votes} />
+                    <SponsorsSidebar sponsors={history.sponsors} />
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/components/law-viewer/LegislativeHistoryTimeline.tsx
+++ b/frontend/src/components/law-viewer/LegislativeHistoryTimeline.tsx
@@ -5,57 +5,64 @@ import type { TimelineEvent as TimelineEventType } from '@/lib/types';
 import TimelineEvent from './TimelineEvent';
 
 interface LegislativeHistoryTimelineProps {
-    events: TimelineEventType[];
+  events: TimelineEventType[];
 }
 
 /** Scrollable timeline of legislative events with milestone/full toggle. */
-export default function LegislativeHistoryTimeline({ events }: LegislativeHistoryTimelineProps) {
-    const [showAll, setShowAll] = useState(false);
+export default function LegislativeHistoryTimeline({
+  events,
+}: LegislativeHistoryTimelineProps) {
+  const [showAll, setShowAll] = useState(false);
 
-    const milestones = events.filter((e) => e.is_milestone);
-    const displayed = showAll ? events : milestones;
-    const hasNonMilestones = events.length > milestones.length;
+  const milestones = events.filter((e) => e.is_milestone);
+  const displayed = showAll ? events : milestones;
+  const hasNonMilestones = events.length > milestones.length;
 
-    if (events.length === 0) {
-        return (
-            <p className="py-8 text-center text-sm text-gray-500">
-                No legislative history available for this law.
-            </p>
-        );
-    }
-
+  if (events.length === 0) {
     return (
-        <div className="flex flex-col">
-            {/* Header */}
-            <div className="mb-2 flex items-center justify-between">
-                <h2 className="text-sm font-semibold text-gray-900">
-                    Discussion
-                    <span className="ml-2 font-normal text-gray-400">
-                        {displayed.length} event{displayed.length !== 1 ? 's' : ''}
-                        {!showAll && hasNonMilestones && ` of ${events.length}`}
-                    </span>
-                </h2>
-                {hasNonMilestones && (
-                    <button
-                        onClick={() => setShowAll((v) => !v)}
-                        className="text-xs text-primary-600 hover:text-primary-700 hover:underline"
-                    >
-                        {showAll ? 'Show milestones only' : `Show all ${events.length} events`}
-                    </button>
-                )}
-            </div>
-
-            {/* Event list with vertical connector line */}
-            <div className="relative">
-                {/* Connector line */}
-                <div className="absolute left-[7px] top-4 bottom-4 w-px bg-gray-200" aria-hidden />
-
-                <div className="divide-y divide-gray-100">
-                    {displayed.map((event, i) => (
-                        <TimelineEvent key={i} event={event} />
-                    ))}
-                </div>
-            </div>
-        </div>
+      <p className="py-8 text-center text-sm text-gray-500">
+        No legislative history available for this law.
+      </p>
     );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {/* Header */}
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-gray-900">
+          Discussion
+          <span className="ml-2 font-normal text-gray-400">
+            {displayed.length} event{displayed.length !== 1 ? 's' : ''}
+            {!showAll && hasNonMilestones && ` of ${events.length}`}
+          </span>
+        </h2>
+        {hasNonMilestones && (
+          <button
+            onClick={() => setShowAll((v) => !v)}
+            className="text-xs text-primary-600 hover:text-primary-700 hover:underline"
+          >
+            {showAll
+              ? 'Show milestones only'
+              : `Show all ${events.length} events`}
+          </button>
+        )}
+      </div>
+
+      {/* Event list with vertical connector line */}
+      <div className="relative">
+        {/* Connector line */}
+        <div
+          className="absolute bottom-4 left-[7px] top-4 w-px bg-gray-200"
+          aria-hidden
+        />
+
+        <div className="divide-y divide-gray-100">
+          {displayed.map((event, i) => (
+            <TimelineEvent key={i} event={event} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/law-viewer/LegislativeHistoryTimeline.tsx
+++ b/frontend/src/components/law-viewer/LegislativeHistoryTimeline.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import type { TimelineEvent as TimelineEventType } from '@/lib/types';
+import TimelineEvent from './TimelineEvent';
+
+interface LegislativeHistoryTimelineProps {
+    events: TimelineEventType[];
+}
+
+/** Scrollable timeline of legislative events with milestone/full toggle. */
+export default function LegislativeHistoryTimeline({ events }: LegislativeHistoryTimelineProps) {
+    const [showAll, setShowAll] = useState(false);
+
+    const milestones = events.filter((e) => e.is_milestone);
+    const displayed = showAll ? events : milestones;
+    const hasNonMilestones = events.length > milestones.length;
+
+    if (events.length === 0) {
+        return (
+            <p className="py-8 text-center text-sm text-gray-500">
+                No legislative history available for this law.
+            </p>
+        );
+    }
+
+    return (
+        <div className="flex flex-col">
+            {/* Header */}
+            <div className="mb-2 flex items-center justify-between">
+                <h2 className="text-sm font-semibold text-gray-900">
+                    Discussion
+                    <span className="ml-2 font-normal text-gray-400">
+                        {displayed.length} event{displayed.length !== 1 ? 's' : ''}
+                        {!showAll && hasNonMilestones && ` of ${events.length}`}
+                    </span>
+                </h2>
+                {hasNonMilestones && (
+                    <button
+                        onClick={() => setShowAll((v) => !v)}
+                        className="text-xs text-primary-600 hover:text-primary-700 hover:underline"
+                    >
+                        {showAll ? 'Show milestones only' : `Show all ${events.length} events`}
+                    </button>
+                )}
+            </div>
+
+            {/* Event list with vertical connector line */}
+            <div className="relative">
+                {/* Connector line */}
+                <div className="absolute left-[7px] top-4 bottom-4 w-px bg-gray-200" aria-hidden />
+
+                <div className="divide-y divide-gray-100">
+                    {displayed.map((event, i) => (
+                        <TimelineEvent key={i} event={event} />
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/law-viewer/SponsorsSidebar.tsx
+++ b/frontend/src/components/law-viewer/SponsorsSidebar.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import type { Sponsor } from '@/lib/types';
+
+interface SponsorsSidebarProps {
+    sponsors: Sponsor[];
+}
+
+const MAX_VISIBLE = 5;
+
+function partyColor(party: string | null): string {
+    if (!party) return 'text-gray-500';
+    const p = party.toUpperCase();
+    if (p === 'R') return 'text-red-600';
+    if (p === 'D') return 'text-blue-600';
+    return 'text-gray-500';
+}
+
+function SponsorRow({ sponsor }: { sponsor: Sponsor }) {
+    const meta = [sponsor.party, sponsor.state].filter(Boolean).join('-');
+    return (
+        <div className="flex items-start gap-2 py-1.5">
+            {/* Avatar placeholder */}
+            <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-200 text-[10px] font-semibold text-gray-600">
+                {sponsor.name.charAt(0)}
+            </div>
+            <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="text-xs font-medium text-gray-900 truncate">{sponsor.name}</span>
+                    {sponsor.is_primary && (
+                        <span className="shrink-0 rounded bg-primary-50 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-700 ring-1 ring-inset ring-primary-200">
+                            Author
+                        </span>
+                    )}
+                </div>
+                {meta && (
+                    <span className={`text-[11px] font-medium ${partyColor(sponsor.party)}`}>
+                        {meta}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}
+
+/** Right-panel sponsors list: primary author + cosponsors with expand toggle. */
+export default function SponsorsSidebar({ sponsors }: SponsorsSidebarProps) {
+    const [expanded, setExpanded] = useState(false);
+
+    if (sponsors.length === 0) return null;
+
+    const primary = sponsors.filter((s) => s.is_primary);
+    const cosponsors = sponsors.filter((s) => !s.is_primary);
+
+    const visibleCosponsors = expanded ? cosponsors : cosponsors.slice(0, MAX_VISIBLE);
+    const hiddenCount = cosponsors.length - MAX_VISIBLE;
+
+    return (
+        <div className="rounded-md border border-gray-200 bg-white px-4 py-3">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Sponsors
+            </h3>
+
+            {primary.map((s) => (
+                <SponsorRow key={s.bioguide_id ?? s.name} sponsor={s} />
+            ))}
+
+            {cosponsors.length > 0 && (
+                <>
+                    {primary.length > 0 && (
+                        <div className="my-1.5 border-t border-gray-100" />
+                    )}
+                    {visibleCosponsors.map((s) => (
+                        <SponsorRow key={s.bioguide_id ?? s.name} sponsor={s} />
+                    ))}
+                    {!expanded && hiddenCount > 0 && (
+                        <button
+                            onClick={() => setExpanded(true)}
+                            className="mt-1 text-xs text-primary-600 hover:text-primary-700 hover:underline"
+                        >
+                            +{hiddenCount} more cosponsor{hiddenCount !== 1 ? 's' : ''}
+                        </button>
+                    )}
+                </>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/law-viewer/SponsorsSidebar.tsx
+++ b/frontend/src/components/law-viewer/SponsorsSidebar.tsx
@@ -4,86 +4,92 @@ import { useState } from 'react';
 import type { Sponsor } from '@/lib/types';
 
 interface SponsorsSidebarProps {
-    sponsors: Sponsor[];
+  sponsors: Sponsor[];
 }
 
 const MAX_VISIBLE = 5;
 
 function partyColor(party: string | null): string {
-    if (!party) return 'text-gray-500';
-    const p = party.toUpperCase();
-    if (p === 'R') return 'text-red-600';
-    if (p === 'D') return 'text-blue-600';
-    return 'text-gray-500';
+  if (!party) return 'text-gray-500';
+  const p = party.toUpperCase();
+  if (p === 'R') return 'text-red-600';
+  if (p === 'D') return 'text-blue-600';
+  return 'text-gray-500';
 }
 
 function SponsorRow({ sponsor }: { sponsor: Sponsor }) {
-    const meta = [sponsor.party, sponsor.state].filter(Boolean).join('-');
-    return (
-        <div className="flex items-start gap-2 py-1.5">
-            {/* Avatar placeholder */}
-            <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-200 text-[10px] font-semibold text-gray-600">
-                {sponsor.name.charAt(0)}
-            </div>
-            <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-xs font-medium text-gray-900 truncate">{sponsor.name}</span>
-                    {sponsor.is_primary && (
-                        <span className="shrink-0 rounded bg-primary-50 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-700 ring-1 ring-inset ring-primary-200">
-                            Author
-                        </span>
-                    )}
-                </div>
-                {meta && (
-                    <span className={`text-[11px] font-medium ${partyColor(sponsor.party)}`}>
-                        {meta}
-                    </span>
-                )}
-            </div>
+  const meta = [sponsor.party, sponsor.state].filter(Boolean).join('-');
+  return (
+    <div className="flex items-start gap-2 py-1.5">
+      {/* Avatar placeholder */}
+      <div className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-200 text-[10px] font-semibold text-gray-600">
+        {sponsor.name.charAt(0)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="truncate text-xs font-medium text-gray-900">
+            {sponsor.name}
+          </span>
+          {sponsor.is_primary && (
+            <span className="ring-primary-200 shrink-0 rounded bg-primary-50 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-700 ring-1 ring-inset">
+              Author
+            </span>
+          )}
         </div>
-    );
+        {meta && (
+          <span
+            className={`text-[11px] font-medium ${partyColor(sponsor.party)}`}
+          >
+            {meta}
+          </span>
+        )}
+      </div>
+    </div>
+  );
 }
 
 /** Right-panel sponsors list: primary author + cosponsors with expand toggle. */
 export default function SponsorsSidebar({ sponsors }: SponsorsSidebarProps) {
-    const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
-    if (sponsors.length === 0) return null;
+  if (sponsors.length === 0) return null;
 
-    const primary = sponsors.filter((s) => s.is_primary);
-    const cosponsors = sponsors.filter((s) => !s.is_primary);
+  const primary = sponsors.filter((s) => s.is_primary);
+  const cosponsors = sponsors.filter((s) => !s.is_primary);
 
-    const visibleCosponsors = expanded ? cosponsors : cosponsors.slice(0, MAX_VISIBLE);
-    const hiddenCount = cosponsors.length - MAX_VISIBLE;
+  const visibleCosponsors = expanded
+    ? cosponsors
+    : cosponsors.slice(0, MAX_VISIBLE);
+  const hiddenCount = cosponsors.length - MAX_VISIBLE;
 
-    return (
-        <div className="rounded-md border border-gray-200 bg-white px-4 py-3">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Sponsors
-            </h3>
+  return (
+    <div className="rounded-md border border-gray-200 bg-white px-4 py-3">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+        Sponsors
+      </h3>
 
-            {primary.map((s) => (
-                <SponsorRow key={s.bioguide_id ?? s.name} sponsor={s} />
-            ))}
+      {primary.map((s) => (
+        <SponsorRow key={s.bioguide_id ?? s.name} sponsor={s} />
+      ))}
 
-            {cosponsors.length > 0 && (
-                <>
-                    {primary.length > 0 && (
-                        <div className="my-1.5 border-t border-gray-100" />
-                    )}
-                    {visibleCosponsors.map((s) => (
-                        <SponsorRow key={s.bioguide_id ?? s.name} sponsor={s} />
-                    ))}
-                    {!expanded && hiddenCount > 0 && (
-                        <button
-                            onClick={() => setExpanded(true)}
-                            className="mt-1 text-xs text-primary-600 hover:text-primary-700 hover:underline"
-                        >
-                            +{hiddenCount} more cosponsor{hiddenCount !== 1 ? 's' : ''}
-                        </button>
-                    )}
-                </>
-            )}
-        </div>
-    );
+      {cosponsors.length > 0 && (
+        <>
+          {primary.length > 0 && (
+            <div className="my-1.5 border-t border-gray-100" />
+          )}
+          {visibleCosponsors.map((s) => (
+            <SponsorRow key={s.bioguide_id ?? s.name} sponsor={s} />
+          ))}
+          {!expanded && hiddenCount > 0 && (
+            <button
+              onClick={() => setExpanded(true)}
+              className="mt-1 text-xs text-primary-600 hover:text-primary-700 hover:underline"
+            >
+              +{hiddenCount} more cosponsor{hiddenCount !== 1 ? 's' : ''}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/law-viewer/TimelineEvent.tsx
+++ b/frontend/src/components/law-viewer/TimelineEvent.tsx
@@ -1,159 +1,213 @@
 import type { TimelineEvent as TimelineEventType } from '@/lib/types';
 
 interface TimelineEventProps {
-    event: TimelineEventType;
+  event: TimelineEventType;
 }
 
 function formatDate(dateStr: string | null): string {
-    if (!dateStr) return '—';
-    // dateStr is YYYY-MM-DD from the API
-    const [year, month, day] = dateStr.split('-');
-    return `${year}.${month}.${day}`;
+  if (!dateStr) return '—';
+  // dateStr is YYYY-MM-DD from the API
+  const [year, month, day] = dateStr.split('-');
+  return `${year}.${month}.${day}`;
 }
 
-function EventIcon({ eventType }: { eventType: TimelineEventType['event_type'] }) {
-    const cls = 'h-4 w-4 shrink-0';
-    switch (eventType) {
-        case 'introduced':
-            return (
-                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <circle cx="8" cy="8" r="6" />
-                    <line x1="8" y1="5" x2="8" y2="8" />
-                    <circle cx="8" cy="10.5" r="0.75" fill="currentColor" stroke="none" />
-                </svg>
-            );
-        case 'committee_referral':
-            return (
-                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <rect x="2" y="3" width="12" height="10" rx="1" />
-                    <line x1="5" y1="7" x2="11" y2="7" />
-                    <line x1="5" y1="10" x2="9" y2="10" />
-                </svg>
-            );
-        case 'house_vote':
-        case 'senate_vote':
-            return (
-                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <path d="M2 12 L8 4 L14 12 Z" />
-                    <line x1="8" y1="4" x2="8" y2="13" />
-                </svg>
-            );
-        case 'presidential_action':
-            return (
-                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <path d="M3 12 L3 7 L8 3 L13 7 L13 12 Z" />
-                    <rect x="6" y="9" width="4" height="3" />
-                </svg>
-            );
-        default:
-            return (
-                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-                    <circle cx="8" cy="8" r="5.5" />
-                    <line x1="8" y1="6" x2="8" y2="10" />
-                </svg>
-            );
-    }
+function EventIcon({
+  eventType,
+}: {
+  eventType: TimelineEventType['event_type'];
+}) {
+  const cls = 'h-4 w-4 shrink-0';
+  switch (eventType) {
+    case 'introduced':
+      return (
+        <svg
+          className={cls}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <circle cx="8" cy="8" r="6" />
+          <line x1="8" y1="5" x2="8" y2="8" />
+          <circle cx="8" cy="10.5" r="0.75" fill="currentColor" stroke="none" />
+        </svg>
+      );
+    case 'committee_referral':
+      return (
+        <svg
+          className={cls}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <rect x="2" y="3" width="12" height="10" rx="1" />
+          <line x1="5" y1="7" x2="11" y2="7" />
+          <line x1="5" y1="10" x2="9" y2="10" />
+        </svg>
+      );
+    case 'house_vote':
+    case 'senate_vote':
+      return (
+        <svg
+          className={cls}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path d="M2 12 L8 4 L14 12 Z" />
+          <line x1="8" y1="4" x2="8" y2="13" />
+        </svg>
+      );
+    case 'presidential_action':
+      return (
+        <svg
+          className={cls}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path d="M3 12 L3 7 L8 3 L13 7 L13 12 Z" />
+          <rect x="6" y="9" width="4" height="3" />
+        </svg>
+      );
+    default:
+      return (
+        <svg
+          className={cls}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <circle cx="8" cy="8" r="5.5" />
+          <line x1="8" y1="6" x2="8" y2="10" />
+        </svg>
+      );
+  }
 }
 
-function EventBadge({ eventType }: { eventType: TimelineEventType['event_type'] }) {
-    let label: string;
-    let cls: string;
+function EventBadge({
+  eventType,
+}: {
+  eventType: TimelineEventType['event_type'];
+}) {
+  let label: string;
+  let cls: string;
 
-    switch (eventType) {
-        case 'house_vote':
-        case 'senate_vote':
-            label = 'VOTE';
-            cls = 'bg-blue-50 text-blue-700 ring-blue-200';
-            break;
-        case 'committee_referral':
-            label = 'COMMITTEE';
-            cls = 'bg-amber-50 text-amber-700 ring-amber-200';
-            break;
-        case 'presidential_action':
-            label = 'EXECUTIVE';
-            cls = 'bg-purple-50 text-purple-700 ring-purple-200';
-            break;
-        case 'introduced':
-            label = 'INTRODUCED';
-            cls = 'bg-green-50 text-green-700 ring-green-200';
-            break;
-        default:
-            label = 'EVENT';
-            cls = 'bg-gray-50 text-gray-600 ring-gray-200';
-    }
+  switch (eventType) {
+    case 'house_vote':
+    case 'senate_vote':
+      label = 'VOTE';
+      cls = 'bg-blue-50 text-blue-700 ring-blue-200';
+      break;
+    case 'committee_referral':
+      label = 'COMMITTEE';
+      cls = 'bg-amber-50 text-amber-700 ring-amber-200';
+      break;
+    case 'presidential_action':
+      label = 'EXECUTIVE';
+      cls = 'bg-purple-50 text-purple-700 ring-purple-200';
+      break;
+    case 'introduced':
+      label = 'INTRODUCED';
+      cls = 'bg-green-50 text-green-700 ring-green-200';
+      break;
+    default:
+      label = 'EVENT';
+      cls = 'bg-gray-50 text-gray-600 ring-gray-200';
+  }
 
-    return (
-        <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset ${cls}`}>
-            {label}
-        </span>
-    );
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset ${cls}`}
+    >
+      {label}
+    </span>
+  );
 }
 
 function VoteTally({ event }: { event: TimelineEventType }) {
-    if (event.vote_yeas == null && event.vote_nays == null) return null;
-    const passed = (event.vote_yeas ?? 0) > (event.vote_nays ?? 0);
-    return (
-        <span className={`text-xs font-medium ${passed ? 'text-green-600' : 'text-red-600'}`}>
-            {passed ? '✓' : '✗'} {event.vote_yeas}–{event.vote_nays}
-            {event.vote_not_voting != null ? `–${event.vote_not_voting}` : ''}
-        </span>
-    );
+  if (event.vote_yeas == null && event.vote_nays == null) return null;
+  const passed = (event.vote_yeas ?? 0) > (event.vote_nays ?? 0);
+  return (
+    <span
+      className={`text-xs font-medium ${passed ? 'text-green-600' : 'text-red-600'}`}
+    >
+      {passed ? '✓' : '✗'} {event.vote_yeas}–{event.vote_nays}
+      {event.vote_not_voting != null ? `–${event.vote_not_voting}` : ''}
+    </span>
+  );
 }
 
 /** A single row in the legislative history timeline. */
 export default function TimelineEvent({ event }: TimelineEventProps) {
-    const iconColor =
-        event.event_type === 'presidential_action'
-            ? 'text-purple-600'
-            : event.event_type === 'introduced'
-              ? 'text-green-600'
-              : event.event_type === 'house_vote' || event.event_type === 'senate_vote'
-                ? 'text-blue-600'
-                : event.event_type === 'committee_referral'
-                  ? 'text-amber-600'
-                  : 'text-gray-400';
+  const iconColor =
+    event.event_type === 'presidential_action'
+      ? 'text-purple-600'
+      : event.event_type === 'introduced'
+        ? 'text-green-600'
+        : event.event_type === 'house_vote' ||
+            event.event_type === 'senate_vote'
+          ? 'text-blue-600'
+          : event.event_type === 'committee_referral'
+            ? 'text-amber-600'
+            : 'text-gray-400';
 
-    return (
-        <div className={`flex gap-3 py-3 ${event.is_milestone ? '' : 'opacity-80'}`}>
-            {/* Icon column */}
-            <div className={`mt-0.5 ${iconColor}`}>
-                <EventIcon eventType={event.event_type} />
-            </div>
+  return (
+    <div
+      className={`flex gap-3 py-3 ${event.is_milestone ? '' : 'opacity-80'}`}
+    >
+      {/* Icon column */}
+      <div className={`mt-0.5 ${iconColor}`}>
+        <EventIcon eventType={event.event_type} />
+      </div>
 
-            {/* Content */}
-            <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-semibold text-gray-900">{event.title}</span>
-                    <EventBadge eventType={event.event_type} />
-                    {event.event_type === 'house_vote' || event.event_type === 'senate_vote' ? (
-                        <VoteTally event={event} />
-                    ) : null}
-                </div>
-
-                <div className="mt-0.5 flex items-center gap-2">
-                    <span className="font-mono text-xs text-gray-400">{formatDate(event.date)}</span>
-                    {event.chamber && (
-                        <span className="text-xs text-gray-400">{event.chamber.toUpperCase()}</span>
-                    )}
-                </div>
-
-                {event.description && (
-                    <p className="mt-1 text-xs leading-relaxed text-gray-600">{event.description}</p>
-                )}
-
-                {event.congressional_record_refs.length > 0 && (
-                    <div className="mt-1 flex flex-wrap gap-1">
-                        {event.congressional_record_refs.map((ref) => (
-                            <span
-                                key={ref}
-                                className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-500"
-                            >
-                                {ref}
-                            </span>
-                        ))}
-                    </div>
-                )}
-            </div>
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-semibold text-gray-900">
+            {event.title}
+          </span>
+          <EventBadge eventType={event.event_type} />
+          {event.event_type === 'house_vote' ||
+          event.event_type === 'senate_vote' ? (
+            <VoteTally event={event} />
+          ) : null}
         </div>
-    );
+
+        <div className="mt-0.5 flex items-center gap-2">
+          <span className="font-mono text-xs text-gray-400">
+            {formatDate(event.date)}
+          </span>
+          {event.chamber && (
+            <span className="text-xs text-gray-400">
+              {event.chamber.toUpperCase()}
+            </span>
+          )}
+        </div>
+
+        {event.description && (
+          <p className="mt-1 text-xs leading-relaxed text-gray-600">
+            {event.description}
+          </p>
+        )}
+
+        {event.congressional_record_refs.length > 0 && (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {event.congressional_record_refs.map((ref) => (
+              <span
+                key={ref}
+                className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-500"
+              >
+                {ref}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/law-viewer/TimelineEvent.tsx
+++ b/frontend/src/components/law-viewer/TimelineEvent.tsx
@@ -1,0 +1,159 @@
+import type { TimelineEvent as TimelineEventType } from '@/lib/types';
+
+interface TimelineEventProps {
+    event: TimelineEventType;
+}
+
+function formatDate(dateStr: string | null): string {
+    if (!dateStr) return '—';
+    // dateStr is YYYY-MM-DD from the API
+    const [year, month, day] = dateStr.split('-');
+    return `${year}.${month}.${day}`;
+}
+
+function EventIcon({ eventType }: { eventType: TimelineEventType['event_type'] }) {
+    const cls = 'h-4 w-4 shrink-0';
+    switch (eventType) {
+        case 'introduced':
+            return (
+                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <circle cx="8" cy="8" r="6" />
+                    <line x1="8" y1="5" x2="8" y2="8" />
+                    <circle cx="8" cy="10.5" r="0.75" fill="currentColor" stroke="none" />
+                </svg>
+            );
+        case 'committee_referral':
+            return (
+                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <rect x="2" y="3" width="12" height="10" rx="1" />
+                    <line x1="5" y1="7" x2="11" y2="7" />
+                    <line x1="5" y1="10" x2="9" y2="10" />
+                </svg>
+            );
+        case 'house_vote':
+        case 'senate_vote':
+            return (
+                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M2 12 L8 4 L14 12 Z" />
+                    <line x1="8" y1="4" x2="8" y2="13" />
+                </svg>
+            );
+        case 'presidential_action':
+            return (
+                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <path d="M3 12 L3 7 L8 3 L13 7 L13 12 Z" />
+                    <rect x="6" y="9" width="4" height="3" />
+                </svg>
+            );
+        default:
+            return (
+                <svg className={cls} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                    <circle cx="8" cy="8" r="5.5" />
+                    <line x1="8" y1="6" x2="8" y2="10" />
+                </svg>
+            );
+    }
+}
+
+function EventBadge({ eventType }: { eventType: TimelineEventType['event_type'] }) {
+    let label: string;
+    let cls: string;
+
+    switch (eventType) {
+        case 'house_vote':
+        case 'senate_vote':
+            label = 'VOTE';
+            cls = 'bg-blue-50 text-blue-700 ring-blue-200';
+            break;
+        case 'committee_referral':
+            label = 'COMMITTEE';
+            cls = 'bg-amber-50 text-amber-700 ring-amber-200';
+            break;
+        case 'presidential_action':
+            label = 'EXECUTIVE';
+            cls = 'bg-purple-50 text-purple-700 ring-purple-200';
+            break;
+        case 'introduced':
+            label = 'INTRODUCED';
+            cls = 'bg-green-50 text-green-700 ring-green-200';
+            break;
+        default:
+            label = 'EVENT';
+            cls = 'bg-gray-50 text-gray-600 ring-gray-200';
+    }
+
+    return (
+        <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset ${cls}`}>
+            {label}
+        </span>
+    );
+}
+
+function VoteTally({ event }: { event: TimelineEventType }) {
+    if (event.vote_yeas == null && event.vote_nays == null) return null;
+    const passed = (event.vote_yeas ?? 0) > (event.vote_nays ?? 0);
+    return (
+        <span className={`text-xs font-medium ${passed ? 'text-green-600' : 'text-red-600'}`}>
+            {passed ? '✓' : '✗'} {event.vote_yeas}–{event.vote_nays}
+            {event.vote_not_voting != null ? `–${event.vote_not_voting}` : ''}
+        </span>
+    );
+}
+
+/** A single row in the legislative history timeline. */
+export default function TimelineEvent({ event }: TimelineEventProps) {
+    const iconColor =
+        event.event_type === 'presidential_action'
+            ? 'text-purple-600'
+            : event.event_type === 'introduced'
+              ? 'text-green-600'
+              : event.event_type === 'house_vote' || event.event_type === 'senate_vote'
+                ? 'text-blue-600'
+                : event.event_type === 'committee_referral'
+                  ? 'text-amber-600'
+                  : 'text-gray-400';
+
+    return (
+        <div className={`flex gap-3 py-3 ${event.is_milestone ? '' : 'opacity-80'}`}>
+            {/* Icon column */}
+            <div className={`mt-0.5 ${iconColor}`}>
+                <EventIcon eventType={event.event_type} />
+            </div>
+
+            {/* Content */}
+            <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold text-gray-900">{event.title}</span>
+                    <EventBadge eventType={event.event_type} />
+                    {event.event_type === 'house_vote' || event.event_type === 'senate_vote' ? (
+                        <VoteTally event={event} />
+                    ) : null}
+                </div>
+
+                <div className="mt-0.5 flex items-center gap-2">
+                    <span className="font-mono text-xs text-gray-400">{formatDate(event.date)}</span>
+                    {event.chamber && (
+                        <span className="text-xs text-gray-400">{event.chamber.toUpperCase()}</span>
+                    )}
+                </div>
+
+                {event.description && (
+                    <p className="mt-1 text-xs leading-relaxed text-gray-600">{event.description}</p>
+                )}
+
+                {event.congressional_record_refs.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                        {event.congressional_record_refs.map((ref) => (
+                            <span
+                                key={ref}
+                                className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-500"
+                            >
+                                {ref}
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/law-viewer/VotesSidebar.tsx
+++ b/frontend/src/components/law-viewer/VotesSidebar.tsx
@@ -1,0 +1,83 @@
+import type { ChamberVote } from '@/lib/types';
+
+interface VotesSidebarProps {
+    votes: ChamberVote[];
+}
+
+function PassIcon() {
+    return (
+        <svg className="h-3.5 w-3.5 text-green-600" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
+            <polyline points="2,7 6,11 12,3" />
+        </svg>
+    );
+}
+
+function FailIcon() {
+    return (
+        <svg className="h-3.5 w-3.5 text-red-600" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
+            <line x1="3" y1="3" x2="11" y2="11" />
+            <line x1="11" y1="3" x2="3" y2="11" />
+        </svg>
+    );
+}
+
+function VoteBar({ yeas, nays, notVoting }: { yeas: number; nays: number; notVoting: number }) {
+    const total = yeas + nays + notVoting;
+    if (total === 0) return null;
+    const yeaPct = (yeas / total) * 100;
+    const nayPct = (nays / total) * 100;
+    return (
+        <div className="mt-1.5 flex h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+            <div className="bg-green-500" style={{ width: `${yeaPct}%` }} />
+            <div className="bg-red-500" style={{ width: `${nayPct}%` }} />
+        </div>
+    );
+}
+
+/** Right-panel vote summary: one row per chamber with yea/nay/abstain counts. */
+export default function VotesSidebar({ votes }: VotesSidebarProps) {
+    if (votes.length === 0) return null;
+
+    return (
+        <div className="rounded-md border border-gray-200 bg-white px-4 py-3">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Passage Votes
+            </h3>
+
+            <div className="space-y-3">
+                {votes.map((v) => {
+                    const passed = v.yeas > v.nays;
+                    return (
+                        <div key={v.chamber}>
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-1.5">
+                                    {passed ? <PassIcon /> : <FailIcon />}
+                                    <span className="text-xs font-semibold uppercase tracking-wide text-gray-700">
+                                        {v.chamber}
+                                    </span>
+                                </div>
+                                <span className={`text-xs font-medium ${passed ? 'text-green-600' : 'text-red-600'}`}>
+                                    {passed ? 'Passed' : 'Failed'}
+                                </span>
+                            </div>
+                            <VoteBar yeas={v.yeas} nays={v.nays} notVoting={v.not_voting} />
+                            <div className="mt-1 flex gap-3 text-[11px] text-gray-500">
+                                <span>
+                                    <span className="font-medium text-green-700">{v.yeas}</span> yeas
+                                </span>
+                                <span>
+                                    <span className="font-medium text-red-700">{v.nays}</span> nays
+                                </span>
+                                {v.not_voting > 0 && (
+                                    <span>
+                                        <span className="font-medium text-gray-700">{v.not_voting}</span> not voting
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/law-viewer/VotesSidebar.tsx
+++ b/frontend/src/components/law-viewer/VotesSidebar.tsx
@@ -1,83 +1,110 @@
 import type { ChamberVote } from '@/lib/types';
 
 interface VotesSidebarProps {
-    votes: ChamberVote[];
+  votes: ChamberVote[];
 }
 
 function PassIcon() {
-    return (
-        <svg className="h-3.5 w-3.5 text-green-600" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
-            <polyline points="2,7 6,11 12,3" />
-        </svg>
-    );
+  return (
+    <svg
+      className="h-3.5 w-3.5 text-green-600"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <polyline points="2,7 6,11 12,3" />
+    </svg>
+  );
 }
 
 function FailIcon() {
-    return (
-        <svg className="h-3.5 w-3.5 text-red-600" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
-            <line x1="3" y1="3" x2="11" y2="11" />
-            <line x1="11" y1="3" x2="3" y2="11" />
-        </svg>
-    );
+  return (
+    <svg
+      className="h-3.5 w-3.5 text-red-600"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <line x1="3" y1="3" x2="11" y2="11" />
+      <line x1="11" y1="3" x2="3" y2="11" />
+    </svg>
+  );
 }
 
-function VoteBar({ yeas, nays, notVoting }: { yeas: number; nays: number; notVoting: number }) {
-    const total = yeas + nays + notVoting;
-    if (total === 0) return null;
-    const yeaPct = (yeas / total) * 100;
-    const nayPct = (nays / total) * 100;
-    return (
-        <div className="mt-1.5 flex h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
-            <div className="bg-green-500" style={{ width: `${yeaPct}%` }} />
-            <div className="bg-red-500" style={{ width: `${nayPct}%` }} />
-        </div>
-    );
+function VoteBar({
+  yeas,
+  nays,
+  notVoting,
+}: {
+  yeas: number;
+  nays: number;
+  notVoting: number;
+}) {
+  const total = yeas + nays + notVoting;
+  if (total === 0) return null;
+  const yeaPct = (yeas / total) * 100;
+  const nayPct = (nays / total) * 100;
+  return (
+    <div className="mt-1.5 flex h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+      <div className="bg-green-500" style={{ width: `${yeaPct}%` }} />
+      <div className="bg-red-500" style={{ width: `${nayPct}%` }} />
+    </div>
+  );
 }
 
 /** Right-panel vote summary: one row per chamber with yea/nay/abstain counts. */
 export default function VotesSidebar({ votes }: VotesSidebarProps) {
-    if (votes.length === 0) return null;
+  if (votes.length === 0) return null;
 
-    return (
-        <div className="rounded-md border border-gray-200 bg-white px-4 py-3">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Passage Votes
-            </h3>
+  return (
+    <div className="rounded-md border border-gray-200 bg-white px-4 py-3">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+        Passage Votes
+      </h3>
 
-            <div className="space-y-3">
-                {votes.map((v) => {
-                    const passed = v.yeas > v.nays;
-                    return (
-                        <div key={v.chamber}>
-                            <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-1.5">
-                                    {passed ? <PassIcon /> : <FailIcon />}
-                                    <span className="text-xs font-semibold uppercase tracking-wide text-gray-700">
-                                        {v.chamber}
-                                    </span>
-                                </div>
-                                <span className={`text-xs font-medium ${passed ? 'text-green-600' : 'text-red-600'}`}>
-                                    {passed ? 'Passed' : 'Failed'}
-                                </span>
-                            </div>
-                            <VoteBar yeas={v.yeas} nays={v.nays} notVoting={v.not_voting} />
-                            <div className="mt-1 flex gap-3 text-[11px] text-gray-500">
-                                <span>
-                                    <span className="font-medium text-green-700">{v.yeas}</span> yeas
-                                </span>
-                                <span>
-                                    <span className="font-medium text-red-700">{v.nays}</span> nays
-                                </span>
-                                {v.not_voting > 0 && (
-                                    <span>
-                                        <span className="font-medium text-gray-700">{v.not_voting}</span> not voting
-                                    </span>
-                                )}
-                            </div>
-                        </div>
-                    );
-                })}
+      <div className="space-y-3">
+        {votes.map((v) => {
+          const passed = v.yeas > v.nays;
+          return (
+            <div key={v.chamber}>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  {passed ? <PassIcon /> : <FailIcon />}
+                  <span className="text-xs font-semibold uppercase tracking-wide text-gray-700">
+                    {v.chamber}
+                  </span>
+                </div>
+                <span
+                  className={`text-xs font-medium ${passed ? 'text-green-600' : 'text-red-600'}`}
+                >
+                  {passed ? 'Passed' : 'Failed'}
+                </span>
+              </div>
+              <VoteBar yeas={v.yeas} nays={v.nays} notVoting={v.not_voting} />
+              <div className="mt-1 flex gap-3 text-[11px] text-gray-500">
+                <span>
+                  <span className="font-medium text-green-700">{v.yeas}</span>{' '}
+                  yeas
+                </span>
+                <span>
+                  <span className="font-medium text-red-700">{v.nays}</span>{' '}
+                  nays
+                </span>
+                {v.not_voting > 0 && (
+                  <span>
+                    <span className="font-medium text-gray-700">
+                      {v.not_voting}
+                    </span>{' '}
+                    not voting
+                  </span>
+                )}
+              </div>
             </div>
-        </div>
-    );
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/hooks/useLaw.ts
+++ b/frontend/src/hooks/useLaw.ts
@@ -5,6 +5,7 @@ import {
   fetchLawText,
   fetchLawAmendments,
   fetchLawDiffs,
+  fetchLawHistory,
 } from '@/lib/api';
 
 /** Fetches all public law summaries. */
@@ -59,6 +60,19 @@ export function useLawDiffs(
   return useQuery({
     queryKey: ['lawDiffs', congress, lawNumber],
     queryFn: () => fetchLawDiffs(congress, lawNumber),
+    enabled,
+  });
+}
+
+/** Fetches the legislative history timeline for a single law. Only fires when enabled. */
+export function useLawHistory(
+  congress: number,
+  lawNumber: string,
+  enabled: boolean = true
+) {
+  return useQuery({
+    queryKey: ['lawHistory', congress, lawNumber],
+    queryFn: () => fetchLawHistory(congress, lawNumber),
     enabled,
   });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   SectionView,
   LawSummary,
   LawText,
+  LegislativeHistory,
   ParsedAmendment,
   SectionDiff,
   HeadRevision,
@@ -163,6 +164,22 @@ export async function fetchLawDiffs(
   if (!res.ok) {
     throw new Error(
       `Failed to fetch diffs for PL ${congress}-${lawNumber}: ${res.status}`
+    );
+  }
+  return res.json();
+}
+
+/** Fetch the legislative history timeline for a public law. */
+export async function fetchLawHistory(
+  congress: number,
+  lawNumber: string
+): Promise<LegislativeHistory> {
+  const res = await fetch(
+    `${API_BASE}/laws/${congress}/${encodeURIComponent(lawNumber)}/history`
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch history for PL ${congress}-${lawNumber}: ${res.status}`
     );
   }
   return res.json();

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -252,56 +252,56 @@ export interface SectionDiff {
 // --- Legislative history types ---
 
 export type HistoryEventType =
-    | 'introduced'
-    | 'committee_referral'
-    | 'house_vote'
-    | 'senate_vote'
-    | 'presidential_action'
-    | 'other';
+  | 'introduced'
+  | 'committee_referral'
+  | 'house_vote'
+  | 'senate_vote'
+  | 'presidential_action'
+  | 'other';
 
 export type LawStatus = 'enacted' | 'vetoed' | 'pending';
 
 /** A single event in a bill's legislative timeline. */
 export interface TimelineEvent {
-    event_type: HistoryEventType;
-    date: string | null;
-    title: string;
-    description: string;
-    chamber: string | null;
-    is_milestone: boolean;
-    vote_yeas: number | null;
-    vote_nays: number | null;
-    vote_not_voting: number | null;
-    congressional_record_refs: string[];
+  event_type: HistoryEventType;
+  date: string | null;
+  title: string;
+  description: string;
+  chamber: string | null;
+  is_milestone: boolean;
+  vote_yeas: number | null;
+  vote_nays: number | null;
+  vote_not_voting: number | null;
+  congressional_record_refs: string[];
 }
 
 /** A bill sponsor or cosponsor. */
 export interface Sponsor {
-    name: string;
-    party: string | null;
-    state: string | null;
-    bioguide_id: string | null;
-    is_primary: boolean;
+  name: string;
+  party: string | null;
+  state: string | null;
+  bioguide_id: string | null;
+  is_primary: boolean;
 }
 
 /** Aggregated vote totals for one chamber's final passage vote. */
 export interface ChamberVote {
-    chamber: string;
-    yeas: number;
-    nays: number;
-    not_voting: number;
+  chamber: string;
+  yeas: number;
+  nays: number;
+  not_voting: number;
 }
 
 /** Full legislative history response for a public law. */
 export interface LegislativeHistory {
-    timeline: TimelineEvent[];
-    sponsors: Sponsor[];
-    chamber_votes: ChamberVote[];
-    presidential_action: string | null;
-    president_name: string | null;
-    enacted_date: string | null;
-    status: LawStatus;
-    congress_url: string | null;
+  timeline: TimelineEvent[];
+  sponsors: Sponsor[];
+  chamber_votes: ChamberVote[];
+  presidential_action: string | null;
+  president_name: string | null;
+  enacted_date: string | null;
+  status: LawStatus;
+  congress_url: string | null;
 }
 
 /** Full section view returned by the section detail endpoint. */

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -249,6 +249,61 @@ export interface SectionDiff {
   all_provisions: DiffLine[];
 }
 
+// --- Legislative history types ---
+
+export type HistoryEventType =
+    | 'introduced'
+    | 'committee_referral'
+    | 'house_vote'
+    | 'senate_vote'
+    | 'presidential_action'
+    | 'other';
+
+export type LawStatus = 'enacted' | 'vetoed' | 'pending';
+
+/** A single event in a bill's legislative timeline. */
+export interface TimelineEvent {
+    event_type: HistoryEventType;
+    date: string | null;
+    title: string;
+    description: string;
+    chamber: string | null;
+    is_milestone: boolean;
+    vote_yeas: number | null;
+    vote_nays: number | null;
+    vote_not_voting: number | null;
+    congressional_record_refs: string[];
+}
+
+/** A bill sponsor or cosponsor. */
+export interface Sponsor {
+    name: string;
+    party: string | null;
+    state: string | null;
+    bioguide_id: string | null;
+    is_primary: boolean;
+}
+
+/** Aggregated vote totals for one chamber's final passage vote. */
+export interface ChamberVote {
+    chamber: string;
+    yeas: number;
+    nays: number;
+    not_voting: number;
+}
+
+/** Full legislative history response for a public law. */
+export interface LegislativeHistory {
+    timeline: TimelineEvent[];
+    sponsors: Sponsor[];
+    chamber_votes: ChamberVote[];
+    presidential_action: string | null;
+    president_name: string | null;
+    enacted_date: string | null;
+    status: LawStatus;
+    congress_url: string | null;
+}
+
 /** Full section view returned by the section detail endpoint. */
 export interface SectionView {
   title_number: number;


### PR DESCRIPTION
## Summary
This PR implements the legislative history feature for the law viewer, closing the following sub-issues of #96:

- Closes #157 — Congress.gov client: `BillAction`, `RecordedVote` dataclasses, `get_bill_actions()` pagination, `_parse_cr_refs()` utility
- Closes #158 — President lookup utility (`president_lookup.py`) with static date-range table (1961–2029)
- Closes #159 — Backend history endpoint: `GET /laws/{congress}/{law_number}/history`, action classification, vote tally parsing, Pydantic schemas
- Closes #160 — Frontend types, `fetchLawHistory()` API function, `useLawHistory()` React Query hook
- Closes #161 — History tab added to law detail page with 2-column (2:1) layout shell; lazy-loaded on tab switch
- Closes #162 — `TimelineEvent` component: inline SVG icons (5 variants), event-type badges, vote tally, CR ref chips, `YYYY.MM.DD` date format
- Closes #163 — `LegislativeHistoryTimeline`: scrollable list with vertical connector, milestone-only default, "Show all N events" toggle
- Closes #164 — `SponsorsSidebar`: primary "Author" badge, cosponsors capped at 5 with expand, R=red / D=blue party coloring
- Closes #165 — `VotesSidebar`: per-chamber yea/nay/not-voting rows, proportional color bar, pass/fail icons
- Closes #166 — Vetoed/pending status banners; presidential action card color-coded by status

## Architecture

### Backend
- **`pipeline/congress/client.py`** — `BillAction` + `RecordedVote` dataclasses, `get_bill_actions()` paginator, CR ref regex
- **`app/core/president_lookup.py`** — Static table, `get_president_by_date()`, `get_president_title()`
- **`app/schemas/law_history.py`** — `TimelineEventSchema`, `SponsorSchema`, `ChamberVoteSchema`, `LegislativeHistorySchema`
- **`app/crud/public_law.py`** — `get_law_history()`: fetches actions + sponsors, classifies events, aggregates chamber votes
- **`app/api/v1/laws.py`** — `GET /{congress}/{law_number}/history` endpoint

### Frontend
- **`lib/types.ts`** — `TimelineEvent`, `Sponsor`, `ChamberVote`, `LegislativeHistory` interfaces
- **`lib/api.ts`** — `fetchLawHistory()`
- **`hooks/useLaw.ts`** — `useLawHistory()` hook
- **`components/law-viewer/`** — `TimelineEvent`, `LegislativeHistoryTimeline`, `SponsorsSidebar`, `VotesSidebar`, `LegislativeHistoryTab`
- **`app/laws/[congress]/[lawNumber]/page.tsx`** — History tab wired in

## Implementation notes
- Timeline events are classified into 6 categories with milestone detection for key moments
- Vote tallies extracted from action text via regex (`392 - 17 - 26`, `95 - 0`, etc.)
- Congressional Record refs parsed and displayed as monospace chips (future: link to govinfo)
- Gracefully degrades if Congress.gov API is unavailable
- President names resolved from static table with `Unknown` fallback for out-of-range dates

https://claude.ai/code/session_011aBk25z9HZkEuRb9S4Vq63