### PR TITLE
Implement multi-stage Docker builds with layer caching

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Build and push backend image
         run: |
           BACKEND_TAG="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:$GITHUB_SHA"
+          BACKEND_LATEST="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:latest"
           BUILD_ID=$(gcloud builds submit backend/ \
-            --tag "$BACKEND_TAG" \
+            --config backend/cloudbuild.yaml \
+            --substitutions "_IMAGE_TAG=$BACKEND_TAG,_IMAGE_LATEST=$BACKEND_LATEST" \
             --async --format='value(id)' --quiet)
           echo "Waiting for build $BUILD_ID..."
           while true; do
@@ -115,10 +117,14 @@ jobs:
 
       - name: Build and push frontend image
         run: |
-          IMAGE_TAG="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-frontend:$GITHUB_SHA"
+          FRONTEND_BASE="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-frontend"
+          IMAGE_TAG="$FRONTEND_BASE:$GITHUB_SHA"
+          IMAGE_LATEST="$FRONTEND_BASE:latest"
+          DEPS_CACHE="$FRONTEND_BASE:cache-deps"
+          BUILD_CACHE="$FRONTEND_BASE:cache-build"
           BUILD_ID=$(gcloud builds submit frontend/ \
             --config frontend/cloudbuild.yaml \
-            --substitutions "_IMAGE_TAG=$IMAGE_TAG,_BACKEND_URL=${{ steps.backend-url.outputs.url }}" \
+            --substitutions "_IMAGE_TAG=$IMAGE_TAG,_IMAGE_LATEST=$IMAGE_LATEST,_DEPS_CACHE=$DEPS_CACHE,_BUILD_CACHE=$BUILD_CACHE,_BACKEND_URL=${{ steps.backend-url.outputs.url }}" \
             --async --format='value(id)' --quiet)
           echo "Waiting for build $BUILD_ID..."
           while true; do

--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -1,0 +1,33 @@
+steps:
+    # Pull the previous :latest so Docker can reuse unchanged layers (most
+    # importantly the `uv sync` step). First-ever build has nothing to pull;
+    # ignore that case so the build proceeds without a cache.
+    - id: pull-cache
+      name: 'gcr.io/cloud-builders/docker'
+      entrypoint: 'bash'
+      args:
+          - '-c'
+          - |
+              docker pull ${_IMAGE_LATEST} || echo "No prior :latest image; building without cache"
+      waitFor: ['-']
+
+    - id: build
+      name: 'gcr.io/cloud-builders/docker'
+      args:
+          - 'build'
+          - '--cache-from'
+          - '${_IMAGE_LATEST}'
+          - '-t'
+          - '${_IMAGE_TAG}'
+          - '-t'
+          - '${_IMAGE_LATEST}'
+          - '.'
+      waitFor: ['pull-cache']
+
+images:
+    - '${_IMAGE_TAG}'
+    - '${_IMAGE_LATEST}'
+
+substitutions:
+    _IMAGE_TAG: ''
+    _IMAGE_LATEST: ''

--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -1,21 +1,85 @@
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      [
-        'build',
-        '--build-arg',
-        'BACKEND_URL=${_BACKEND_URL}',
-        '-t',
-        '${_IMAGE_TAG}',
-        '.',
-      ]
+    # Pull cached intermediate stages plus the prior runtime image. `--cache-from`
+    # only sees layers that are actually pulled into the local daemon, so each
+    # stage we want to reuse needs its own tag in the registry.
+    - id: pull-cache
+      name: 'gcr.io/cloud-builders/docker'
+      entrypoint: 'bash'
+      args:
+          - '-c'
+          - |
+              docker pull ${_DEPS_CACHE} || echo "No deps cache"
+              docker pull ${_BUILD_CACHE} || echo "No build cache"
+              docker pull ${_IMAGE_LATEST} || echo "No runtime cache"
+              exit 0
+      waitFor: ['-']
 
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '${_IMAGE_TAG}']
+    # Stage 1: deps — caches `npm ci` when package.json/package-lock.json
+    # haven't changed.
+    - id: build-deps
+      name: 'gcr.io/cloud-builders/docker'
+      args:
+          - 'build'
+          - '--target'
+          - 'deps'
+          - '--cache-from'
+          - '${_DEPS_CACHE}'
+          - '-t'
+          - '${_DEPS_CACHE}'
+          - '.'
+      waitFor: ['pull-cache']
+
+    # Stage 2: build — reuses the deps stage's node_modules layer. `COPY . .`
+    # invalidates after the deps layer, so `npm run build` still re-runs on
+    # code changes (Next.js incremental cache would address that separately).
+    - id: build-build
+      name: 'gcr.io/cloud-builders/docker'
+      args:
+          - 'build'
+          - '--target'
+          - 'build'
+          - '--build-arg'
+          - 'BACKEND_URL=${_BACKEND_URL}'
+          - '--cache-from'
+          - '${_DEPS_CACHE}'
+          - '--cache-from'
+          - '${_BUILD_CACHE}'
+          - '-t'
+          - '${_BUILD_CACHE}'
+          - '.'
+      waitFor: ['build-deps']
+
+    # Stage 3: runtime — final image. Passing all three cache sources lets
+    # Docker reuse the build stage's output when nothing in the build context
+    # changed.
+    - id: build-runtime
+      name: 'gcr.io/cloud-builders/docker'
+      args:
+          - 'build'
+          - '--build-arg'
+          - 'BACKEND_URL=${_BACKEND_URL}'
+          - '--cache-from'
+          - '${_DEPS_CACHE}'
+          - '--cache-from'
+          - '${_BUILD_CACHE}'
+          - '--cache-from'
+          - '${_IMAGE_LATEST}'
+          - '-t'
+          - '${_IMAGE_TAG}'
+          - '-t'
+          - '${_IMAGE_LATEST}'
+          - '.'
+      waitFor: ['build-build']
 
 images:
