### PR TITLE
fix: show 'editorially omitted' message for omitted sections

### DIFF
--- a/frontend/src/components/viewer/NotesViewer.test.tsx
+++ b/frontend/src/components/viewer/NotesViewer.test.tsx
@@ -15,6 +15,7 @@ const sectionData: SectionView = {
   last_modified_date: '2020-01-01',
   is_positive_law: true,
   is_repealed: false,
+  omitted: false,
   notes: {
     citations: [],
     amendments: [],

--- a/frontend/src/components/viewer/SectionViewer.test.tsx
+++ b/frontend/src/components/viewer/SectionViewer.test.tsx
@@ -23,6 +23,7 @@ const baseSectionData: SectionView = {
   last_modified_date: '2020-01-01',
   is_positive_law: true,
   is_repealed: false,
+  omitted: false,
   notes: {
     citations: [
       {
@@ -175,6 +176,48 @@ describe('SectionViewer', () => {
       })
     ).toBeInTheDocument();
     expect(screen.queryByText('Amendment History')).toBeNull();
+  });
+
+  it('shows editorially omitted message when omitted flag is true', () => {
+    const omittedData: SectionView = {
+      ...baseSectionData,
+      heading: 'Omitted',
+      text_content: null,
+      omitted: true,
+      is_repealed: false,
+      notes: { ...baseSectionData.notes!, amendments: [], citations: [], has_amendments: false, has_citations: false },
+    };
+    mockUseSection.mockReturnValue({
+      data: omittedData,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={2} sectionNumber="3" />);
+    expect(
+      screen.getByText('This section has been editorially omitted.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows editorially omitted message when heading is "Omitted" even if flag is false', () => {
+    const omittedData: SectionView = {
+      ...baseSectionData,
+      heading: 'Omitted',
+      text_content: null,
+      omitted: false,
+      is_repealed: false,
+      notes: { ...baseSectionData.notes!, amendments: [], citations: [], has_amendments: false, has_citations: false },
+    };
+    mockUseSection.mockReturnValue({
+      data: omittedData,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useSection>);
+
+    render(<SectionViewer titleNumber={2} sectionNumber="3" />);
+    expect(
+      screen.getByText('This section has been editorially omitted.')
+    ).toBeInTheDocument();
   });
 
   it('switches between Code and History tabs', async () => {

--- a/frontend/src/components/viewer/SectionViewer.test.tsx
+++ b/frontend/src/components/viewer/SectionViewer.test.tsx
@@ -185,7 +185,13 @@ describe('SectionViewer', () => {
       text_content: null,
       omitted: true,
       is_repealed: false,
-      notes: { ...baseSectionData.notes!, amendments: [], citations: [], has_amendments: false, has_citations: false },
+      notes: {
+        ...baseSectionData.notes!,
+        amendments: [],
+        citations: [],
+        has_amendments: false,
+        has_citations: false,
+      },
     };
     mockUseSection.mockReturnValue({
       data: omittedData,
@@ -206,7 +212,13 @@ describe('SectionViewer', () => {
       text_content: null,
       omitted: false,
       is_repealed: false,
-      notes: { ...baseSectionData.notes!, amendments: [], citations: [], has_amendments: false, has_citations: false },
+      notes: {
+        ...baseSectionData.notes!,
+        amendments: [],
+        citations: [],
+        has_amendments: false,
+        has_citations: false,
+      },
     };
     mockUseSection.mockReturnValue({
       data: omittedData,

--- a/frontend/src/components/viewer/SectionViewer.tsx
+++ b/frontend/src/components/viewer/SectionViewer.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useSection } from '@/hooks/useSection';
 import type { BreadcrumbSegment } from '@/lib/types';
+import { detectStatus } from '@/lib/statusStyles';
 import TabBar from '@/components/ui/TabBar';
 import SectionHeader from './SectionHeader';
 import type { LawReference } from './SectionHeader';
@@ -49,6 +50,12 @@ export default function SectionViewer({
   const shortTitles = data.notes?.short_titles ?? [];
   const hasHistory = amendments.length > 0 || citations.length > 0;
 
+  const status = data.is_repealed
+    ? 'repealed'
+    : data.omitted
+      ? 'omitted'
+      : detectStatus(data.heading);
+
   // Helper: find the short title associated with a public law ID
   const findShortTitle = (plId: string): string | null =>
     shortTitles.find((st) => st.public_law === plId)?.title ?? null;
@@ -92,7 +99,7 @@ export default function SectionViewer({
         heading={data.heading}
         breadcrumbs={breadcrumbs}
         isPositiveLaw={data.is_positive_law}
-        status={data.is_repealed ? 'repealed' : null}
+        status={status}
         enacted={enacted}
         lastAmended={lastAmended}
       />
@@ -105,7 +112,7 @@ export default function SectionViewer({
           heading={data.heading}
           textContent={data.text_content}
           provisions={data.provisions}
-          status={data.is_repealed ? 'repealed' : null}
+          status={status}
         />
       ) : (
         <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -374,6 +374,7 @@ export interface SectionView {
   last_modified_date: string | null;
   is_positive_law: boolean;
   is_repealed: boolean;
+  omitted: boolean;
   notes: SectionNotes | null;
   last_revision?: HeadRevision | null;
 }


### PR DESCRIPTION
## What was the bug

Sections with heading \"Omitted\" (e.g. 2 U.S.C. §§ 3, 4) displayed the generic fallback \"No text content available for this section.\" instead of \"This section has been editorially omitted.\" The correct message, badge, and icon already existed in `statusStyles.ts` — they were just never reached.

**Root causes:**
1. `SectionViewer.tsx` derived `status` with only `data.is_repealed ? 'repealed' : null`, never checking `data.omitted` or the section heading.
2. The backend `omitted` DB flag is currently `false` for sections whose heading is "Omitted" (a separate data ingestion issue), so checking the flag alone was insufficient.
3. The `SectionView` TypeScript type was missing the `omitted` field even though the backend API returns it.

## What the fix does

- **`frontend/src/lib/types.ts`**: Adds `omitted: boolean` to `SectionView`.
- **`frontend/src/components/viewer/SectionViewer.tsx`**: Derives `status` in three steps: `is_repealed` → `omitted` flag → `detectStatus(data.heading)` fallback. The heading fallback catches all sections with heading "Omitted" regardless of whether the DB flag is set.
- **`frontend/src/components/viewer/SectionViewer.test.tsx`**: Updates the fixture to include `omitted: false` (now required by the type) and adds two tests covering (a) `omitted: true` and (b) `omitted: false` but heading "Omitted" — both should show the editorially omitted message.

Closes #199