### PR TITLE
chore: backlog cleanup (docs, diff UX polish, linkifyContent utility)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Pre-commit hooks**: Ruff (lint + format) and Prettier run automatically on commit via `.pre-commit-config.yaml`. If not installed, run `cd backend && uv run pre-commit install`.
 - **Before pushing**: Always run `uv run mypy app --ignore-missing-imports && uv run pytest` in the backend directory. After pushing, check CI status with `gh run list --branch <branch> --limit 1` and `gh run view <run-id> --log-failed`.
 - **GitHub issue labels**: When creating GitHub issues, apply the `bug` label for bugfix issues and the `enhancement` label for feature issues (e.g., `gh issue create --label bug ...` or `gh issue create --label enhancement ...`).
+- **PR-to-issue linking**: Every PR body must include `Closes #N` or `Fixes #N` so the motivating issue auto-closes on merge.
 
 ## Project Overview
 

--- a/frontend/src/components/law-viewer/LawDiffViewer.tsx
+++ b/frontend/src/components/law-viewer/LawDiffViewer.tsx
@@ -185,7 +185,7 @@ export default function LawDiffViewer({
 
   return (
     <div className="flex flex-col gap-3">
-      {/* Summary bar — total lines added/removed */}
+      {/* Summary bar — total additions/removals */}
       {(totalAdded > 0 || totalRemoved > 0) && (
         <div className="flex items-center gap-3 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm">
           <span className="font-medium text-gray-700">
@@ -194,7 +194,7 @@ export default function LawDiffViewer({
           <span className="text-gray-300">·</span>
           {totalAdded > 0 && (
             <span className="font-mono font-medium text-green-600">
-              +{totalAdded} lines added
+              +{totalAdded} additions
             </span>
           )}
           {totalAdded > 0 && totalRemoved > 0 && (
@@ -202,7 +202,7 @@ export default function LawDiffViewer({
           )}
           {totalRemoved > 0 && (
             <span className="font-mono font-medium text-red-600">
-              −{totalRemoved} lines removed
+              −{totalRemoved} removals
             </span>
           )}
         </div>

--- a/frontend/src/components/law-viewer/UnifiedDiffCard.tsx
+++ b/frontend/src/components/law-viewer/UnifiedDiffCard.tsx
@@ -587,16 +587,6 @@ export default function UnifiedDiffCard({ diff }: UnifiedDiffCardProps) {
   // Deduplicate change types for badges
   const changeTypes = [...new Set(diff.amendments.map((a) => a.change_type))];
 
-  // Count added/removed lines from hunks
-  const linesAdded = diff.hunks.reduce(
-    (sum, h) => sum + h.lines.filter((l) => l.type === 'added').length,
-    0
-  );
-  const linesRemoved = diff.hunks.reduce(
-    (sum, h) => sum + h.lines.filter((l) => l.type === 'removed').length,
-    0
-  );
-
   // Build collapsed regions between/around hunks
   // Each region is identified by: regionIndex, startProvisionIdx, endProvisionIdx
   type Region =
@@ -693,19 +683,6 @@ export default function UnifiedDiffCard({ diff }: UnifiedDiffCardProps) {
         {diff.amendments.some((a) => a.needs_review) && (
           <span className="text-xs font-medium text-amber-600">
             Needs Review
-          </span>
-        )}
-        {(linesAdded > 0 || linesRemoved > 0) && (
-          <span className="ml-auto font-mono text-xs">
-            {linesAdded > 0 && (
-              <span className="text-green-600">+{linesAdded}</span>
-            )}
-            {linesAdded > 0 && linesRemoved > 0 && (
-              <span className="text-gray-400"> </span>
-            )}
-            {linesRemoved > 0 && (
-              <span className="text-red-600">−{linesRemoved}</span>
-            )}
           </span>
         )}
       </div>

--- a/frontend/src/lib/linkifyContent.test.tsx
+++ b/frontend/src/lib/linkifyContent.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { linkifyContent } from './linkifyContent';
+import type { NoteReference } from '@/lib/types';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const identity = (href: string) => href;
+
+function makeRef(overrides: Partial<NoteReference>): NoteReference {
+  return {
+    ref_type: 'usc_section',
+    href: '',
+    display_text: '',
+    congress: null,
+    law_number: null,
+    usc_title: null,
+    usc_section: null,
+    target_id: '',
+    resolvable: true,
+    ...overrides,
+  };
+}
+
+describe('linkifyContent', () => {
+  it('returns plain text when no references', () => {
+    const result = linkifyContent('Hello world', [], identity);
+    expect(result).toBe('Hello world');
+  });
+
+  it('wraps USC section references as internal links', () => {
+    const refs: NoteReference[] = [
+      makeRef({
+        ref_type: 'usc_section',
+        display_text: 'section 106 of title 17',
+        usc_title: 17,
+        usc_section: '106',
+        target_id: '17 USC 106',
+      }),
+    ];
+    const result = linkifyContent(
+      'See section 106 of title 17 for details.',
+      refs,
+      identity
+    );
+    render(<span>{result}</span>);
+    const link = screen.getByRole('link', {
+      name: 'section 106 of title 17',
+    });
+    expect(link).toHaveAttribute('href', '/sections/17/106');
+  });
+
+  it('wraps public law references as internal links', () => {
+    const refs: NoteReference[] = [
+      makeRef({
+        ref_type: 'public_law',
+        display_text: 'Pub. L. 115–264',
+        congress: 115,
+        law_number: 264,
+        target_id: 'PL 115-264',
+      }),
+    ];
+    const result = linkifyContent(
+      'Enacted by Pub. L. 115–264.',
+      refs,
+      identity
+    );
+    render(<span>{result}</span>);
+    const link = screen.getByRole('link', { name: 'Pub. L. 115–264' });
+    expect(link).toHaveAttribute('href', '/laws/115/264');
+  });
+
+  it('renders act references as styled text without link', () => {
+    const refs: NoteReference[] = [
+      makeRef({
+        ref_type: 'act',
+        display_text: 'Social Security Act',
+        target_id: 'Act of 1935-08-14 ch. 531',
+      }),
+    ];
+    const result = linkifyContent(
+      'The Social Security Act applies.',
+      refs,
+      identity
+    );
+    render(<span>{result}</span>);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('Social Security Act')).toBeInTheDocument();
+  });
+
+  it('applies withRev to generated hrefs', () => {
+    const refs: NoteReference[] = [
+      makeRef({
+        ref_type: 'usc_section',
+        display_text: 'section 106',
+        usc_title: 17,
+        usc_section: '106',
+        target_id: '17 USC 106',
+      }),
+    ];
+    const withRev = (href: string) => `${href}?rev=3`;
+    const result = linkifyContent('See section 106.', refs, withRev);
+    render(<span>{result}</span>);
+    const link = screen.getByRole('link', { name: 'section 106' });
+    expect(link).toHaveAttribute('href', '/sections/17/106?rev=3');
+  });
+
+  it('handles multiple references in the same text', () => {
+    const refs: NoteReference[] = [
+      makeRef({
+        ref_type: 'usc_section',
+        display_text: 'section 106',
+        usc_title: 17,
+        usc_section: '106',
+        target_id: '17 USC 106',
+      }),
+      makeRef({
+        ref_type: 'public_law',
+        display_text: 'Pub. L. 115–264',
+        congress: 115,
+        law_number: 264,
+        target_id: 'PL 115-264',
+      }),
+    ];
+    const result = linkifyContent(
+      'Amended section 106 by Pub. L. 115–264.',
+      refs,
+      identity
+    );
+    render(<span>{result}</span>);
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+  });
+
+  it('prefers longer matches over shorter ones', () => {
+    const refs: NoteReference[] = [
+      makeRef({
+        ref_type: 'usc_section',
+        display_text: 'section 106',
+        usc_title: 17,
+        usc_section: '106',
+        target_id: '17 USC 106',
+      }),
+      makeRef({
+        ref_type: 'usc_section',
+        display_text: 'section 106 of title 17',
+        usc_title: 17,
+        usc_section: '106',
+        target_id: '17 USC 106',
+      }),
+    ];
+    const result = linkifyContent(
+      'See section 106 of title 17.',
+      refs,
+      identity
+    );
+    render(<span>{result}</span>);
+    // Should produce one link for the longer match, not two
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent('section 106 of title 17');
+  });
+
+  it('renders non-resolvable refs as styled text, not links', () => {
+    const refs: NoteReference[] = [
+      makeRef({
+        ref_type: 'public_law',
+        display_text: 'Pub. L. 99–999',
+        congress: 99,
+        law_number: 999,
+        target_id: 'PL 99-999',
+        resolvable: false,
+      }),
+    ];
+    const result = linkifyContent(
+      'See Pub. L. 99–999 for details.',
+      refs,
+      identity
+    );
+    render(<span>{result}</span>);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('Pub. L. 99–999')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/linkifyContent.tsx
+++ b/frontend/src/lib/linkifyContent.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import type { NoteReference } from '@/lib/types';
+
+interface Match {
+  index: number;
+  length: number;
+  ref: NoteReference;
+}
+
+/** Build an internal route for a reference, or null if no route exists. */
+function refToHref(ref: NoteReference): string | null {
+  if (ref.ref_type === 'usc_section' && ref.usc_title && ref.usc_section) {
+    return `/sections/${ref.usc_title}/${ref.usc_section}`;
+  }
+  if (ref.ref_type === 'public_law' && ref.congress && ref.law_number) {
+    return `/laws/${ref.congress}/${ref.law_number}`;
+  }
+  return null;
+}
+
+/**
+ * Replace reference display_text occurrences in `text` with clickable links.
+ *
+ * - USC section refs → internal Link to /sections/{title}/{section}
+ * - Public law refs → internal Link to /laws/{congress}/{number}
+ * - Act / statute refs → styled span (no internal route)
+ * - `withRev` is applied to all internal hrefs to preserve ?rev= context.
+ */
+export function linkifyContent(
+  text: string,
+  references: NoteReference[],
+  withRev: (href: string) => string
+): ReactNode {
+  if (references.length === 0) return text;
+
+  // Sort by display_text length descending so longer matches take priority
+  const sorted = [...references].sort(
+    (a, b) => b.display_text.length - a.display_text.length
+  );
+
+  // Find all non-overlapping matches
+  const matches: Match[] = [];
+  for (const ref of sorted) {
+    if (!ref.display_text) continue;
+    let searchFrom = 0;
+    while (searchFrom < text.length) {
+      const idx = text.indexOf(ref.display_text, searchFrom);
+      if (idx === -1) break;
+      // Check no overlap with existing matches
+      const end = idx + ref.display_text.length;
+      const overlaps = matches.some(
+        (m) => idx < m.index + m.length && end > m.index
+      );
+      if (!overlaps) {
+        matches.push({ index: idx, length: ref.display_text.length, ref });
+      }
+      searchFrom = idx + 1;
+    }
+  }
+
+  if (matches.length === 0) return text;
+
+  // Sort matches by position
+  matches.sort((a, b) => a.index - b.index);
+
+  const linkClass = 'text-blue-600 hover:underline';
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+
+  for (const match of matches) {
+    // Text before this match
+    if (match.index > cursor) {
+      parts.push(text.slice(cursor, match.index));
+    }
+
+    const display = text.slice(match.index, match.index + match.length);
+    const href = refToHref(match.ref);
+
+    if (href && match.ref.resolvable) {
+      parts.push(
+        <Link key={match.index} href={withRev(href)} className={linkClass}>
+          {display}
+        </Link>
+      );
+    } else {
+      parts.push(
+        <span
+          key={match.index}
+          className="text-red-600"
+          title={match.ref.target_id}
+        >
+          {display}
+        </span>
+      );
+    }
+
+    cursor = match.index + match.length;
+  }
+
+  // Remaining text
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+
+  return <>{parts}</>;
+}

--- a/frontend/src/lib/linkifyContent.tsx
+++ b/frontend/src/lib/linkifyContent.tsx
@@ -77,7 +77,7 @@ export function linkifyContent(
     const display = text.slice(match.index, match.index + match.length);
     const href = refToHref(match.ref);
 
-    if (href && match.ref.resolvable) {
+    if (href && match.ref.resolvable !== false) {
       parts.push(
         <Link key={match.index} href={withRev(href)} className={linkClass}>
           {display}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -90,12 +90,35 @@ export interface CodeLine {
   is_signature?: boolean;
 }
 
+export type NoteRefType = 'public_law' | 'act' | 'usc_section' | 'statute';
+
+/** A hyperlink reference extracted from section note XML (<ref href="...">). */
+export interface NoteReference {
+  ref_type: NoteRefType;
+  href: string;
+  display_text: string;
+  congress?: number | null;
+  law_number?: number | null;
+  act_date?: string | null;
+  act_chapter?: number | null;
+  usc_title?: number | null;
+  usc_section?: string | null;
+  stat_volume?: number | null;
+  stat_page?: number | null;
+  start_char?: number | null;
+  end_char?: number | null;
+  target_id: string;
+  /** Whether the referenced target exists in our DB. Absent = treat as true. */
+  resolvable?: boolean;
+}
+
 /** A structured note attached to a section. */
 export interface SectionNote {
   header: string;
   content: string;
   lines: CodeLine[];
   category: 'historical' | 'editorial' | 'statutory';
+  references?: NoteReference[];
 }
 
 /** An amendment record for a section. */


### PR DESCRIPTION
## Summary

Four independent chores batched into one PR:

- **CLAUDE.md** — add PR-to-issue linking convention (`Closes #N` / `Fixes #N` in every PR body)
- **Remove +N/−M per-diff chips** — the per-section line-count chips in `UnifiedDiffCard` header added noise without value; removed along with the dead `linesAdded`/`linesRemoved` variables
- **Relabel diff summary bar** — `LawDiffViewer` aggregate bar now says "additions / removals" instead of "lines added / lines removed" — diff rows represent partial-line text changes, not whole statutory lines
- **Commit orphaned `linkifyContent` utility** — `frontend/src/lib/linkifyContent.tsx` and its test were sitting untracked; added as a standalone utility for rendering `NoteReference[]` arrays as React nodes with internal links

## Test plan

- [ ] Law changes tab: per-section header row no longer shows `+N / −M` chips; change-type badges and pattern chips are unaffected
- [ ] Aggregate bar shows e.g. "+12 additions · −4 removals"
- [ ] `npm run test` passes (linkifyContent tests green)
- [ ] `npm run type-check` passes

Closes #203
Closes #194
Closes #193