-  - '${_IMAGE_TAG}'
+    - '${_IMAGE_TAG}'
+    - '${_IMAGE_LATEST}'
+    - '${_DEPS_CACHE}'
+    - '${_BUILD_CACHE}'
 
 substitutions:
-  _BACKEND_URL: ''
-  _IMAGE_TAG: ''
+    _BACKEND_URL: ''
+    _IMAGE_TAG: ''
+    _IMAGE_LATEST: ''
+    _DEPS_CACHE: ''
+    _BUILD_CACHE: ''

--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -1,85 +1,85 @@
 steps:
-    # Pull cached intermediate stages plus the prior runtime image. `--cache-from`
-    # only sees layers that are actually pulled into the local daemon, so each
-    # stage we want to reuse needs its own tag in the registry.
-    - id: pull-cache
-      name: 'gcr.io/cloud-builders/docker'
-      entrypoint: 'bash'
-      args:
-          - '-c'
-          - |
-              docker pull ${_DEPS_CACHE} || echo "No deps cache"
-              docker pull ${_BUILD_CACHE} || echo "No build cache"
-              docker pull ${_IMAGE_LATEST} || echo "No runtime cache"
-              exit 0
-      waitFor: ['-']
+  # Pull cached intermediate stages plus the prior runtime image. `--cache-from`
+  # only sees layers that are actually pulled into the local daemon, so each
+  # stage we want to reuse needs its own tag in the registry.
+  - id: pull-cache
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker pull ${_DEPS_CACHE} || echo "No deps cache"
+        docker pull ${_BUILD_CACHE} || echo "No build cache"
+        docker pull ${_IMAGE_LATEST} || echo "No runtime cache"
+        exit 0
+    waitFor: ['-']
 
-    # Stage 1: deps — caches `npm ci` when package.json/package-lock.json
-    # haven't changed.
-    - id: build-deps
-      name: 'gcr.io/cloud-builders/docker'
-      args:
-          - 'build'
-          - '--target'
-          - 'deps'
-          - '--cache-from'
-          - '${_DEPS_CACHE}'
-          - '-t'
-          - '${_DEPS_CACHE}'
-          - '.'
-      waitFor: ['pull-cache']
+  # Stage 1: deps — caches `npm ci` when package.json/package-lock.json
+  # haven't changed.
+  - id: build-deps
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--target'
+      - 'deps'
+      - '--cache-from'
+      - '${_DEPS_CACHE}'
+      - '-t'
+      - '${_DEPS_CACHE}'
+      - '.'
+    waitFor: ['pull-cache']
 
-    # Stage 2: build — reuses the deps stage's node_modules layer. `COPY . .`
-    # invalidates after the deps layer, so `npm run build` still re-runs on
-    # code changes (Next.js incremental cache would address that separately).
-    - id: build-build
-      name: 'gcr.io/cloud-builders/docker'
-      args:
-          - 'build'
-          - '--target'
-          - 'build'
-          - '--build-arg'
-          - 'BACKEND_URL=${_BACKEND_URL}'
-          - '--cache-from'
-          - '${_DEPS_CACHE}'
-          - '--cache-from'
-          - '${_BUILD_CACHE}'
-          - '-t'
-          - '${_BUILD_CACHE}'
-          - '.'
-      waitFor: ['build-deps']
+  # Stage 2: build — reuses the deps stage's node_modules layer. `COPY . .`
+  # invalidates after the deps layer, so `npm run build` still re-runs on
+  # code changes (Next.js incremental cache would address that separately).
+  - id: build-build
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--target'
+      - 'build'
+      - '--build-arg'
+      - 'BACKEND_URL=${_BACKEND_URL}'
+      - '--cache-from'
+      - '${_DEPS_CACHE}'
+      - '--cache-from'
+      - '${_BUILD_CACHE}'
+      - '-t'
+      - '${_BUILD_CACHE}'
+      - '.'
+    waitFor: ['build-deps']
 
