### PR TITLE
Parallelize law detail fetching in GovInfo ingestion service

### DIFF
--- a/backend/pipeline/govinfo/ingestion.py
+++ b/backend/pipeline/govinfo/ingestion.py
@@ -79,12 +79,12 @@ class PublicLawIngestionService:
                     return await self.client.get_public_law_detail(package_id)
 
             fetch_results = await asyncio.gather(
-                *[_fetch_detail(l.package_id) for l in laws],
+                *[_fetch_detail(law.package_id) for law in laws],
                 return_exceptions=True,
             )
 
             # Upsert sequentially to avoid session contention
-            for law_info, result in zip(laws, fetch_results):
+            for law_info, result in zip(laws, fetch_results, strict=True):
                 if isinstance(result, BaseException):
                     logger.error(f"Error fetching {law_info.package_id}: {result}")
                     continue
@@ -216,12 +216,12 @@ class PublicLawIngestionService:
                     return await self.client.get_public_law_detail(package_id)
 
             fetch_results = await asyncio.gather(
-                *[_fetch_detail(l.package_id) for l in laws],
+                *[_fetch_detail(law.package_id) for law in laws],
                 return_exceptions=True,
             )
 
             # Upsert sequentially to avoid session contention
-            for law_info, result in zip(laws, fetch_results):
+            for law_info, result in zip(laws, fetch_results, strict=True):
                 if isinstance(result, BaseException):
                     logger.error(f"Error fetching {law_info.package_id}: {result}")
                     continue

--- a/backend/pipeline/govinfo/ingestion.py
+++ b/backend/pipeline/govinfo/ingestion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import date, datetime
 from typing import TYPE_CHECKING
@@ -70,25 +71,33 @@ class PublicLawIngestionService:
             updated = 0
             skipped = 0
 
-            for law_info in laws:
-                try:
-                    # Get detailed info for each law
-                    detail = await self.client.get_public_law_detail(
-                        law_info.package_id
-                    )
+            # Fetch all law details in parallel, respecting API rate limits
+            sem = asyncio.Semaphore(10)
 
-                    # Upsert the law
-                    was_created = await self._upsert_public_law(detail, force)
+            async def _fetch_detail(package_id: str) -> PLAWPackageDetail:
+                async with sem:
+                    return await self.client.get_public_law_detail(package_id)
+
+            fetch_results = await asyncio.gather(
+                *[_fetch_detail(l.package_id) for l in laws],
+                return_exceptions=True,
+            )
+
+            # Upsert sequentially to avoid session contention
+            for law_info, result in zip(laws, fetch_results):
+                if isinstance(result, BaseException):
+                    logger.error(f"Error fetching {law_info.package_id}: {result}")
+                    continue
+                try:
+                    was_created = await self._upsert_public_law(result, force)
                     if was_created is True:
                         created += 1
                     elif was_created is False:
                         updated += 1
                     else:
                         skipped += 1
-
                 except Exception as e:
                     logger.error(f"Error ingesting {law_info.package_id}: {e}")
-                    continue
 
             log.status = "completed"
             log.completed_at = datetime.utcnow()
@@ -199,12 +208,25 @@ class PublicLawIngestionService:
             updated = 0
             skipped = 0
 
-            for law_info in laws:
+            # Fetch all law details in parallel, respecting API rate limits
+            sem = asyncio.Semaphore(10)
+
+            async def _fetch_detail(package_id: str) -> PLAWPackageDetail:
+                async with sem:
+                    return await self.client.get_public_law_detail(package_id)
+
+            fetch_results = await asyncio.gather(
+                *[_fetch_detail(l.package_id) for l in laws],
+                return_exceptions=True,
+            )
+
+            # Upsert sequentially to avoid session contention
+            for law_info, result in zip(laws, fetch_results):
+                if isinstance(result, BaseException):
+                    logger.error(f"Error fetching {law_info.package_id}: {result}")
+                    continue
                 try:
-                    detail = await self.client.get_public_law_detail(
-                        law_info.package_id
-                    )
-                    was_created = await self._upsert_public_law(detail, force)
+                    was_created = await self._upsert_public_law(result, force)
                     if was_created is True:
                         created += 1
                     elif was_created is False:
@@ -213,7 +235,6 @@ class PublicLawIngestionService:
                         skipped += 1
                 except Exception as e:
                     logger.error(f"Error ingesting {law_info.package_id}: {e}")
