### PR TITLE
Add max-retries flag to Cloud Run seed task deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -252,6 +252,7 @@ jobs:
             --cpu 4 \
             --memory 16Gi \
             --task-timeout 120m \
+            --max-retries 2 \
             --command "bash" \
             --args "scripts/seed.sh" \
             --quiet


### PR DESCRIPTION
## Summary
Added retry configuration to the Cloud Run task deployment for the database seeding script to improve reliability during deployment.

## Key Changes
- Added `--max-retries 2` flag to the Cloud Run deploy command for the seed task
- This allows the seed.sh script to be retried up to 2 times if the initial execution fails

## Implementation Details
The retry flag is applied to the Cloud Run task that executes `scripts/seed.sh`, which helps handle transient failures that may occur during database seeding operations. With a 30-minute task timeout already in place, this adds an additional layer of resilience to the deployment pipeline.

https://claude.ai/code/session_018VuDwmNS8UtMMamESTSSnS