### PR TITLE
Parallelize law ingestion in seed command using asyncio.gather

### DIFF
--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -237,22 +237,38 @@ async def seed_laws_command() -> int:
     print(f"\nSeeding {len(SEED_LAWS)} Public Laws...")
     print()
 
-    failed = 0
-    async with async_session_maker() as session:
-        service = PublicLawIngestionService(session, cache=_cli_cache)
-        for congress, law_number, _default_title, short_name in SEED_LAWS:
-            label = f"PL {congress}-{law_number}"
+    async def _ingest_one(
+        congress: int, law_number: int, short_name: str
+    ) -> tuple[str, str, str]:
+        label = f"PL {congress}-{law_number}"
+        async with async_session_maker() as session:
+            service = PublicLawIngestionService(session, cache=_cli_cache)
             try:
                 log = await service.ingest_law(congress, law_number, force=False)
                 if log.status in ("completed", "skipped"):
                     status = "ok" if log.status == "completed" else "exists"
-                    print(f"  [{status:<6}] {label:<14} {short_name}")
+                    return (label, short_name, status)
                 else:
-                    print(f"  [FAIL  ] {label:<14} {short_name}: {log.error_message}")
-                    failed += 1
+                    return (label, short_name, f"FAIL\x00{log.error_message}")
             except Exception as exc:
-                print(f"  [ERROR ] {label:<14} {short_name}: {exc}")
-                failed += 1
+                return (label, short_name, f"ERROR\x00{exc}")
+
+    tasks = [
+        _ingest_one(congress, law_number, short_name)
+        for congress, law_number, _default_title, short_name in SEED_LAWS
+    ]
+    results = await asyncio.gather(*tasks)
+
+    failed = 0
+    for label, short_name, status in results:
+        if status.startswith("FAIL\x00"):
+            print(f"  [FAIL  ] {label:<14} {short_name}: {status[5:]}")
+            failed += 1
+        elif status.startswith("ERROR\x00"):
+            print(f"  [ERROR ] {label:<14} {short_name}: {status[6:]}")
+            failed += 1
+        else:
+            print(f"  [{status:<6}] {label:<14} {short_name}")
 
     print()
     if failed:


### PR DESCRIPTION
## Summary
Refactored the `seed_laws_command` to parallelize law ingestion operations using `asyncio.gather()` instead of processing laws sequentially. This improves performance by allowing multiple law ingestion tasks to run concurrently.

## Key Changes
- Extracted law ingestion logic into a new `_ingest_one()` async function that returns results as tuples instead of printing directly
- Changed from sequential processing (for loop with immediate prints) to concurrent processing using `asyncio.gather()`
- Each ingestion task now creates its own database session, enabling safe parallel execution
- Deferred all output printing until after all ingestion tasks complete, processing results in a separate loop
- Used null byte (`\x00`) as a delimiter in status strings to encode error messages within the return tuple

## Implementation Details
- The `_ingest_one()` function encapsulates the ingestion logic and returns a tuple of `(label, short_name, status)` where status is either a simple status string ("ok", "exists") or an error message prefixed with "FAIL\x00" or "ERROR\x00"
- Results are collected via `asyncio.gather(*tasks)` which waits for all concurrent operations to complete
- The final result processing loop handles formatting and printing, maintaining the same output format as before
- Error counting and reporting logic remains unchanged

https://claude.ai/code/session_01DmYcZbVRU8jkTzUN3o8QCy