### PR TITLE
fix: sort laws by numeric law_number to fix lexicographic ordering

### DIFF
--- a/backend/app/api/v1/laws.py
+++ b/backend/app/api/v1/laws.py
@@ -27,7 +27,7 @@ router = APIRouter()
 
 @router.get("")
 async def list_laws(
-    limit: int = Query(50, ge=1, le=200, description="Max results to return"),
+    limit: int = Query(50, ge=1, le=500, description="Max results to return"),
     offset: int = Query(0, ge=0, description="Number of results to skip"),
     session: AsyncSession = Depends(get_async_session),
 ) -> list[LawSummarySchema]:

--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import Integer, cast, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -52,7 +52,10 @@ async def get_laws_list(
     """
     stmt = (
         select(PublicLaw)
-        .order_by(PublicLaw.congress.desc(), PublicLaw.law_number.desc())
+        .order_by(
+            PublicLaw.congress.desc(),
+            cast(PublicLaw.law_number, Integer).desc(),
+        )
         .limit(limit)
         .offset(offset)
     )

--- a/backend/tests/api/test_laws.py
+++ b/backend/tests/api/test_laws.py
@@ -31,7 +31,9 @@ def test_list_laws_returns_laws(mock_list: AsyncMock, client: TestClient) -> Non
 
 
 @patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
-def test_list_laws_passes_limit_to_crud(mock_list: AsyncMock, client: TestClient) -> None:
+def test_list_laws_passes_limit_to_crud(
+    mock_list: AsyncMock, client: TestClient
+) -> None:
     """The limit query param is forwarded to the CRUD layer."""
     mock_list.return_value = []
 
@@ -42,7 +44,9 @@ def test_list_laws_passes_limit_to_crud(mock_list: AsyncMock, client: TestClient
 
 
 @patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
-def test_list_laws_limit_exceeds_old_cap(mock_list: AsyncMock, client: TestClient) -> None:
+def test_list_laws_limit_exceeds_old_cap(
+    mock_list: AsyncMock, client: TestClient
+) -> None:
     """Limit of 500 is accepted (previously capped at 200, causing truncation)."""
     mock_list.return_value = []
 

--- a/backend/tests/api/test_laws.py
+++ b/backend/tests/api/test_laws.py
@@ -1,0 +1,50 @@
+"""Tests for public laws list endpoint."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.schemas.law_viewer import LawSummarySchema
+
+
+def _make_law(congress: int, law_number: str) -> LawSummarySchema:
+    return LawSummarySchema(
+        congress=congress,
+        law_number=law_number,
+        official_title=None,
+        short_title=None,
+        enacted_date="2013-01-01",
+        sections_affected=0,
+    )
+
+
+@patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
+def test_list_laws_returns_laws(mock_list: AsyncMock, client: TestClient) -> None:
+    """Laws list endpoint returns laws from the CRUD layer."""
+    mock_list.return_value = [_make_law(113, "9"), _make_law(113, "8")]
+
+    response = client.get("/api/v1/laws/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["law_number"] == "9"
+
+
+@patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
+def test_list_laws_passes_limit_to_crud(mock_list: AsyncMock, client: TestClient) -> None:
+    """The limit query param is forwarded to the CRUD layer."""
+    mock_list.return_value = []
+
+    client.get("/api/v1/laws/?limit=500")
+    mock_list.assert_called_once()
+    _, kwargs = mock_list.call_args
+    assert kwargs["limit"] == 500
+
+
+@patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
+def test_list_laws_limit_exceeds_old_cap(mock_list: AsyncMock, client: TestClient) -> None:
+    """Limit of 500 is accepted (previously capped at 200, causing truncation)."""
+    mock_list.return_value = []
+
+    response = client.get("/api/v1/laws/?limit=500")
+    assert response.status_code == 200

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -66,7 +66,7 @@ export async function fetchSection(
 
 /** Fetch all public law summaries. */
 export async function fetchLaws(): Promise<LawSummary[]> {
-  const res = await fetch(`${API_BASE}/laws/`);
+  const res = await fetch(`${API_BASE}/laws/?limit=500`);
   if (!res.ok) {
     throw new Error(`Failed to fetch laws: ${res.status}`);
   }


### PR DESCRIPTION
## What was the bug

`PublicLaw.law_number` is stored as `String(20)`. The list query in `get_laws_list` sorted it with `.desc()`, which produced lexicographic order: `"9" > "8" > "7" > ... > "296" > "295" > ... > "10"`. Combined with the frontend calling `fetchLaws()` with no limit (defaulting to 50), only the lex-top 50 law numbers were ever returned. Laws 10–28 and 100–275 were invisible on the Laws page even though all 296 Congress 113 laws are correctly seeded.

## What the fix does

- **`backend/app/crud/public_law.py`**: Wraps `PublicLaw.law_number` in `cast(..., Integer)` so `ORDER BY` uses numeric descending order.
- **`backend/app/api/v1/laws.py`**: Raises the max `limit` cap from 200 → 500, so a single request can retrieve all 296 laws.
- **`frontend/src/lib/api.ts`**: Passes `limit=500` in `fetchLaws()` so the frontend retrieves all laws instead of the default 50.
- **`backend/tests/api/test_laws.py`**: Adds API-level tests covering the list endpoint and the new limit cap.

No schema migration required — the cast happens at query time.

Closes #201