### PR TITLE
Add CBO estimates, related bills panels, and amendment timeline events

### DIFF
--- a/frontend/src/components/law-viewer/CBOEstimatesPanel.tsx
+++ b/frontend/src/components/law-viewer/CBOEstimatesPanel.tsx
@@ -1,0 +1,62 @@
+import type { CBOEstimate } from '@/lib/types';
+
+interface CBOEstimatesPanelProps {
+  estimates: CBOEstimate[];
+}
+
+const MONTH_ABBRS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+function formatPubDate(dateStr: string | null): string {
+  if (!dateStr) return '';
+  const [year, month] = dateStr.split('-');
+  const monthIndex = parseInt(month, 10) - 1;
+  const monthAbbr = MONTH_ABBRS[monthIndex] ?? month;
+  return `${monthAbbr} ${year}`;
+}
+
+/** GitHub-style CI-checks panel listing CBO cost estimates for a bill. */
+export default function CBOEstimatesPanel({ estimates }: CBOEstimatesPanelProps) {
+  if (estimates.length === 0) return null;
+
+  return (
+    <div className="rounded-md border border-gray-200 bg-white">
+      <div className="border-b border-gray-100 px-4 py-2.5">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+          CBO Analysis
+        </h3>
+      </div>
+      <div className="divide-y divide-gray-100">
+        {estimates.map((est, i) => (
+          <div key={i} className="px-4 py-3">
+            <div className="flex items-start gap-2">
+              <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-baseline gap-2">
+                  <p className="text-xs font-medium text-gray-800">{est.title}</p>
+                  {est.pub_date && (
+                    <span className="font-mono text-[11px] text-gray-400">
+                      {formatPubDate(est.pub_date)}
+                    </span>
+                  )}
+                </div>
+                {est.url && (
+                  <a
+                    href={est.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-1 inline-block text-[11px] text-blue-600 hover:underline"
+                  >
+                    View estimate →
+                  </a>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/law-viewer/CBOEstimatesPanel.tsx
+++ b/frontend/src/components/law-viewer/CBOEstimatesPanel.tsx
@@ -5,8 +5,18 @@ interface CBOEstimatesPanelProps {
 }
 
 const MONTH_ABBRS = [
-  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
 ];
 
 function formatPubDate(dateStr: string | null): string {
@@ -18,7 +28,9 @@ function formatPubDate(dateStr: string | null): string {
 }
 
 /** GitHub-style CI-checks panel listing CBO cost estimates for a bill. */
-export default function CBOEstimatesPanel({ estimates }: CBOEstimatesPanelProps) {
+export default function CBOEstimatesPanel({
+  estimates,
+}: CBOEstimatesPanelProps) {
   if (estimates.length === 0) return null;
 
   return (
@@ -35,7 +47,9 @@ export default function CBOEstimatesPanel({ estimates }: CBOEstimatesPanelProps)
               <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-baseline gap-2">
-                  <p className="text-xs font-medium text-gray-800">{est.title}</p>
+                  <p className="text-xs font-medium text-gray-800">
+                    {est.title}
+                  </p>
                   {est.pub_date && (
                     <span className="font-mono text-[11px] text-gray-400">
                       {formatPubDate(est.pub_date)}

--- a/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
+++ b/frontend/src/components/law-viewer/LegislativeHistoryTab.tsx
@@ -1,5 +1,7 @@
 import type { LegislativeHistory } from '@/lib/types';
+import CBOEstimatesPanel from './CBOEstimatesPanel';
 import LegislativeHistoryTimeline from './LegislativeHistoryTimeline';
+import RelatedBillsPanel from './RelatedBillsPanel';
 import SponsorsSidebar from './SponsorsSidebar';
 import VotesSidebar from './VotesSidebar';
 
@@ -123,6 +125,8 @@ export default function LegislativeHistoryTab({
         <div className="col-span-1 flex flex-col gap-4">
           <PresidentialActionCard history={history} />
           <VotesSidebar votes={history.chamber_votes} />
+          <CBOEstimatesPanel estimates={history.cbo_estimates ?? []} />
+          <RelatedBillsPanel bills={history.related_bills ?? []} />
           <SponsorsSidebar sponsors={history.sponsors} />
         </div>
       </div>

--- a/frontend/src/components/law-viewer/RelatedBillsPanel.tsx
+++ b/frontend/src/components/law-viewer/RelatedBillsPanel.tsx
@@ -1,0 +1,96 @@
+import type { RelatedBill } from '@/lib/types';
+
+interface RelatedBillsPanelProps {
+  bills: RelatedBill[];
+}
+
+const BILL_TYPE_LABELS: Record<string, string> = {
+  hr: 'H.R.',
+  s: 'S.',
+  hjres: 'H.J.Res.',
+  sjres: 'S.J.Res.',
+  hconres: 'H.Con.Res.',
+  sconres: 'S.Con.Res.',
+  hres: 'H.Res.',
+  sres: 'S.Res.',
+};
+
+const BILL_TYPE_PATHS: Record<string, string> = {
+  hr: 'house-bill',
+  s: 'senate-bill',
+  hjres: 'house-joint-resolution',
+  sjres: 'senate-joint-resolution',
+  hconres: 'house-concurrent-resolution',
+  sconres: 'senate-concurrent-resolution',
+  hres: 'house-simple-resolution',
+  sres: 'senate-simple-resolution',
+};
+
+function formatBillLabel(bill: RelatedBill): string {
+  const key = bill.bill_type.toLowerCase();
+  const typeLabel = BILL_TYPE_LABELS[key] ?? bill.bill_type.toUpperCase();
+  return `${typeLabel} ${bill.bill_number} (${bill.congress}th)`;
+}
+
+function billUrl(bill: RelatedBill): string {
+  const key = bill.bill_type.toLowerCase();
+  const typePath = BILL_TYPE_PATHS[key] ?? key;
+  return `https://www.congress.gov/bill/${bill.congress}th-congress/${typePath}/${bill.bill_number}`;
+}
+
+/** Linked-PRs-style sidebar panel listing bills related to this legislation. */
+export default function RelatedBillsPanel({ bills }: RelatedBillsPanelProps) {
+  if (bills.length === 0) return null;
+
+  return (
+    <div className="rounded-md border border-gray-200 bg-white">
+      <div className="border-b border-gray-100 px-4 py-2.5">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Related Bills
+        </h3>
+      </div>
+      <div className="divide-y divide-gray-100">
+        {bills.map((bill, i) => (
+          <div key={i} className="px-4 py-3">
+            <div className="flex items-start gap-2">
+              {/* pull-request icon */}
+              <svg
+                className="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-400"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <circle cx="4" cy="4" r="2" />
+                <circle cx="12" cy="12" r="2" />
+                <circle cx="12" cy="4" r="2" />
+                <line x1="4" y1="6" x2="4" y2="10" />
+                <path d="M12 6 L12 9 Q12 10 11 10 L5 10" />
+              </svg>
+              <div className="min-w-0 flex-1">
+                <a
+                  href={billUrl(bill)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs font-medium text-blue-600 hover:underline"
+                >
+                  {formatBillLabel(bill)}
+                </a>
+                {bill.title && (
+                  <p className="mt-0.5 text-[11px] leading-relaxed text-gray-500">
+                    {bill.title}
+                  </p>
+                )}
+                {bill.relationship_details && (
+                  <p className="mt-0.5 text-[11px] italic text-gray-400">
+                    {bill.relationship_details}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/law-viewer/TimelineEvent.tsx
+++ b/frontend/src/components/law-viewer/TimelineEvent.tsx
@@ -1,4 +1,7 @@
-import type { AmendmentStatus, TimelineEvent as TimelineEventType } from '@/lib/types';
+import type {
+  AmendmentStatus,
+  TimelineEvent as TimelineEventType,
+} from '@/lib/types';
 
 interface TimelineEventProps {
   event: TimelineEventType;
@@ -160,14 +163,37 @@ function VoteTally({ event }: { event: TimelineEventType }) {
   );
 }
 
-function AmendmentStatusBadge({ status }: { status: AmendmentStatus | null | undefined }) {
+function AmendmentStatusBadge({
+  status,
+}: {
+  status: AmendmentStatus | null | undefined;
+}) {
   if (!status) return null;
 
-  const configs: Record<AmendmentStatus, { label: string; cls: string; prefix: string }> = {
-    adopted: { label: 'Adopted', cls: 'text-green-700 bg-green-50 ring-green-200', prefix: '✓' },
-    rejected: { label: 'Rejected', cls: 'text-red-700 bg-red-50 ring-red-200', prefix: '✗' },
-    withdrawn: { label: 'Withdrawn', cls: 'text-gray-600 bg-gray-50 ring-gray-200', prefix: '—' },
-    pending: { label: 'Pending', cls: 'text-yellow-700 bg-yellow-50 ring-yellow-200', prefix: '●' },
+  const configs: Record<
+    AmendmentStatus,
+    { label: string; cls: string; prefix: string }
+  > = {
+    adopted: {
+      label: 'Adopted',
+      cls: 'text-green-700 bg-green-50 ring-green-200',
+      prefix: '✓',
+    },
+    rejected: {
+      label: 'Rejected',
+      cls: 'text-red-700 bg-red-50 ring-red-200',
+      prefix: '✗',
+    },
+    withdrawn: {
+      label: 'Withdrawn',
+      cls: 'text-gray-600 bg-gray-50 ring-gray-200',
+      prefix: '—',
+    },
+    pending: {
+      label: 'Pending',
+      cls: 'text-yellow-700 bg-yellow-50 ring-yellow-200',
+      prefix: '●',
+    },
   };
 
   const config = configs[status];

--- a/frontend/src/components/law-viewer/TimelineEvent.tsx
+++ b/frontend/src/components/law-viewer/TimelineEvent.tsx
@@ -1,4 +1,4 @@
-import type { TimelineEvent as TimelineEventType } from '@/lib/types';
+import type { AmendmentStatus, TimelineEvent as TimelineEventType } from '@/lib/types';
 
 interface TimelineEventProps {
   event: TimelineEventType;
@@ -73,6 +73,20 @@ function EventIcon({
           <rect x="6" y="9" width="4" height="3" />
         </svg>
       );
+    case 'amendment':
+      return (
+        <svg
+          className={cls}
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <circle cx="8" cy="8" r="3" />
+          <line x1="1" y1="8" x2="5" y2="8" />
+          <line x1="11" y1="8" x2="15" y2="8" />
+        </svg>
+      );
     default:
       return (
         <svg
@@ -115,6 +129,10 @@ function EventBadge({
       label = 'INTRODUCED';
       cls = 'bg-green-50 text-green-700 ring-green-200';
       break;
+    case 'amendment':
+      label = 'AMENDMENT';
+      cls = 'bg-orange-50 text-orange-700 ring-orange-200';
+      break;
     default:
       label = 'EVENT';
       cls = 'bg-gray-50 text-gray-600 ring-gray-200';
@@ -142,6 +160,29 @@ function VoteTally({ event }: { event: TimelineEventType }) {
   );
 }
 
+function AmendmentStatusBadge({ status }: { status: AmendmentStatus | null | undefined }) {
+  if (!status) return null;
+
+  const configs: Record<AmendmentStatus, { label: string; cls: string; prefix: string }> = {
+    adopted: { label: 'Adopted', cls: 'text-green-700 bg-green-50 ring-green-200', prefix: '✓' },
+    rejected: { label: 'Rejected', cls: 'text-red-700 bg-red-50 ring-red-200', prefix: '✗' },
+    withdrawn: { label: 'Withdrawn', cls: 'text-gray-600 bg-gray-50 ring-gray-200', prefix: '—' },
+    pending: { label: 'Pending', cls: 'text-yellow-700 bg-yellow-50 ring-yellow-200', prefix: '●' },
+  };
+
+  const config = configs[status];
+  if (!config) return null;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold ring-1 ring-inset ${config.cls}`}
+    >
+      <span aria-hidden="true">{config.prefix}</span>
+      {config.label}
+    </span>
+  );
+}
+
 /** A single row in the legislative history timeline. */
 export default function TimelineEvent({ event }: TimelineEventProps) {
   const iconColor =
@@ -154,7 +195,9 @@ export default function TimelineEvent({ event }: TimelineEventProps) {
           ? 'text-blue-600'
           : event.event_type === 'committee_referral'
             ? 'text-amber-600'
-            : 'text-gray-400';
+            : event.event_type === 'amendment'
+              ? 'text-orange-500'
+              : 'text-gray-400';
 
   return (
     <div
@@ -175,6 +218,9 @@ export default function TimelineEvent({ event }: TimelineEventProps) {
           {event.event_type === 'house_vote' ||
           event.event_type === 'senate_vote' ? (
             <VoteTally event={event} />
+          ) : null}
+          {event.event_type === 'amendment' ? (
+            <AmendmentStatusBadge status={event.amendment_status} />
           ) : null}
         </div>
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -257,7 +257,10 @@ export type HistoryEventType =
   | 'house_vote'
   | 'senate_vote'
   | 'presidential_action'
+  | 'amendment'
   | 'other';
+
+export type AmendmentStatus = 'adopted' | 'rejected' | 'withdrawn' | 'pending';
 
 export type LawStatus = 'enacted' | 'vetoed' | 'pending';
 
@@ -273,6 +276,7 @@ export interface TimelineEvent {
   vote_nays: number | null;
   vote_not_voting: number | null;
   congressional_record_refs: string[];
+  amendment_status?: AmendmentStatus | null;
 }
 
 /** A bill sponsor or cosponsor. */
@@ -292,6 +296,34 @@ export interface ChamberVote {
   not_voting: number;
 }
 
+/** A legislative amendment to a bill (from the history API). */
+export interface HistoryAmendment {
+  amendment_number: string;
+  sponsor: string | null;
+  description: string | null;
+  purpose: string | null;
+  proposed_date: string | null;
+  action_date: string | null;
+  status: string | null;
+}
+
+/** A CBO cost estimate for a bill. */
+export interface CBOEstimate {
+  title: string;
+  url: string | null;
+  pub_date: string | null;
+  description: string | null;
+}
+
+/** A bill related to this legislation. */
+export interface RelatedBill {
+  congress: number;
+  bill_type: string;
+  bill_number: number;
+  title: string | null;
+  relationship_details: string | null;
+}
+
 /** Full legislative history response for a public law. */
 export interface LegislativeHistory {
   timeline: TimelineEvent[];
@@ -302,6 +334,9 @@ export interface LegislativeHistory {
   enacted_date: string | null;
   status: LawStatus;
   congress_url: string | null;
+  amendments: HistoryAmendment[];
+  cbo_estimates: CBOEstimate[];
+  related_bills: RelatedBill[];
 }
 
 /** Full section view returned by the section detail endpoint. */


### PR DESCRIPTION
## Summary
This PR enhances the legislative history viewer with new sidebar panels for CBO cost estimates and related bills, and adds support for displaying amendment events in the legislative timeline.

## Key Changes

- **New Components**:
  - `CBOEstimatesPanel`: Displays CBO cost estimates for a bill with formatted publication dates and links to full estimates
  - `RelatedBillsPanel`: Shows related bills with proper formatting for different bill types (H.R., S., resolutions, etc.) and links to Congress.gov

- **Timeline Enhancements**:
  - Added `amendment` event type to `HistoryEventType`
  - New `AmendmentStatusBadge` component to display amendment status (adopted, rejected, withdrawn, pending) with color-coded indicators
  - Added amendment icon and orange color styling to timeline events
  - Amendment status field added to `TimelineEvent` interface

- **Type Definitions**:
  - New `AmendmentStatus` type for amendment outcomes
  - New `HistoryAmendment` interface for amendment data
  - New `CBOEstimate` interface for CBO estimate metadata
  - New `RelatedBill` interface for related legislation
  - Extended `LegislativeHistory` to include amendments, CBO estimates, and related bills arrays

- **UI Integration**:
  - Integrated new panels into `LegislativeHistoryTab` sidebar
  - Panels gracefully hide when data is empty
  - Consistent styling with existing GitHub/PR-style panel design

## Implementation Details

- Bill type mappings handle all standard congressional bill types (H.R., S., joint resolutions, concurrent resolutions, simple resolutions)
- CBO date formatting converts ISO date strings to abbreviated month format (e.g., "Jan 2024")
- Amendment status badges use semantic color coding (green for adopted, red for rejected, etc.)
- All external links open in new tabs with proper security attributes

https://claude.ai/code/session_01JPbjoS9Kap4pwonLUs9jva