### PR TITLE
feat: render Phase 2 timeline entries (amendments, CBO estimates, related bills)

### DIFF
--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -1166,6 +1166,32 @@ async def _load_history_from_db(
     return timeline_events, sponsors, list(vote_by_chamber.values())
 
 
+async def _find_law_number_for_bill(
+    session: AsyncSession,
+    congress: int,
+    bill_type: str,
+    bill_number: int,
+) -> int | None:
+    """Return the law_number if this bill became a public law in our DB."""
+    stmt = (
+        select(PublicLaw.law_number)
+        .join(Bill, PublicLaw.bill_id == Bill.bill_id)
+        .where(
+            Bill.congress == congress,
+            Bill.bill_number == str(bill_number),
+            Bill.bill_type == bill_type,
+        )
+    )
+    result = await session.execute(stmt)
+    law_num_str = result.scalar_one_or_none()
+    if law_num_str is None:
+        return None
+    try:
+        return int(law_num_str)
+    except (ValueError, TypeError):
+        return None
+
+
 async def get_law_history(
     session: AsyncSession,
     congress: int,
@@ -1336,6 +1362,7 @@ async def get_law_history(
                             description=amdt.description or amdt.purpose or "",
                             chamber=None,
                             is_milestone=False,
+                            amendment_status=amdt.status,
                         )
                     )
 
@@ -1368,6 +1395,9 @@ async def get_law_history(
                     raw_related = []
 
                 for rb in raw_related:
+                    related_law_number = await _find_law_number_for_bill(
+                        session, rb.congress, rb.bill_type, rb.bill_number
+                    )
                     related_bills.append(
                         RelatedBillSchema(
                             congress=rb.congress,
@@ -1375,6 +1405,7 @@ async def get_law_history(
                             bill_number=rb.bill_number,
                             title=rb.title,
                             relationship_details=rb.relationship_details,
+                            law_number=related_law_number,
                         )
                     )
 

--- a/backend/app/schemas/law_history.py
+++ b/backend/app/schemas/law_history.py
@@ -29,6 +29,7 @@ class TimelineEventSchema(BaseModel):
     vote_nays: int | None = None
     vote_not_voting: int | None = None
     congressional_record_refs: list[str] = []
+    amendment_status: str | None = None
 
 
 class SponsorSchema(BaseModel):
@@ -79,6 +80,7 @@ class RelatedBillSchema(BaseModel):
     bill_number: int
     title: str | None
     relationship_details: str | None
+    law_number: int | None = None
 
 
 class LegislativeHistorySchema(BaseModel):

--- a/frontend/src/components/law-viewer/RelatedBillsPanel.test.tsx
+++ b/frontend/src/components/law-viewer/RelatedBillsPanel.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import RelatedBillsPanel from './RelatedBillsPanel';
+import type { RelatedBill } from '@/lib/types';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseBill: RelatedBill = {
+  congress: 113,
+  bill_type: 'S',
+  bill_number: 545,
+  title: 'A related Senate bill',
+  relationship_details: 'Identical bill',
+  law_number: null,
+};
+
+describe('RelatedBillsPanel', () => {
+  it('renders nothing when bills list is empty', () => {
+    const { container } = render(<RelatedBillsPanel bills={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('links to Congress.gov when law_number is null', () => {
+    render(<RelatedBillsPanel bills={[baseBill]} />);
+    const link = screen.getByRole('link', { name: /S\. 545/ });
+    expect(link.getAttribute('href')).toContain('congress.gov');
+    expect(link.getAttribute('target')).toBe('_blank');
+  });
+
+  it('links internally when law_number is set', () => {
+    const enactedBill: RelatedBill = { ...baseBill, law_number: 22 };
+    render(<RelatedBillsPanel bills={[enactedBill]} />);
+    const link = screen.getByRole('link', { name: /S\. 545/ });
+    expect(link.getAttribute('href')).toBe('/laws/113/22');
+    expect(link.getAttribute('target')).toBeNull();
+  });
+
+  it('renders bill title and relationship details', () => {
+    render(<RelatedBillsPanel bills={[baseBill]} />);
+    expect(screen.getByText('A related Senate bill')).toBeDefined();
+    expect(screen.getByText('Identical bill')).toBeDefined();
+  });
+});

--- a/frontend/src/components/law-viewer/RelatedBillsPanel.tsx
+++ b/frontend/src/components/law-viewer/RelatedBillsPanel.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { RelatedBill } from '@/lib/types';
 
 interface RelatedBillsPanelProps {
@@ -32,7 +33,7 @@ function formatBillLabel(bill: RelatedBill): string {
   return `${typeLabel} ${bill.bill_number} (${bill.congress}th)`;
 }
 
-function billUrl(bill: RelatedBill): string {
+function congressGovUrl(bill: RelatedBill): string {
   const key = bill.bill_type.toLowerCase();
   const typePath = BILL_TYPE_PATHS[key] ?? key;
   return `https://www.congress.gov/bill/${bill.congress}th-congress/${typePath}/${bill.bill_number}`;
@@ -68,14 +69,23 @@ export default function RelatedBillsPanel({ bills }: RelatedBillsPanelProps) {
                 <path d="M12 6 L12 9 Q12 10 11 10 L5 10" />
               </svg>
               <div className="min-w-0 flex-1">
-                <a
-                  href={billUrl(bill)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs font-medium text-blue-600 hover:underline"
-                >
-                  {formatBillLabel(bill)}
-                </a>
+                {bill.law_number != null ? (
+                  <Link
+                    href={`/laws/${bill.congress}/${bill.law_number}`}
+                    className="text-xs font-medium text-blue-600 hover:underline"
+                  >
+                    {formatBillLabel(bill)}
+                  </Link>
+                ) : (
+                  <a
+                    href={congressGovUrl(bill)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs font-medium text-blue-600 hover:underline"
+                  >
+                    {formatBillLabel(bill)}
+                  </a>
+                )}
                 {bill.title && (
                   <p className="mt-0.5 text-[11px] leading-relaxed text-gray-500">
                     {bill.title}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -345,6 +345,7 @@ export interface RelatedBill {
   bill_number: number;
   title: string | null;
   relationship_details: string | null;
+  law_number: number | null;
 }
 
 /** Full legislative history response for a public law. */


### PR DESCRIPTION
## Summary

- Adds `amendment_status` to `TimelineEventSchema` so the adopted/rejected/withdrawn/pending status badges in `TimelineEvent.tsx` now receive data from the API and render correctly
- Adds `law_number: int | None` to `RelatedBillSchema` — populated via a new `_find_law_number_for_bill` DB helper that joins `PublicLaw` ↔ `Bill` to check if a related bill became law in our system
- Updates `RelatedBillsPanel` to use an internal `<Link>` to `/laws/{congress}/{law_number}` when enacted, falling back to Congress.gov otherwise
- Adds `law_number` to the frontend `RelatedBill` type
- Adds `RelatedBillsPanel` tests covering both the internal and external link routing paths

The `CBOEstimatesPanel`, `LegislativeHistoryTab` integration, and Phase 1 milestone view were already implemented correctly and required no changes.

Closes #168