-                    continue
 
             log.status = "completed"
             log.completed_at = datetime.utcnow()

--- a/backend/tests/pipeline/test_govinfo.py
+++ b/backend/tests/pipeline/test_govinfo.py
@@ -216,7 +216,9 @@ class TestPublicLawIngestionServiceParallelism:
         mock_session = MagicMock()
         mock_session.add = MagicMock()
         mock_session.flush = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        mock_session.execute = AsyncMock(
+            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        )
         mock_session.commit = AsyncMock()
 
         service = PublicLawIngestionService(session=mock_session, api_key="test-key")
@@ -262,7 +264,9 @@ class TestPublicLawIngestionServiceParallelism:
         mock_session = MagicMock()
         mock_session.add = MagicMock()
         mock_session.flush = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        mock_session.execute = AsyncMock(
+            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        )
         mock_session.commit = AsyncMock()
 
         service = PublicLawIngestionService(session=mock_session, api_key="test-key")
@@ -306,7 +310,9 @@ class TestPublicLawIngestionServiceParallelism:
         mock_session = MagicMock()
         mock_session.add = MagicMock()
         mock_session.flush = AsyncMock()
-        mock_session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        mock_session.execute = AsyncMock(
+            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        )
         mock_session.commit = AsyncMock()
 
         service = PublicLawIngestionService(session=mock_session, api_key="test-key")

--- a/backend/tests/pipeline/test_govinfo.py
+++ b/backend/tests/pipeline/test_govinfo.py
@@ -1,7 +1,8 @@
 """Tests for GovInfo API client."""
 
+import asyncio
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -156,3 +157,169 @@ class TestGovInfoClient:
         package_id = client.build_package_id(118, 5, "private")
 
         assert package_id == "PLAW-118pvt5"
