### PR TITLE
fix: validate ZIP magic bytes from GCS cache, evict stale HTML entries

### DIFF
--- a/backend/pipeline/cache.py
+++ b/backend/pipeline/cache.py
@@ -150,6 +150,22 @@ class PipelineCache:
             except Exception as e:
                 logger.warning(f"GCS write failed for {key}: {e}")
 
+    def delete(self, key: str) -> None:
+        """Delete a cache entry from both local and GCS."""
+        local = self._local_path(key)
+        if local.exists():
+            local.unlink()
+            logger.debug(f"Cache deleted locally: {key}")
+
+        if self._init_gcs() and self._gcs_bucket is not None:
+            try:
+                blob = self._gcs_bucket.blob(key)
+                if blob.exists():
+                    blob.delete()
+                    logger.debug(f"Cache deleted from GCS: {key}")
+            except Exception as e:
+                logger.warning(f"GCS delete failed for {key}: {e}")
+
     # =========================================================================
     # Local-only helpers (for directory-level checks like OLRC extraction)
     # =========================================================================

--- a/backend/pipeline/olrc/downloader.py
+++ b/backend/pipeline/olrc/downloader.py
@@ -336,21 +336,25 @@ class OLRCDownloader:
             if zip_bytes is None:
                 return None
 
-            # Some titles don't exist at older release points (e.g., Title 54
-            # was enacted in P.L. 113-287, so it's absent from RP 113-21). The
-            # OLRC serves an HTML error page with HTTP 200 in that case, so
-            # validate the ZIP magic bytes before caching — otherwise the
-            # bogus HTML gets stored in GCS and every retry fails the same way.
-            if not zip_bytes.startswith((b"PK\x03\x04", b"PK\x05\x06")):
-                logger.warning(
-                    f"Title {title_number}@{release_point}: response is not a "
-                    "ZIP (likely not codified at this release point), skipping"
-                )
-                return None
+        # Validate ZIP magic bytes regardless of source (OLRC or GCS cache).
+        # The OLRC returns HTTP 200 with an HTML error page for titles that
+        # don't exist at a given release point (e.g. Title 54 was enacted in
+        # P.L. 113-287, so it's absent from RP 113-21). Stale cache entries
+        # written before this check was added would otherwise surface as a
+        # confusing BadZipFile ERROR below.
+        if not zip_bytes.startswith((b"PK\x03\x04", b"PK\x05\x06")):
+            logger.info(
+                f"Title {title_number}@{release_point}: not a ZIP "
+                "(not codified at this release point), skipping"
+            )
+            # Evict the stale cache entry so future runs don't repeat this.
+            if self._cache and source == "GCS cache":
+                self._cache.delete(cache_key)
+            return None
 
-            # Store in cache
-            if self._cache:
-                self._cache.put_bytes(cache_key, zip_bytes)
+        # Cache valid ZIPs (only reached after magic-byte validation passes).
+        if self._cache and source == "OLRC":
+            self._cache.put_bytes(cache_key, zip_bytes)
 
         # Extract ZIP
         try:
@@ -371,9 +375,9 @@ class OLRCDownloader:
                     f"Title {title_number}@{release_point}"
                 )
                 return None
-        except zipfile.BadZipFile as e:
+        except zipfile.BadZipFile:
             logger.error(
-                f"Invalid ZIP file for Title {title_number}@{release_point}: {e}"
+                f"Title {title_number}@{release_point}: corrupt ZIP from {source}"
             )
             return None
 


### PR DESCRIPTION
## Context

Titles absent at old release points (e.g. 52/54 at 113-21, enacted later in P.L. 113-235/287) cause the OLRC to return HTTP 200 with an HTML error page instead of a ZIP. Before this fix, those HTML bytes were cached in GCS. On subsequent runs, the cache hit bypassed the existing magic-byte validation (which only ran on fresh OLRC fetches), fell through to `zipfile.ZipFile(...)`, and logged a misleading `ERROR: Invalid ZIP file` even though skipping is the correct behaviour.

## Changes

**`pipeline/olrc/downloader.py`**
- Move ZIP magic-byte validation outside the OLRC-only fetch block so it applies to GCS cache hits too
- Downgrade log level to `INFO` (absent titles are expected gaps, not errors)
- Evict the stale GCS entry on detection so future runs don't repeat the check
- Move `put_bytes` to after validation so fresh OLRC HTML is never cached in the first place

**`pipeline/cache.py`**
- Add `PipelineCache.delete()` to support cache eviction from both local and GCS

## Test plan

- [x] Full test suite passes (673 tests)
- [x] Re-run seed job — Titles 52/53/54 at 113-21 should log `INFO: not codified at this release point, skipping` instead of `ERROR: Invalid ZIP file`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)