### PR TITLE
chore: add project-level WebFetch permissions for data sources

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:uscode.house.gov)",
+      "WebFetch(domain:api.govinfo.gov)",
+      "WebFetch(domain:www.govinfo.gov)",
+      "WebFetch(domain:api.congress.gov)",
+      "WebFetch(domain:www.congress.gov)",
+      "WebFetch(domain:www.law.cornell.edu)",
+      "WebFetch(domain:codeweliveby.org)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a `WebFetch` allowlist so all contributors get prompt-free access to the federal data sources and CWLB production site used throughout the project.
- Domains covered: `uscode.house.gov` (OLRC), `api.govinfo.gov`, `www.govinfo.gov`, `api.congress.gov`, `www.congress.gov`, `www.law.cornell.edu`, `codeweliveby.org`.
- Previously these were only in the local (gitignored) `settings.local.json`; this makes them shared across the team.

## Test plan

- [x] Verify `.claude/settings.json` is present and valid JSON after checkout
- [x] Confirm WebFetch to a covered domain (e.g. `uscode.house.gov`) no longer prompts for permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)