### PR TITLE
fix: parse notes for sections with flat XML structure

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1337,6 +1337,80 @@ def _parse_notes_structure(
     _parse_editorial_notes(raw_notes, notes)
     _parse_statutory_notes(raw_notes, notes)
 
+    # Fallback: some older sections use flat <note> elements without category
+    # wrapper headings ("Editorial Notes" / "Statutory Notes"), so none of the
+    # three parsers above match.  Parse all [NH]...[/NH] blocks directly.
+    if not notes.notes:
+        _parse_flat_notes(raw_notes, notes)
+
+
+def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
+    """Parse notes that lack category-wrapper headings (flat XML structure).
+
+    Some older US Code sections have <note> elements directly under <notes>
+    without an "Editorial Notes" or "Statutory Notes" wrapper.  The parser
+    emits [NH]Header[/NH] markers for each note heading but no category marker,
+    so the three category-aware parsers find nothing.
+
+    Category assignment uses the header text:
+    - Editorial: Amendments, Change of Name, References in Text, Codification,
+      Prior Provisions, Construction, Recodification, Effective Date of Repeal
+    - Statutory: everything else (effective dates, savings, miscellaneous, etc.)
+    """
+    EDITORIAL_HEADERS = {
+        "Amendments",
+        "Change Of Name",
+        "References In Text",
+        "Codification",
+        "Prior Provisions",
+        "Construction",
+        "Recodification",
+        "Effective Date Of Repeal",
+    }
+
+    header_pattern = re.compile(r"\[NH\](.*?)\[/NH\]", re.DOTALL)
+    header_positions: list[tuple[int, int, str]] = []
+    for match in header_pattern.finditer(raw_notes):
+        header = match.group(1).strip()
+        if not header:
+            continue
+        header_positions.append((match.start(), match.end(), header))
+
+    seen_headers: set[str] = set()
+    for i, (_start, end, header) in enumerate(header_positions):
+        if header in seen_headers:
+            continue
+        seen_headers.add(header)
+
+        content_end = (
+            header_positions[i + 1][0]
+            if i + 1 < len(header_positions)
+            else len(raw_notes)
+        )
+        raw_content = raw_notes[end:content_end]
+        content = _strip_note_markers(raw_content)
+
+        if not content or len(content) <= 30:
+            continue
+
+        category = (
+            NoteCategory.EDITORIAL
+            if header in EDITORIAL_HEADERS
+            else NoteCategory.STATUTORY
+        )
+
+        if header == "Amendments":
+            notes.amendments = _parse_amendments(content)
+
+        notes.notes.append(
+            SectionNote(
+                header=header,
+                content=content,
+                lines=normalize_note_content(raw_content),
+                category=category,
+            )
+        )
+
 
 def _strip_note_markers(text: str) -> str:
     """Strip note markers from text.

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1466,6 +1466,112 @@ class TestStatutoryNotesHeaderParsing:
         assert "congressional defense committees" in first_note.content
 
 
+class TestFlatNotesParser:
+    """Tests for _parse_flat_notes — fallback for sections without category wrappers.
+
+    Real-world example: 16 U.S.C. § 797 has individual <note> elements directly
+    under <notes> with no "Editorial Notes" or "Statutory Notes" wrapper heading,
+    so the three category-aware parsers all fail and notes.notes ends up empty.
+    """
+
+    def test_flat_amendments_note_is_editorial(self) -> None:
+        """Flat 'Amendments' note is categorised as EDITORIAL."""
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_flat_notes
+
+        raw_notes = (
+            "[NH]Amendments[/NH] "
+            "2005—Subsec. (e). Pub. L. 109–58, inserted text after first proviso. "
+            "1986—Subsec. (e). Pub. L. 99–495 inserted additional provisions."
+        )
+        notes = SectionNotes()
+        _parse_flat_notes(raw_notes, notes)
+
+        assert len(notes.notes) == 1
+        assert notes.notes[0].header == "Amendments"
+        assert notes.notes[0].category.value == "editorial"
+
+    def test_flat_statutory_note_is_statutory(self) -> None:
+        """Flat notes with non-editorial headers are categorised as STATUTORY."""
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_flat_notes
+
+        raw_notes = (
+            "[NH]Effective Date Of 1986 Amendment[/NH] "
+            "Pub. L. 99–495, § 18, Oct. 16, 1986, 100 Stat. 1259, provided that "
+            "the amendments shall take effect with respect to each license issued after enactment."
+        )
+        notes = SectionNotes()
+        _parse_flat_notes(raw_notes, notes)
+
+        assert len(notes.notes) == 1
+        assert notes.notes[0].header == "Effective Date Of 1986 Amendment"
+        assert notes.notes[0].category.value == "statutory"
+
+    def test_flat_notes_multiple_headers(self) -> None:
+        """Multiple flat notes are all parsed with correct categories."""
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_flat_notes
+
+        raw_notes = (
+            "[NH]Amendments[/NH] "
+            "2005—Subsec. (e). Pub. L. 109–58, inserted text after first proviso. "
+            "1986—Subsec. (e). Pub. L. 99–495 inserted additional provisions. "
+            "[NH]Change Of Name[/NH] "
+            "Department of War designated Department of the Army by act July 26, 1947. "
+            "[NH]Savings Provision[/NH] "
+            "Pub. L. 99–495, § 17(a), Oct. 16, 1986, 100 Stat. 1259, provided that "
+            "nothing in the Act shall be construed as authorizing the appropriation of water."
+        )
+        notes = SectionNotes()
+        _parse_flat_notes(raw_notes, notes)
+
+        assert len(notes.notes) == 3
+        headers = [n.header for n in notes.notes]
+        assert "Amendments" in headers
+        assert "Change Of Name" in headers
+        assert "Savings Provision" in headers
+
+        editorial = [n for n in notes.notes if n.category.value == "editorial"]
+        statutory = [n for n in notes.notes if n.category.value == "statutory"]
+        assert len(editorial) == 2  # Amendments + Change Of Name
+        assert len(statutory) == 1  # Savings Provision
+
+    def test_flat_notes_fallback_in_parse_notes_structure(self) -> None:
+        """_parse_notes_structure triggers the flat fallback when no category headers exist.
+
+        This is the actual bug from 16 U.S.C. § 797: notes text contains [NH] markers
+        but no 'Editorial Notes' / 'Statutory Notes' wrapper.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        raw_notes = (
+            "[NH]Amendments[/NH] "
+            "2005—Subsec. (e). Pub. L. 109–58, inserted text after first proviso. "
+            "1986—Subsec. (e). Pub. L. 99–495 inserted additional provisions. "
+            "[NH]Savings Provision[/NH] "
+            "Pub. L. 99–495, § 17(a), Oct. 16, 1986, 100 Stat. 1259, provided that "
+            "nothing in the Act shall be construed as authorizing the appropriation of water."
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        assert len(notes.notes) >= 2
+        headers = [n.header for n in notes.notes]
+        assert "Amendments" in headers
+        assert "Savings Provision" in headers
+
+    def test_flat_notes_short_content_skipped(self) -> None:
+        """Notes with content <= 30 characters are skipped."""
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_flat_notes
+
+        raw_notes = "[NH]Amendments[/NH] Too short."
+        notes = SectionNotes()
+        _parse_flat_notes(raw_notes, notes)
+
+        assert len(notes.notes) == 0
+
+
 class TestCleanHeading:
     """Tests for _clean_heading function."""
 


### PR DESCRIPTION
## Context

Section pages like [16 U.S.C. § 797](https://codeweliveby.org/sections/16/797) showed no notes despite the USLM XML containing rich annotations (Amendments, Change of Name, Effective Date, Savings Provision, etc.).

The USLM XML for older sections uses a **flat** notes structure — individual `<note>` elements appear directly under `<notes>` without an "Editorial Notes" / "Statutory Notes" category wrapper heading. All three category-aware parsers in `_parse_notes_structure` search for those literal heading strings and found nothing, leaving `notes.notes` empty.

## Changes

- **`pipeline/olrc/normalized_section.py`**: Added `_parse_flat_notes()` as a fallback called from `_parse_notes_structure` when all three category parsers produce nothing. It reads all `[NH]...[/NH]` blocks directly and assigns `EDITORIAL`/`STATUTORY` category by header text (Amendments, Change of Name, etc. → editorial; everything else → statutory). Also handles the Amendments special case that populates `notes.amendments`.

- **`tests/pipeline/test_normalized_section.py`**: Added `TestFlatNotesParser` with 5 tests covering the fallback path, category assignment, multi-note parsing, the end-to-end `_parse_notes_structure` trigger, and the minimum-content guard.

After re-ingestion, 16 U.S.C. § 797 resolves **9 notes** (2 editorial, 7 statutory) where it previously had 0.

Closes #241