### PR TITLE
fix: strip [H2] and [QC:N] markup tokens from note content and raw_notes API output

### DIFF
--- a/backend/app/schemas/us_code.py
+++ b/backend/app/schemas/us_code.py
@@ -5,9 +5,10 @@ the pipeline and application layers.
 """
 
 import enum
+import re
 from datetime import date
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from app.models.enums import NoteRefType
 from app.schemas.public_law import PublicLawSchema, SourceLawSchema
@@ -347,6 +348,26 @@ class SectionNotesSchema(BaseModel):
     # =========================================================================
 
     raw_notes: str = Field("", description="Full raw text of all notes (fallback)")
+
+    @field_validator("raw_notes", mode="before")
+    @classmethod
+    def strip_internal_markup_tokens(cls, v: object) -> object:
+        """Strip internal XML serialization markers before surfacing in the API.
+
+        These markers ([H2], [QC:N], etc.) are generated during XML ingestion
+        for intermediate processing by the notes normalizer and should not be
+        visible to API consumers.
+        """
+        if not isinstance(v, str):
+            return v
+        v = re.sub(r"\[NH\].*?\[/NH\]", "", v, flags=re.DOTALL)
+        v = re.sub(r"\[H1\].*?\[/H1\]", "", v, flags=re.DOTALL)
+        v = re.sub(r"\[H2\](.*?)\[/H2\]", r"\1", v, flags=re.DOTALL)
+        v = re.sub(r"\[QC:\d+\](.*?)\[/QC\]", r"\1", v, flags=re.DOTALL)
+        v = re.sub(r"\[SIG\](.*?)\[/SIG\]", r"\1", v, flags=re.DOTALL)
+        v = re.sub(r"\[PARA\]", "\n\n", v)
+        v = re.sub(r"\[/NH\]|\[/H1\]", "", v)
+        return v.strip()
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1328,13 +1328,17 @@ def _strip_note_markers(text: str) -> str:
     Removes:
     - [NH]...[/NH] note header markers
     - [H1]...[/H1] bold header markers (cross-headings)
+    - [H2]...[/H2] italic sub-header markers (text kept)
+    - [QC:N]...[/QC] quoted-content markers (text kept)
     - Orphaned [/NH] and [/H1] closing markers
     """
     text = re.sub(r"\[NH\].*?\[/NH\]", "", text, flags=re.DOTALL)
     text = re.sub(r"\[H1\].*?\[/H1\]", "", text, flags=re.DOTALL)
     text = re.sub(r"\[/NH\]", "", text)
     text = re.sub(r"\[/H1\]", "", text)
-    # Clean up remaining inline markers for display
+    # Clean up remaining inline markers for display — keep their text content
+    text = re.sub(r"\[H2\](.*?)\[/H2\]", r"\1", text, flags=re.DOTALL)
+    text = re.sub(r"\[QC:\d+\](.*?)\[/QC\]", r"\1", text, flags=re.DOTALL)
     text = re.sub(r"\[SIG\](.*?)\[/SIG\]", r"\1", text, flags=re.DOTALL)
     text = re.sub(r"\[PARA\]", "\n\n", text)
     return text.strip()

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1325,6 +1325,31 @@ class TestStripNoteMarkers:
         text = "Just regular content with no markers."
         assert _strip_note_markers(text) == text
 
