### PR TITLE
fix: add seed-congress-law-history step to seed.sh

### DIFF
--- a/backend/scripts/seed.sh
+++ b/backend/scripts/seed.sh
@@ -27,6 +27,9 @@ uv run python -m pipeline.cli chrono-bootstrap
 echo "=== Ingesting Congress 113 laws ==="
 uv run python -m pipeline.cli govinfo-ingest-congress 113
 
+echo "=== Seeding legislative history for Congress 113 ==="
+uv run python -m pipeline.cli seed-congress-law-history 113
+
 echo "=== Advancing chronological pipeline (2 revisions) ==="
 uv run python -m pipeline.cli chrono-advance --count 2
 


### PR DESCRIPTION
## Summary

- Adds `seed-congress-law-history 113` call to `seed.sh` after `govinfo-ingest-congress 113`, so the `law_bill_action` and `law_sponsor` tables are populated on every reseed

## Context

See #205. The CLI commands for legislative history seeding were added in #175 but `seed.sh` was never updated to call them. Every seed run since then has left the two tables empty, causing the History tab to fall back to live Congress.gov API calls on every request.

The placement matters: laws must exist in the DB before history ingestion runs, so this step goes after `govinfo-ingest-congress` and before `chrono-advance`. Touching `seed.sh` also means the `check-seed` step in `cd.yml` will detect the change and trigger a full reseed on merge.

## Test plan

- [ ] Confirm `seed_needed=true` fires for this PR's deploy (seed.sh is in the detection pattern)
- [ ] After reseed, verify `SELECT COUNT(*) FROM law_bill_action` and `law_sponsor` are non-zero
- [ ] Verify the History tab on a Congress 113 law no longer makes live API calls (check backend logs for Congress.gov requests)

Closes #205