### PR TITLE
Add cross-reference linking between note categories

### DIFF
--- a/frontend/src/components/viewer/NoteBlock.tsx
+++ b/frontend/src/components/viewer/NoteBlock.tsx
@@ -24,7 +24,6 @@ function renderContent(
   const segments = findNoteLinks(content, crossRefs, note.category, basePath);
   if (segments.length === 0) return content;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const nodes: any[] = [];
   let pos = 0;
   for (const seg of segments) {

--- a/frontend/src/components/viewer/NoteBlock.tsx
+++ b/frontend/src/components/viewer/NoteBlock.tsx
@@ -1,17 +1,62 @@
+import Link from 'next/link';
 import type { SectionNote, CodeLine } from '@/lib/types';
+import { findNoteLinks, type CrossRefLookup } from '@/lib/noteUtils';
 
 interface NoteBlockProps {
   note: SectionNote;
   lineNumberOffset?: number;
+  crossRefs?: CrossRefLookup;
+  basePath?: string;
+}
+
+/**
+ * Render line content, hyperlinking any cross-references to other note files.
+ * Returns a plain string when there are no cross-refs to avoid unnecessary JSX.
+ */
+function renderContent(
+  content: string,
+  note: SectionNote,
+  crossRefs: CrossRefLookup | undefined,
+  basePath: string | undefined
+) {
+  if (!crossRefs || !basePath || crossRefs.size === 0) return content;
+
+  const segments = findNoteLinks(content, crossRefs, note.category, basePath);
+  if (segments.length === 0) return content;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nodes: any[] = [];
+  let pos = 0;
+  for (const seg of segments) {
+    if (seg.start > pos) nodes.push(content.slice(pos, seg.start));
+    nodes.push(
+      <Link
+        key={seg.start}
+        href={seg.url}
+        className="text-blue-600 hover:underline"
+      >
+        {seg.text}
+      </Link>
+    );
+    pos = seg.end;
+  }
+  if (pos < content.length) nodes.push(content.slice(pos));
+  return <>{nodes}</>;
 }
 
 /** Renders a single line with line number and optional indent. */
 function NoteLine({
   lineNumber,
   line,
+  note,
+  crossRefs,
+  basePath,
 }: {
   lineNumber: number;
   line: CodeLine;
+  note: SectionNote;
+  crossRefs?: CrossRefLookup;
+  basePath?: string;
 }) {
   const indent = line.indent_level > 0 ? '\t'.repeat(line.indent_level) : '';
   const isListItem = line.marker !== null;
@@ -28,9 +73,11 @@ function NoteLine({
         className={`min-w-0 whitespace-pre-wrap text-gray-800${isListItem ? ' pl-[4ch] -indent-[4ch]' : ''}`}
       >
         {line.is_header ? (
-          <span className="font-semibold">{line.content}</span>
+          <span className="font-semibold">
+            {renderContent(line.content, note, crossRefs, basePath)}
+          </span>
         ) : (
-          line.content
+          renderContent(line.content, note, crossRefs, basePath)
         )}
       </span>
     </div>
@@ -41,6 +88,8 @@ function NoteLine({
 export default function NoteBlock({
   note,
   lineNumberOffset = 1,
+  crossRefs,
+  basePath,
 }: NoteBlockProps) {
   if (note.lines.length > 0) {
     return (
@@ -50,6 +99,9 @@ export default function NoteBlock({
             key={line.line_number}
             lineNumber={lineNumberOffset + i}
             line={line}
+            note={note}
+            crossRefs={crossRefs}
+            basePath={basePath}
           />
         ))}
       </div>
@@ -71,6 +123,9 @@ export default function NoteBlock({
             marker: null,
             is_header: false,
           }}
+          note={note}
+          crossRefs={crossRefs}
+          basePath={basePath}
         />
       ))}
     </div>

--- a/frontend/src/components/viewer/NotesViewer.test.tsx
+++ b/frontend/src/components/viewer/NotesViewer.test.tsx
@@ -169,6 +169,64 @@ describe('NotesViewer', () => {
     });
   });
 
+  it('hyperlinks cross-references to other note categories', async () => {
+    const crossRefData: SectionView = {
+      ...sectionData,
+      title_number: 50,
+      section_number: '541',
+      notes: {
+        ...sectionData.notes!,
+        notes: [
+          {
+            header: 'References in Text',
+            content: '',
+            lines: [
+              {
+                line_number: 1,
+                content:
+                  'See Effective and Termination Date note below.',
+                indent_level: 0,
+                marker: null,
+                is_header: false,
+              },
+            ],
+            category: 'editorial',
+          },
+          {
+            header: 'Effective and Termination Date',
+            content: 'Act expires on Jan. 1, 2030.',
+            lines: [],
+            category: 'statutory',
+          },
+        ],
+      },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(crossRefData), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    render(
+      <NotesViewer
+        titleNumber={50}
+        sectionNumber="541"
+        file="EDITORIAL_NOTES"
+      />,
+      { wrapper }
+    );
+    await waitFor(() => {
+      expect(screen.getByText('References in Text')).toBeInTheDocument();
+    });
+    const link = screen.getByRole('link', {
+      name: /Effective and Termination Date note below/i,
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      '/sections/50/541/STATUTORY_NOTES#effective-and-termination-date'
+    );
+  });
+
   it('shows error state on fetch failure', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('', { status: 500 })

--- a/frontend/src/components/viewer/NotesViewer.test.tsx
+++ b/frontend/src/components/viewer/NotesViewer.test.tsx
@@ -183,8 +183,7 @@ describe('NotesViewer', () => {
             lines: [
               {
                 line_number: 1,
-                content:
-                  'See Effective and Termination Date note below.',
+                content: 'See Effective and Termination Date note below.',
                 indent_level: 0,
                 marker: null,
                 is_header: false,

--- a/frontend/src/components/viewer/NotesViewer.tsx
+++ b/frontend/src/components/viewer/NotesViewer.tsx
@@ -45,9 +45,8 @@ export default function NotesViewer({
     return <p className="text-red-600">Failed to load section.</p>;
   }
 
-  const filtered = (data.notes?.notes ?? []).filter(
-    (n) => n.category === category
-  );
+  const allNotes: SectionNote[] = data.notes?.notes ?? [];
+  const filtered = allNotes.filter((n) => n.category === category);
 
   const fullCitation = data.full_citation ?? '';
   const heading = data.heading ?? '';
@@ -61,12 +60,16 @@ export default function NotesViewer({
     );
   }
 
+  const basePath = `/sections/${titleNumber}/${encodeURIComponent(sectionNumber)}`;
+
   return (
     <SectionNotes
       notes={filtered}
       fullCitation={fullCitation}
       heading={heading}
       categoryLabel={categoryLabel}
+      allNotes={allNotes}
+      basePath={basePath}
     />
   );
 }

--- a/frontend/src/components/viewer/SectionNotes.tsx
+++ b/frontend/src/components/viewer/SectionNotes.tsx
@@ -1,4 +1,5 @@
 import type { SectionNote } from '@/lib/types';
+import { buildCrossRefLookup, slugify, type CrossRefLookup } from '@/lib/noteUtils';
 import NoteBlock from './NoteBlock';
 
 interface SectionNotesProps {
@@ -6,6 +7,8 @@ interface SectionNotesProps {
   fullCitation: string;
   heading: string;
   categoryLabel: string;
+  allNotes?: SectionNote[];
+  basePath?: string;
 }
 
 /** Count lines a note will render. */
@@ -20,8 +23,13 @@ export default function SectionNotes({
   fullCitation,
   heading,
   categoryLabel,
+  allNotes,
+  basePath,
 }: SectionNotesProps) {
   if (notes.length === 0) return null;
+
+  const crossRefs: CrossRefLookup =
+    allNotes && basePath ? buildCrossRefLookup(allNotes, basePath) : new Map();
 
   const docstring = [fullCitation, heading, categoryLabel];
   const blankLineNumber = docstring.length + 1;
@@ -54,7 +62,7 @@ export default function SectionNotes({
         lineNumber += noteLineCount(note);
 
         return (
-          <div key={i}>
+          <div key={i} id={slugify(note.header)}>
             <div className="flex">
               <span className="w-10 shrink-0 select-none text-right text-gray-400">
                 {headerLineNum}
@@ -62,7 +70,12 @@ export default function SectionNotes({
               <span className="mx-2 select-none text-gray-400">|</span>
               <span className="font-semibold text-gray-900">{note.header}</span>
             </div>
-            <NoteBlock note={note} lineNumberOffset={contentOffset} />
+            <NoteBlock
+              note={note}
+              lineNumberOffset={contentOffset}
+              crossRefs={crossRefs}
+              basePath={basePath}
+            />
           </div>
         );
       })}

--- a/frontend/src/components/viewer/SectionNotes.tsx
+++ b/frontend/src/components/viewer/SectionNotes.tsx
@@ -1,5 +1,9 @@
 import type { SectionNote } from '@/lib/types';
-import { buildCrossRefLookup, slugify, type CrossRefLookup } from '@/lib/noteUtils';
+import {
+  buildCrossRefLookup,
+  slugify,
+  type CrossRefLookup,
+} from '@/lib/noteUtils';
 import NoteBlock from './NoteBlock';
 
 interface SectionNotesProps {

--- a/frontend/src/lib/noteUtils.test.ts
+++ b/frontend/src/lib/noteUtils.test.ts
@@ -97,8 +97,7 @@ describe('findNoteLinks', () => {
   const lookup = buildCrossRefLookup(allNotes, basePath);
 
   it('detects named note reference with direction', () => {
-    const content =
-      'See Effective and Termination Date note below.';
+    const content = 'See Effective and Termination Date note below.';
     const matches = findNoteLinks(content, lookup, 'editorial', basePath);
     expect(matches).toHaveLength(1);
     expect(matches[0].text).toBe('Effective and Termination Date note below');

--- a/frontend/src/lib/noteUtils.test.ts
+++ b/frontend/src/lib/noteUtils.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  slugify,
+  buildCrossRefLookup,
+  getDirectionalUrl,
+  findNoteLinks,
+} from './noteUtils';
+import type { SectionNote } from './types';
+
+describe('slugify', () => {
+  it('lowercases and replaces spaces with dashes', () => {
+    expect(slugify('Effective and Termination Date')).toBe(
+      'effective-and-termination-date'
+    );
+  });
+
+  it('removes non-word characters', () => {
+    expect(slugify('References in Text')).toBe('references-in-text');
+  });
+
+  it('collapses multiple dashes', () => {
+    expect(slugify('Short  Title')).toBe('short-title');
+  });
+
+  it('handles a single word', () => {
+    expect(slugify('Amendments')).toBe('amendments');
+  });
+});
+
+const basePath = '/sections/50/541';
+
+const allNotes: Pick<SectionNote, 'header' | 'category'>[] = [
+  { header: 'References in Text', category: 'editorial' },
+  { header: 'Codification', category: 'editorial' },
+  { header: 'Effective and Termination Date', category: 'statutory' },
+  { header: 'Short Title', category: 'statutory' },
+];
+
+describe('buildCrossRefLookup', () => {
+  it('maps each header slug to its URL with anchor', () => {
+    const lookup = buildCrossRefLookup(allNotes, basePath);
+    expect(lookup.get('references-in-text')?.url).toBe(
+      '/sections/50/541/EDITORIAL_NOTES#references-in-text'
+    );
+    expect(lookup.get('effective-and-termination-date')?.url).toBe(
+      '/sections/50/541/STATUTORY_NOTES#effective-and-termination-date'
+    );
+  });
+
+  it('stores the original header and category', () => {
+    const lookup = buildCrossRefLookup(allNotes, basePath);
+    const ref = lookup.get('short-title');
+    expect(ref?.header).toBe('Short Title');
+    expect(ref?.category).toBe('statutory');
+  });
+
+  it('returns an empty map for empty input', () => {
+    expect(buildCrossRefLookup([], basePath).size).toBe(0);
+  });
+});
+
+describe('getDirectionalUrl', () => {
+  const available = new Set(['editorial', 'statutory']);
+
+  it('returns statutory URL for "below" from editorial', () => {
+    const url = getDirectionalUrl('below', 'editorial', available, basePath);
+    expect(url).toBe('/sections/50/541/STATUTORY_NOTES');
+  });
+
+  it('returns null for "below" from statutory (nothing below)', () => {
+    const url = getDirectionalUrl('below', 'statutory', available, basePath);
+    expect(url).toBeNull();
+  });
+
+  it('returns editorial URL for "above" from statutory', () => {
+    const url = getDirectionalUrl('above', 'statutory', available, basePath);
+    expect(url).toBe('/sections/50/541/EDITORIAL_NOTES');
+  });
+
+  it('skips categories not in the available set', () => {
+    const url = getDirectionalUrl(
+      'below',
+      'historical',
+      new Set(['statutory']),
+      basePath
+    );
+    expect(url).toBe('/sections/50/541/STATUTORY_NOTES');
+  });
+
+  it('returns null for unknown category', () => {
+    const url = getDirectionalUrl('below', 'unknown', available, basePath);
+    expect(url).toBeNull();
+  });
+});
+
+describe('findNoteLinks', () => {
+  const lookup = buildCrossRefLookup(allNotes, basePath);
+
+  it('detects named note reference with direction', () => {
+    const content =
+      'See Effective and Termination Date note below.';
+    const matches = findNoteLinks(content, lookup, 'editorial', basePath);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('Effective and Termination Date note below');
+    expect(matches[0].url).toBe(
+      '/sections/50/541/STATUTORY_NOTES#effective-and-termination-date'
+    );
+  });
+
+  it('detects named note reference without direction', () => {
+    const content = 'See Effective and Termination Date note.';
+    const matches = findNoteLinks(content, lookup, 'editorial', basePath);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('Effective and Termination Date note');
+  });
+
+  it('detects bare directional reference "note below"', () => {
+    const content = 'See note below.';
+    const matches = findNoteLinks(content, lookup, 'editorial', basePath);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('note below');
+    expect(matches[0].url).toBe('/sections/50/541/STATUTORY_NOTES');
+  });
+
+  it('detects "note set out below" variant', () => {
+    const content = 'see note set out below for details.';
+    const matches = findNoteLinks(content, lookup, 'editorial', basePath);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('note set out below');
+    expect(matches[0].url).toBe('/sections/50/541/STATUTORY_NOTES');
+  });
+
+  it('does not link same-category notes', () => {
+    // "References in Text" is also editorial — should not be linked from editorial
+    const content = 'See References in Text note below.';
+    const matches = findNoteLinks(content, lookup, 'editorial', basePath);
+    // "note below" (bare directional) should still match
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('note below');
+  });
+
+  it('returns no matches when content has no cross-references', () => {
+    const content = 'Pub. L. 91-452 amended this section.';
+    const matches = findNoteLinks(content, lookup, 'editorial', basePath);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('returns empty for an empty crossRefs map', () => {
+    const matches = findNoteLinks(
+      'See note below.',
+      new Map(),
+      'editorial',
+      basePath
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  it('does not double-match a named reference as also a bare directional', () => {
+    const content = 'See Effective and Termination Date note below.';
+    const matches = findNoteLinks(content, lookup, 'editorial', basePath);
+    expect(matches).toHaveLength(1);
+  });
+});

--- a/frontend/src/lib/noteUtils.ts
+++ b/frontend/src/lib/noteUtils.ts
@@ -105,7 +105,12 @@ export function findNoteLinks(
     );
     let m: RegExpExecArray | null;
     while ((m = pattern.exec(content)) !== null) {
-      matches.push({ start: m.index, end: m.index + m[0].length, url: ref.url, text: m[0] });
+      matches.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        url: ref.url,
+        text: m[0],
+      });
     }
   }
 
@@ -119,10 +124,17 @@ export function findNoteLinks(
   while ((dm = dirPattern.exec(content)) !== null) {
     const start = dm.index;
     const end = dm.index + dm[0].length;
-    const alreadyCovered = matches.some((m) => start >= m.start && end <= m.end);
+    const alreadyCovered = matches.some(
+      (m) => start >= m.start && end <= m.end
+    );
     if (alreadyCovered) continue;
     const direction = dm[1].toLowerCase() as 'below' | 'above';
-    const url = getDirectionalUrl(direction, currentCategory, availableCategories, basePath);
+    const url = getDirectionalUrl(
+      direction,
+      currentCategory,
+      availableCategories,
+      basePath
+    );
     if (url) {
       matches.push({ start, end, url, text: dm[0] });
     }

--- a/frontend/src/lib/noteUtils.ts
+++ b/frontend/src/lib/noteUtils.ts
@@ -1,0 +1,142 @@
+import type { SectionNote } from '@/lib/types';
+
+const CATEGORY_ORDER = ['historical', 'editorial', 'statutory'] as const;
+type NoteCategory = (typeof CATEGORY_ORDER)[number];
+
+const CATEGORY_TO_FILE: Record<NoteCategory, string> = {
+  historical: 'HISTORICAL_NOTES',
+  editorial: 'EDITORIAL_NOTES',
+  statutory: 'STATUTORY_NOTES',
+};
+
+/** Convert a note header to a URL-safe anchor slug. */
+export function slugify(header: string): string {
+  return header
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+export interface CrossRef {
+  url: string;
+  header: string;
+  category: NoteCategory;
+}
+
+/** Maps slugified note header → cross-ref target. */
+export type CrossRefLookup = Map<string, CrossRef>;
+
+/** Build a lookup of all note headers → their URL (including anchor). */
+export function buildCrossRefLookup(
+  allNotes: Pick<SectionNote, 'header' | 'category'>[],
+  basePath: string
+): CrossRefLookup {
+  const lookup = new Map<string, CrossRef>();
+  for (const note of allNotes) {
+    const category = note.category as NoteCategory;
+    const file = CATEGORY_TO_FILE[category];
+    if (!file) continue;
+    const anchor = slugify(note.header);
+    lookup.set(anchor, {
+      url: `${basePath}/${file}#${anchor}`,
+      header: note.header,
+      category,
+    });
+  }
+  return lookup;
+}
+
+/** Return the URL for the next/previous note category (for bare "note below/above"). */
+export function getDirectionalUrl(
+  direction: 'below' | 'above',
+  currentCategory: string,
+  availableCategories: Set<string>,
+  basePath: string
+): string | null {
+  const idx = CATEGORY_ORDER.indexOf(currentCategory as NoteCategory);
+  if (idx === -1) return null;
+  if (direction === 'below') {
+    for (let i = idx + 1; i < CATEGORY_ORDER.length; i++) {
+      const cat = CATEGORY_ORDER[i];
+      if (availableCategories.has(cat)) {
+        return `${basePath}/${CATEGORY_TO_FILE[cat]}`;
+      }
+    }
+  } else {
+    for (let i = idx - 1; i >= 0; i--) {
+      const cat = CATEGORY_ORDER[i];
+      if (availableCategories.has(cat)) {
+        return `${basePath}/${CATEGORY_TO_FILE[cat]}`;
+      }
+    }
+  }
+  return null;
+}
+
+interface MatchSegment {
+  start: number;
+  end: number;
+  url: string;
+  text: string;
+}
+
+/**
+ * Parse a content string and return segments that should be rendered as links.
+ * Named note references (e.g. "Effective and Termination Date note below") take
+ * priority over bare directional references ("note below").
+ */
+export function findNoteLinks(
+  content: string,
+  crossRefs: CrossRefLookup,
+  currentCategory: string,
+  basePath: string
+): MatchSegment[] {
+  const matches: MatchSegment[] = [];
+
+  // 1. Named note references: "<header> note[ below|above|set out below|set out above]"
+  for (const ref of crossRefs.values()) {
+    if (ref.category === currentCategory) continue;
+    const escaped = ref.header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(
+      `${escaped}\\s+note(?:\\s+(?:set\\s+out\\s+)?(?:below|above))?`,
+      'gi'
+    );
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(content)) !== null) {
+      matches.push({ start: m.index, end: m.index + m[0].length, url: ref.url, text: m[0] });
+    }
+  }
+
+  // 2. Bare directional references: "note [set out] below|above"
+  //    Only if not already covered by a named match.
+  const availableCategories = new Set(
+    Array.from(crossRefs.values()).map((r) => r.category as string)
+  );
+  const dirPattern = /\bnote(?:\s+set\s+out)?\s+(below|above)\b/gi;
+  let dm: RegExpExecArray | null;
+  while ((dm = dirPattern.exec(content)) !== null) {
+    const start = dm.index;
+    const end = dm.index + dm[0].length;
+    const alreadyCovered = matches.some((m) => start >= m.start && end <= m.end);
+    if (alreadyCovered) continue;
+    const direction = dm[1].toLowerCase() as 'below' | 'above';
+    const url = getDirectionalUrl(direction, currentCategory, availableCategories, basePath);
+    if (url) {
+      matches.push({ start, end, url, text: dm[0] });
+    }
+  }
+
+  if (matches.length === 0) return [];
+
+  // Sort by start position, then remove overlaps (keep first occurrence).
+  matches.sort((a, b) => a.start - b.start || b.end - a.end);
+  const result: MatchSegment[] = [matches[0]];
+  for (let i = 1; i < matches.length; i++) {
+    if (matches[i].start >= result[result.length - 1].end) {
+      result.push(matches[i]);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
This PR adds automatic hyperlinking of cross-references between different note categories (historical, editorial, and statutory notes). When a note references another note category (e.g., "See Effective and Termination Date note below"), it now renders as a clickable link to that note.

## Key Changes

- **New `noteUtils` module** (`noteUtils.ts`): Core utilities for handling note cross-references
  - `slugify()`: Converts note headers to URL-safe anchors
  - `buildCrossRefLookup()`: Creates a map of all note headers to their URLs
  - `getDirectionalUrl()`: Resolves directional references ("above"/"below") to the appropriate note category
  - `findNoteLinks()`: Parses content to identify linkable cross-references with intelligent pattern matching

- **Updated `NoteBlock` component**: Now renders cross-reference links inline
  - Added `renderContent()` helper to convert matched segments into `<Link>` components
  - Passes cross-reference data through component hierarchy

- **Updated `SectionNotes` component**: Builds and passes cross-reference lookup to note blocks
  - Adds anchor IDs to note headers for direct linking

- **Updated `NotesViewer` component**: Collects all notes and provides base path for cross-reference resolution

- **Comprehensive test coverage** (`noteUtils.test.ts`): 
  - Tests for all utility functions with various edge cases
  - Tests for named references, directional references, and overlap prevention

## Implementation Details

- Named note references (e.g., "Effective and Termination Date note below") take priority over bare directional references ("note below") to prevent double-linking
- Same-category references are intentionally not linked (e.g., editorial notes don't link to other editorial notes)
- The category order (historical → editorial → statutory) determines which category is "above" or "below"
- Overlapping matches are deduplicated, keeping the first occurrence
- Links use Next.js `<Link>` component with anchor fragments for smooth navigation

https://claude.ai/code/session_01X555ixLcR7C7mpAYFmwGxY