### PR TITLE
fix: set source on DataIngestionLog in law history ingestion

### DIFF
--- a/backend/pipeline/congress/law_history_ingestion.py
+++ b/backend/pipeline/congress/law_history_ingestion.py
@@ -56,6 +56,7 @@ class LawHistoryIngestionService:
             DataIngestionLog with status and counts.
         """
         log = DataIngestionLog(
+            source="Congress.gov",
             operation=f"seed-law-history-{congress}-{law_number}",
             status="started",
             records_processed=0,
@@ -151,6 +152,7 @@ class LawHistoryIngestionService:
             Aggregate DataIngestionLog.
         """
         log = DataIngestionLog(
+            source="Congress.gov",
             operation=f"seed-congress-law-history-{congress}",
             status="started",
             records_processed=0,


### PR DESCRIPTION
Both seed_law and seed_congress constructed DataIngestionLog without
the required non-null source column, causing NotNullViolationError on
flush during the cwlb-seed Cloud Run job. Aligned with the convention
used in other Congress.gov pipelines by passing source="Congress.gov".