-    # Stage 3: runtime — final image. Passing all three cache sources lets
-    # Docker reuse the build stage's output when nothing in the build context
-    # changed.
-    - id: build-runtime
-      name: 'gcr.io/cloud-builders/docker'
-      args:
-          - 'build'
-          - '--build-arg'
-          - 'BACKEND_URL=${_BACKEND_URL}'
-          - '--cache-from'
-          - '${_DEPS_CACHE}'
-          - '--cache-from'
-          - '${_BUILD_CACHE}'
-          - '--cache-from'
-          - '${_IMAGE_LATEST}'
-          - '-t'
-          - '${_IMAGE_TAG}'
-          - '-t'
-          - '${_IMAGE_LATEST}'
-          - '.'
-      waitFor: ['build-build']
+  # Stage 3: runtime — final image. Passing all three cache sources lets
+  # Docker reuse the build stage's output when nothing in the build context
+  # changed.
+  - id: build-runtime
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--build-arg'
+      - 'BACKEND_URL=${_BACKEND_URL}'
+      - '--cache-from'
+      - '${_DEPS_CACHE}'
+      - '--cache-from'
+      - '${_BUILD_CACHE}'
+      - '--cache-from'
+      - '${_IMAGE_LATEST}'
+      - '-t'
+      - '${_IMAGE_TAG}'
+      - '-t'
+      - '${_IMAGE_LATEST}'
+      - '.'
+    waitFor: ['build-build']
 
 images:
-    - '${_IMAGE_TAG}'
-    - '${_IMAGE_LATEST}'
-    - '${_DEPS_CACHE}'
-    - '${_BUILD_CACHE}'
+  - '${_IMAGE_TAG}'
+  - '${_IMAGE_LATEST}'
+  - '${_DEPS_CACHE}'
+  - '${_BUILD_CACHE}'
 
 substitutions:
-    _BACKEND_URL: ''
-    _IMAGE_TAG: ''
-    _IMAGE_LATEST: ''
-    _DEPS_CACHE: ''
-    _BUILD_CACHE: ''
+  _BACKEND_URL: ''
+  _IMAGE_TAG: ''
+  _IMAGE_LATEST: ''
+  _DEPS_CACHE: ''
+  _BUILD_CACHE: ''


### PR DESCRIPTION
## Summary

Optimize Docker build performance for both frontend and backend by implementing multi-stage builds with explicit layer caching. This reduces build times by reusing unchanged dependency layers and intermediate build artifacts across CI/CD runs.

## Changes

**Frontend (`frontend/cloudbuild.yaml`)**
- Refactored single-stage build into three explicit stages: `deps`, `build`, and `runtime`
- Added cache pull step to retrieve previous stage images from registry before building
- Each stage tagged separately (`cache-deps`, `cache-build`, `latest`) to enable granular layer reuse
- Dependencies (`npm ci`) cached independently from application code, so builds skip reinstalls when `package.json`/`package-lock.json` unchanged
- Build stage reuses deps layer; runtime stage reuses both deps and build layers
- Updated `images` section to push all three cache tags plus the versioned image tag

**Backend (`backend/cloudbuild.yaml`)** (new file)
- Created Cloud Build configuration with cache-aware Docker build
- Pull previous `:latest` image before building to reuse `uv sync` layer
- Tag built image with both commit SHA and `:latest` for subsequent builds to reference
- Gracefully handles first-ever build (no prior cache to pull)

**CI/CD Workflow (`.github/workflows/cd.yml`)**
- Backend: Updated to use new `backend/cloudbuild.yaml` config and pass `_IMAGE_LATEST` substitution
- Frontend: Updated to pass all four cache-related substitutions (`_IMAGE_LATEST`, `_DEPS_CACHE`, `_BUILD_CACHE`) to Cloud Build
- Both now explicitly reference their respective `cloudbuild.yaml` files via `--config` flag

## Implementation Details

- Cache pull steps use `docker pull || echo "..."` pattern to gracefully handle missing cache on first build
- `waitFor` dependencies ensure steps execute in correct order (pull-cache → build stages → push)
- Frontend's three-stage approach allows `npm ci` to be cached separately from `npm run build`, so code changes don't invalidate the node_modules layer
- Backend uses simpler two-level caching (just `:latest` reference) since Python dependency installation is typically the slowest step

https://claude.ai/code/session_014eFMdpcgbasSijjwEEFiQd