+
+
+def _make_detail(congress: int, law_number: int) -> PLAWPackageDetail:
+    return PLAWPackageDetail(
+        package_id=f"PLAW-{congress}publ{law_number}",
+        congress=congress,
+        law_number=law_number,
+        law_type="public",
+        title=f"Test Law {law_number}",
+        short_title=None,
+        date_issued=datetime(2024, 1, 1),
+        government_author=None,
+        publisher=None,
+        collection_code="PLAW",
+        doc_class="publ",
+        pdf_url=None,
+        xml_url=None,
+        htm_url=None,
+        bill_id=None,
+        statutes_at_large_citation=None,
+        committees=[],
+    )
+
+
+class TestPublicLawIngestionServiceParallelism:
+    """Tests for parallel law detail fetching in PublicLawIngestionService."""
+
+    @pytest.mark.asyncio
+    async def test_ingest_congress_fetches_in_parallel(self) -> None:
+        """All get_public_law_detail calls are issued concurrently via gather."""
+        from pipeline.govinfo.ingestion import PublicLawIngestionService
+
+        details = [_make_detail(119, n) for n in range(1, 4)]
+        law_infos = [
+            PLAWPackageInfo(
+                package_id=d.package_id,
+                congress=d.congress,
+                law_number=d.law_number,
+                law_type=d.law_type,
+                title=d.title,
+                last_modified=datetime(2024, 1, 1),
+            )
+            for d in details
+        ]
+
+        call_order: list[str] = []
+        fetch_started: list[asyncio.Event] = [asyncio.Event() for _ in details]
+        fetch_unblock = asyncio.Event()
+
+        async def fake_get_detail(package_id: str) -> PLAWPackageDetail:
+            idx = next(i for i, d in enumerate(details) if d.package_id == package_id)
+            fetch_started[idx].set()
+            await fetch_unblock.wait()
+            call_order.append(package_id)
+            return details[idx]
+
+        mock_session = MagicMock()
+        mock_session.add = MagicMock()
+        mock_session.flush = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        mock_session.commit = AsyncMock()
+
+        service = PublicLawIngestionService(session=mock_session, api_key="test-key")
+        service.client.get_public_laws_for_congress = AsyncMock(return_value=law_infos)
+        service.client.get_public_law_detail = fake_get_detail
+
+        async def run() -> None:
+            # Unblock fetches once all have started (proving overlap)
+            await asyncio.gather(*[e.wait() for e in fetch_started])
+            fetch_unblock.set()
+
+        await asyncio.gather(
+            service.ingest_congress(119),
+            run(),
+        )
+
+        # All three fetches started before any completed — they overlapped
+        assert len(call_order) == 3
+
+    @pytest.mark.asyncio
+    async def test_ingest_congress_skips_failed_fetches(self) -> None:
+        """A fetch failure for one law is logged and skipped; others succeed."""
+        from pipeline.govinfo.ingestion import PublicLawIngestionService
+
+        good_detail = _make_detail(119, 2)
+        law_infos = [
+            PLAWPackageInfo(
+                package_id=f"PLAW-119publ{n}",
+                congress=119,
+                law_number=n,
+                law_type="public",
+                title=f"Law {n}",
+                last_modified=datetime(2024, 1, 1),
+            )
+            for n in (1, 2)
+        ]
+
+        async def fake_get_detail(package_id: str) -> PLAWPackageDetail:
+            if package_id == "PLAW-119publ1":
+                raise RuntimeError("network error")
+            return good_detail
+
+        mock_session = MagicMock()
+        mock_session.add = MagicMock()
+        mock_session.flush = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        mock_session.commit = AsyncMock()
+
+        service = PublicLawIngestionService(session=mock_session, api_key="test-key")
+        service.client.get_public_laws_for_congress = AsyncMock(return_value=law_infos)
+        service.client.get_public_law_detail = fake_get_detail
+
+        log = await service.ingest_congress(119)
+
+        assert log.status == "completed"
+        assert log.records_created == 1  # only the successful one
+
+    @pytest.mark.asyncio
+    async def test_ingest_recent_laws_fetches_in_parallel(self) -> None:
+        """ingest_recent_laws also issues detail fetches concurrently."""
+        from pipeline.govinfo.ingestion import PublicLawIngestionService
+
+        details = [_make_detail(119, n) for n in range(1, 4)]
+        law_infos = [
+            PLAWPackageInfo(
+                package_id=d.package_id,
+                congress=d.congress,
+                law_number=d.law_number,
+                law_type=d.law_type,
+                title=d.title,
+                last_modified=datetime(2024, 1, 1),
+            )
+            for d in details
+        ]
+
+        fetch_started: list[asyncio.Event] = [asyncio.Event() for _ in details]
+        fetch_unblock = asyncio.Event()
+        call_order: list[str] = []
+
+        async def fake_get_detail(package_id: str) -> PLAWPackageDetail:
+            idx = next(i for i, d in enumerate(details) if d.package_id == package_id)
+            fetch_started[idx].set()
+            await fetch_unblock.wait()
+            call_order.append(package_id)
+            return details[idx]
+
+        mock_session = MagicMock()
+        mock_session.add = MagicMock()
+        mock_session.flush = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+        mock_session.commit = AsyncMock()
+
+        service = PublicLawIngestionService(session=mock_session, api_key="test-key")
+        service.client.get_public_laws = AsyncMock(return_value=law_infos)
+        service.client.get_public_law_detail = fake_get_detail
+
+        async def run() -> None:
+            await asyncio.gather(*[e.wait() for e in fetch_started])
+            fetch_unblock.set()
+
+        await asyncio.gather(
+            service.ingest_recent_laws(days=7),
+            run(),
+        )
+
+        assert len(call_order) == 3


### PR DESCRIPTION
## Summary
Refactored the `PublicLawIngestionService` to fetch law details concurrently instead of sequentially, improving performance while maintaining API rate limiting and proper error handling.

## Key Changes
- **Parallel fetching**: Both `ingest_congress()` and `ingest_recent_laws()` now use `asyncio.gather()` to fetch all law details concurrently
- **Rate limiting**: Implemented a semaphore with a limit of 10 concurrent requests to respect API rate limits
- **Error handling**: Individual fetch failures are now logged and skipped without blocking other fetches; the ingestion continues with remaining laws
- **Sequential upserting**: Database operations remain sequential to avoid session contention, while network I/O is parallelized
- **Comprehensive tests**: Added three new async test cases verifying:
  - Concurrent fetches overlap as expected
  - Failed fetches are properly logged and skipped
  - Both `ingest_congress()` and `ingest_recent_laws()` use parallel fetching

## Implementation Details
- Uses `asyncio.Semaphore(10)` to limit concurrent API requests
- Wraps individual fetch calls in a semaphore context manager
- Uses `asyncio.gather(..., return_exceptions=True)` to collect all results including exceptions
- Processes results sequentially for database operations, checking for exceptions before upserting
- Maintains backward compatibility with existing error logging patterns

https://claude.ai/code/session_01GqmfjkV1YFVQrSy6fTe7oS