+    def test_strip_h2_markers_keeps_text(self) -> None:
+        """[H2]...[/H2] wrappers are removed but the inner text is preserved."""
+        text = 'provided that: [H2]Brevity[/H2] (i) Poetry: ...'
+        result = _strip_note_markers(text)
+        assert "[H2]" not in result
+        assert "[/H2]" not in result
+        assert "Brevity" in result
+
+    def test_strip_qc_markers_keeps_text(self) -> None:
+        """[QC:N]...[/QC] wrappers are removed but the inner text is preserved."""
+        text = 'provided that: [QC:1]"The amendments made by subsection (a) shall apply."[/QC] No Requirement'
+        result = _strip_note_markers(text)
+        assert "[QC:1]" not in result
+        assert "[/QC]" not in result
+        assert "amendments made by subsection" in result
+        assert "No Requirement" in result
+
+    def test_strip_qc_multilevel(self) -> None:
+        """[QC:N] with any level number is stripped."""
+        text = "[QC:1]First level.[/QC] [QC:2]Second level.[/QC]"
+        result = _strip_note_markers(text)
+        assert "[QC:" not in result
+        assert "First level." in result
+        assert "Second level." in result
+
 
 class TestStatutoryNotesHeaderParsing:
     """Tests for statutory notes correctly distinguishing headers from content.

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1327,7 +1327,7 @@ class TestStripNoteMarkers:
 
     def test_strip_h2_markers_keeps_text(self) -> None:
         """[H2]...[/H2] wrappers are removed but the inner text is preserved."""
-        text = 'provided that: [H2]Brevity[/H2] (i) Poetry: ...'
+        text = "provided that: [H2]Brevity[/H2] (i) Poetry: ..."
         result = _strip_note_markers(text)
         assert "[H2]" not in result
         assert "[/H2]" not in result

--- a/backend/tests/test_section_notes_schema.py
+++ b/backend/tests/test_section_notes_schema.py
@@ -1,0 +1,65 @@
+"""Tests for SectionNotesSchema — specifically the raw_notes markup-stripping validator."""
+
+import pytest
+
+from app.schemas.us_code import SectionNotesSchema
+
+
+class TestRawNotesMarkupStripping:
+    """raw_notes should have internal XML markup tokens stripped before API exposure."""
+
+    def _make_notes(self, raw_notes: str) -> SectionNotesSchema:
+        return SectionNotesSchema.model_validate({"raw_notes": raw_notes})
+
+    def test_qc_markers_stripped_text_kept(self) -> None:
+        raw = 'provided that: [QC:1]"The amendments shall apply."[/QC] No Requirement'
+        result = self._make_notes(raw)
+        assert "[QC:1]" not in result.raw_notes
+        assert "[/QC]" not in result.raw_notes
+        assert "amendments shall apply" in result.raw_notes
+        assert "No Requirement" in result.raw_notes
+
+    def test_qc_multilevel_stripped(self) -> None:
+        raw = "[QC:1]Level one.[/QC] text [QC:3]Level three.[/QC]"
+        result = self._make_notes(raw)
+        assert "[QC:" not in result.raw_notes
+        assert "Level one." in result.raw_notes
+        assert "Level three." in result.raw_notes
+
+    def test_h2_markers_stripped_text_kept(self) -> None:
+        raw = "provided that: [H2]Brevity[/H2] (i) Poetry: ..."
+        result = self._make_notes(raw)
+        assert "[H2]" not in result.raw_notes
+        assert "[/H2]" not in result.raw_notes
+        assert "Brevity" in result.raw_notes
+        assert "Poetry" in result.raw_notes
+
+    def test_h1_markers_stripped_text_removed(self) -> None:
+        raw = "Content. [H1]Cross-Heading[/H1] More content."
+        result = self._make_notes(raw)
+        assert "[H1]" not in result.raw_notes
+        assert "Cross-Heading" not in result.raw_notes
+        assert "More content." in result.raw_notes
+
+    def test_plain_text_unchanged(self) -> None:
+        raw = "Pub. L. 94-553, Oct. 19, 1976, 90 Stat. 2541."
+        result = self._make_notes(raw)
+        assert result.raw_notes == raw
+
+    def test_empty_raw_notes(self) -> None:
+        result = self._make_notes("")
+        assert result.raw_notes == ""
+
+    def test_combined_markers(self) -> None:
+        raw = (
+            "[NH]References In Text[/NH] "
+            "The term means: [QC:1]as defined by section 101.[/QC] "
+            "[H2]Definition[/H2] Further clarification."
+        )
+        result = self._make_notes(raw)
+        assert "[NH]" not in result.raw_notes
+        assert "[QC:" not in result.raw_notes
+        assert "[H2]" not in result.raw_notes
+        assert "as defined by section 101." in result.raw_notes
+        assert "Definition" in result.raw_notes
+        assert "Further clarification." in result.raw_notes

--- a/backend/tests/test_section_notes_schema.py
+++ b/backend/tests/test_section_notes_schema.py
@@ -1,7 +1,5 @@
 """Tests for SectionNotesSchema — specifically the raw_notes markup-stripping validator."""
 
-import pytest
-
 from app.schemas.us_code import SectionNotesSchema
 
 


### PR DESCRIPTION
## What was the bug

Two related issues with the same root cause:

**Issue #220 (`notes.notes[n].content`):** `[H2]...[/H2]` italic sub-header markers and `[QC:1]...[/QC]` quoted-content markers appeared verbatim in note content strings. Example from 17 U.S.C. § 107:
```
give some idea: [QC:1]"quotation of excerpts in a review..."[/QC]
...
[H2]Brevity[/H2]
[H2](i)[/H2] Poetry: ...
```

**Issue #224 (`notes.raw_notes`):** The same tokens leaked into the `raw_notes` field, which is the fallback plain-text representation of all notes.

## Root Cause

The XML ingestion pipeline uses `[H2]...[/H2]` and `[QC:N]...[/QC]` as intermediate markers when serializing USLM XML `<heading>` and `<quotedContent>` elements. These markers are intended to be consumed by `normalize_note_content()` to produce structured `ParsedLine` objects. However:

1. `_strip_note_markers()` — which populates the `content` field of `SectionNote` — only stripped `[NH]`, `[H1]`, `[SIG]`, and `[PARA]` markers. It never stripped `[H2]` or `[QC:N]`.
2. `raw_notes` stores the intermediate text as-is in the `normalized_notes` JSONB column, so the markers were returned verbatim by the API.

## What the fix does

**Fix 1 — `pipeline/olrc/normalized_section.py`:** Extends `_strip_note_markers()` to unwrap `[H2]` and `[QC:N]` markers (removing the `[H2]`/`[QC:N]`/`[/H2]`/`[/QC]` wrappers while preserving the inner text), matching the same pattern already used for `[SIG]`. This fixes newly ingested data.

**Fix 2 — `app/schemas/us_code.py`:** Adds a `field_validator` on `raw_notes` in `SectionNotesSchema` that strips all internal markup tokens at deserialization time. This fixes existing stored data in the DB without requiring re-ingestion, since the validator runs whenever `SectionNotesSchema.model_validate(stored_dict)` is called at API response time.

Closes #220
Closes #224