### PR TITLE
fix: replace ASCII pipe with box-drawing char in notes gutter (#214)

### DIFF
--- a/frontend/src/components/viewer/NoteBlock.tsx
+++ b/frontend/src/components/viewer/NoteBlock.tsx
@@ -64,7 +64,7 @@ function NoteLine({
       <span className="w-10 shrink-0 select-none text-right text-gray-400">
         {lineNumber}
       </span>
-      <span className="mx-2 select-none text-gray-400">|</span>
+      <span className="mx-2 select-none text-gray-400">│</span>
       {indent && (
         <span className="shrink-0 whitespace-pre text-gray-800">{indent}</span>
       )}

--- a/frontend/src/components/viewer/SectionNotes.tsx
+++ b/frontend/src/components/viewer/SectionNotes.tsx
@@ -46,7 +46,7 @@ export default function SectionNotes({
           <span className="w-10 shrink-0 select-none text-right text-gray-400">
             {i + 1}
           </span>
-          <span className="mx-2 select-none text-gray-400">|</span>
+          <span className="mx-2 select-none text-gray-400">│</span>
           <span className="min-w-0 pl-[2ch] -indent-[2ch]">
             <span className="select-none"># </span>
             {text}
@@ -57,7 +57,7 @@ export default function SectionNotes({
         <span className="w-10 shrink-0 select-none text-right text-gray-400">
           {blankLineNumber}
         </span>
-        <span className="mx-2 select-none text-gray-400">|</span>
+        <span className="mx-2 select-none text-gray-400">│</span>
       </div>
       {notes.map((note, i) => {
         const headerLineNum = lineNumber;
@@ -71,7 +71,7 @@ export default function SectionNotes({
               <span className="w-10 shrink-0 select-none text-right text-gray-400">
                 {headerLineNum}
               </span>
-              <span className="mx-2 select-none text-gray-400">|</span>
+              <span className="mx-2 select-none text-gray-400">│</span>
               <span className="font-semibold text-gray-900">{note.header}</span>
             </div>
             <NoteBlock


### PR DESCRIPTION
## Bug

The Notes pages (`NoteBlock.tsx`, `SectionNotes.tsx`) rendered the line-number gutter separator as `|` (U+007C ASCII VERTICAL LINE), while the Code viewer (`SectionProvisions.tsx`) used `│` (U+2502 BOX DRAWINGS LIGHT VERTICAL). The ASCII pipe has a mid-gap and sits off-center in most monospace fonts, making the Notes gutter look thinner and misaligned compared to the Code viewer gutter.

## Fix

Replaced all four `|` occurrences in the gutter `<span>` elements:

- `NoteBlock.tsx` line 67 — 1 occurrence
- `SectionNotes.tsx` lines 49, 60, 74 — 3 occurrences

No logic changes; purely a character substitution. `npm run type-check` and `npm run lint` both pass.

Closes #214

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9QMJkGypSWHayyy9ai6P3)_