### PR TITLE
perf: bulk-insert section snapshots to eliminate per-row flush latency

### DIFF
--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -13,10 +13,10 @@ import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import NamedTuple
 
-from sqlalchemy import select
+from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.enums import RevisionStatus, RevisionType
@@ -189,7 +189,13 @@ async def ingest_title(
 
     t_normalize = time.monotonic()
 
-    # Build ORM objects and flush (event loop — group_ids now resolved).
+    # Bulk-insert all snapshots in one executemany call instead of individual
+    # session.add() + flush() per row. The ORM UoW emits a separate INSERT
+    # round-trip per object (plus RETURNING for the PK); for large titles
+    # (1000+ sections) that serialises hundreds of network round-trips, which
+    # was the dominant cost (~90% of wall-clock per title in Cloud Run).
+    now = datetime.now(UTC)
+    snapshot_dicts = []
     for row in rows:
         group_id = None
         if row.parent_group_key:
@@ -197,33 +203,36 @@ async def ingest_title(
             if group_record:
                 group_id = group_record.group_id
 
-        snapshot = SectionSnapshot(
-            revision_id=revision_id,
-            title_number=title_num,
-            section_number=row.section_number,
-            heading=row.heading,
-            text_content=row.text_content,
-            normalized_provisions=row.normalized_provisions,
-            notes=row.notes,
-            normalized_notes=row.normalized_notes,
-            text_hash=row.text_hash,
-            notes_hash=row.notes_hash,
-            full_citation=row.full_citation,
-            is_deleted=False,
-            group_id=group_id,
-            sort_order=row.sort_order,
+        snapshot_dicts.append(
+            {
+                "revision_id": revision_id,
+                "title_number": title_num,
+                "section_number": row.section_number,
+                "heading": row.heading,
+                "text_content": row.text_content,
+                "normalized_provisions": row.normalized_provisions,
+                "notes": row.notes,
+                "normalized_notes": row.normalized_notes,
+                "text_hash": row.text_hash,
+                "notes_hash": row.notes_hash,
+                "full_citation": row.full_citation,
+                "is_deleted": False,
+                "group_id": group_id,
+                "sort_order": row.sort_order if row.sort_order is not None else 0,
+                "created_at": now,
+                "updated_at": now,
+            }
         )
-        session.add(snapshot)
 
-    await session.flush()
-    t_flush = time.monotonic()
+    await session.execute(insert(SectionSnapshot), snapshot_dicts)
+    t_insert = time.monotonic()
 
     count = len(rows)
     logger.info(
         f"Title {title_num}: {count} sections ingested "
         f"[download={t_download - t0:.1f}s parse={t_parse - t_download:.1f}s "
         f"groups={t_groups - t_parse:.1f}s normalize={t_normalize - t_groups:.1f}s "
-        f"flush={t_flush - t_normalize:.1f}s total={t_flush - t0:.1f}s]"
+        f"insert={t_insert - t_normalize:.1f}s total={t_insert - t0:.1f}s]"
     )
     return count
 

--- a/backend/tests/pipeline/test_bootstrap.py
+++ b/backend/tests/pipeline/test_bootstrap.py
@@ -66,6 +66,14 @@ def _make_mock_session() -> AsyncMock:
     return session
 
 
+def _get_snapshot_dicts(session: AsyncMock) -> list[dict]:
+    """Extract snapshot insert dicts from session.execute bulk-insert calls."""
+    for call in session.execute.call_args_list:
+        if len(call.args) == 2 and isinstance(call.args[1], list):
+            return call.args[1]
+    return []
+
+
 def _make_mock_downloader(
     xml_path: Path | None = Path("/fake/title17.xml"),
 ) -> MagicMock:
@@ -142,12 +150,11 @@ class TestCreateInitialCommit:
         assert result.titles_processed == 1
         assert result.total_sections == 1
 
-        # Verify session.add was called with OLRCReleasePoint and CodeRevision
+        # Verify session.add was called with OLRCReleasePoint and CodeRevision.
+        # Snapshots are bulk-inserted via session.execute(), not session.add().
         add_calls = session.add.call_args_list
-        # Should have at least: release_point, revision, snapshot(s)
-        assert len(add_calls) >= 3
+        assert len(add_calls) >= 2
 
-        # Check the revision object was added
         added_objects = [call.args[0] for call in add_calls]
         from app.models.revision import CodeRevision
 
@@ -183,18 +190,12 @@ class TestCreateInitialCommit:
 
         assert result.total_sections == 2
 
-        # Check snapshot objects were added
-        add_calls = session.add.call_args_list
-        added_objects = [call.args[0] for call in add_calls]
-
-        from app.models.snapshot import SectionSnapshot
-
-        snapshots = [o for o in added_objects if isinstance(o, SectionSnapshot)]
+        # Snapshots are bulk-inserted via session.execute(insert(...), dicts).
+        snapshots = _get_snapshot_dicts(session)
         assert len(snapshots) == 2
-        assert snapshots[0].section_number == "101"
-        assert snapshots[1].section_number == "102"
-        assert snapshots[0].title_number == 17
-        assert snapshots[1].title_number == 17
+        section_numbers = {s["section_number"] for s in snapshots}
+        assert section_numbers == {"101", "102"}
+        assert all(s["title_number"] == 17 for s in snapshots)
 
     @pytest.mark.asyncio
     async def test_skip_unavailable_titles(self) -> None:
@@ -275,8 +276,11 @@ class TestCreateInitialCommit:
 
         call_count = 0
 
-        def fake_execute(_stmt):
+        def fake_execute(*args):
             nonlocal call_count
+            # Bulk inserts (2 positional args) don't increment the select counter.
+            if len(args) == 2 and isinstance(args[1], list):
+                return MagicMock()
             call_count += 1
             result = MagicMock()
             if call_count == 1:
@@ -337,16 +341,9 @@ class TestSnapshotFieldMapping:
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
-        # Find the snapshot that was added
-        from app.models.snapshot import SectionSnapshot
-
-        added = [
-            call.args[0]
-            for call in session.add.call_args_list
-            if isinstance(call.args[0], SectionSnapshot)
-        ]
-        assert len(added) == 1
-        assert added[0].text_hash == expected_hash
+        snapshots = _get_snapshot_dicts(session)
+        assert len(snapshots) == 1
+        assert snapshots[0]["text_hash"] == expected_hash
 
     @pytest.mark.asyncio
     async def test_snapshot_notes_hash(self) -> None:
@@ -370,16 +367,10 @@ class TestSnapshotFieldMapping:
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
-        from app.models.snapshot import SectionSnapshot
-
-        added = [
-            call.args[0]
-            for call in session.add.call_args_list
-            if isinstance(call.args[0], SectionSnapshot)
-        ]
-        assert len(added) == 1
-        assert added[0].notes_hash == expected_hash
-        assert added[0].notes == notes
+        snapshots = _get_snapshot_dicts(session)
+        assert len(snapshots) == 1
+        assert snapshots[0]["notes_hash"] == expected_hash
+        assert snapshots[0]["notes"] == notes
 
     @pytest.mark.asyncio
     async def test_snapshot_no_notes_hash_when_none(self) -> None:
@@ -400,15 +391,9 @@ class TestSnapshotFieldMapping:
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
-        from app.models.snapshot import SectionSnapshot
-
-        added = [
-            call.args[0]
-            for call in session.add.call_args_list
-            if isinstance(call.args[0], SectionSnapshot)
-        ]
-        assert len(added) == 1
-        assert added[0].notes_hash is None
+        snapshots = _get_snapshot_dicts(session)
+        assert len(snapshots) == 1
+        assert snapshots[0]["notes_hash"] is None
 
     @pytest.mark.asyncio
     async def test_snapshot_full_citation(self) -> None:
@@ -429,16 +414,10 @@ class TestSnapshotFieldMapping:
         ):
             await service.create_initial_commit("113-21", titles=[17])
 
-        from app.models.snapshot import SectionSnapshot
-
-        added = [
-            call.args[0]
-            for call in session.add.call_args_list
-            if isinstance(call.args[0], SectionSnapshot)
-        ]
-        assert len(added) == 1
-        assert added[0].full_citation == "17 U.S.C. § 101"
-        assert added[0].is_deleted is False
+        snapshots = _get_snapshot_dicts(session)
+        assert len(snapshots) == 1
+        assert snapshots[0]["full_citation"] == "17 U.S.C. § 101"
+        assert snapshots[0]["is_deleted"] is False
 
     @pytest.mark.asyncio
     async def test_download_failure_skips_title(self) -> None:


### PR DESCRIPTION
## Context

Cloud Run logs for the `cwlb-seed` job showed flush dominating wall-clock time by an enormous margin:

| Title | Sections | Flush time (before) |
|-------|----------|---------------------|
| 2     | 1213     | **511s** (8.5 min)  |
| 11    | 263      | **229s**            |
| 8     | 352      | **116s**            |
| 6     | 402      | **108s**            |
| 5     | 139      | **88s**             |

Root cause: `ingest_title` was calling `session.add(snapshot)` in a loop then `session.flush()`. SQLAlchemy's ORM unit-of-work emits one `INSERT … RETURNING snapshot_id` network round-trip per object. For 1213 sections over a Cloud Run → Cloud SQL connection (~5ms RTT), that's ~6s of pure latency even with zero DB work — and in practice far worse due to WAL pressure from 4 concurrent title sessions all flushing simultaneously.

## Changes

- **`pipeline/olrc/bootstrap.py`**: Replace the `session.add()` loop + `session.flush()` in `ingest_title` with `session.execute(insert(SectionSnapshot), snapshot_dicts)`. SQLAlchemy 2.x + asyncpg uses `insertmanyvalues` — a batched multi-row INSERT that eliminates per-row round-trips entirely. The timestamp fields (`created_at`, `updated_at`) are supplied explicitly since Python-side ORM defaults don't apply to Core inserts.
- **`tests/pipeline/test_bootstrap.py`**: Update snapshot assertions to inspect the bulk-insert `session.execute()` call args (via new `_get_snapshot_dicts` helper) instead of `session.add()` call args.

## Test plan

- [ ] All 15 bootstrap unit tests pass (`pytest tests/pipeline/test_bootstrap.py`)
- [ ] Full test suite passes (673 tests)
- [ ] Re-run `cwlb-seed` Cloud Run job and confirm `insert=` times in the log are seconds, not minutes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)