### PR TITLE
chore: remove Phase 1 title scope — pipeline now targets all titles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -112,9 +112,6 @@ CWLB treats federal legislation as version control:
 - `PublicLaw` - Enacted legislation with metadata
 - `LawChange` - Diffs showing what each law modified
 
-### Phase 1 Titles (from Task 0.8):
-10, 17, 18, 20, 22, 26, 42, 50
-
 ## Plan Artifacts
 
 When implementation plans are created during planning:

--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pipeline.olrc.downloader import PHASE_1_TITLES, OLRCDownloader
+from pipeline.olrc.downloader import OLRCDownloader
 from pipeline.olrc.parser import USLMParser
 
 if TYPE_CHECKING:
@@ -185,27 +185,11 @@ async def ingest_titles_command(
         return 1 if failed > 0 else 0
 
 
-async def ingest_phase1(
-    download_dir: Path = Path("data/olrc"),
-    force_download: bool = False,
-    force_parse: bool = False,
-) -> int:
-    """Ingest Phase 1 US Code titles (backwards-compatible wrapper)."""
-    from pipeline.olrc.downloader import PHASE_1_TITLES
-
-    return await ingest_titles_command(
-        title_list=PHASE_1_TITLES,
-        download_dir=download_dir,
-        force_download=force_download,
-        force_parse=force_parse,
-    )
-
-
 # =============================================================================
 # Seed laws for local development
 # =============================================================================
 
-# Curated set of Public Laws spanning Phase 1 titles with varying complexity.
+# Curated set of Public Laws with varying complexity.
 # Each entry: (congress, law_number, default_title, short_name)
 SEED_LAWS: list[tuple[int, int, int | None, str]] = [
     # Simple (1-3 amendments)
@@ -1688,7 +1672,7 @@ async def initial_commit_command(
 
     Args:
         release_point: Release point identifier (e.g., "113-21").
-        titles: Title numbers to process (default: Phase 1 titles).
+        titles: Title numbers to process. If None, all titles 1-54 are used.
         download_dir: Directory for OLRC XML files.
 
     Returns:
@@ -1782,7 +1766,7 @@ async def validate_release_point_command(
 
     Args:
         release_point: Release point identifier (e.g., "113-22").
-        titles: Title numbers to validate (default: Phase 1 titles).
+        titles: Title numbers to validate. If None, all downloaded titles are validated.
         download_dir: Directory for OLRC XML files.
         verbose: If True, show per-section results.
 
@@ -1792,13 +1776,11 @@ async def validate_release_point_command(
     from app.models.base import async_session_maker
     from pipeline.legal_parser.release_point_validator import ReleasePointValidator
 
-    titles = titles or PHASE_1_TITLES
-
     async with async_session_maker() as session:
         validator = ReleasePointValidator(session, download_dir=download_dir)
         report = await validator.validate_against_release_point(
             release_point=release_point,
-            titles=titles,
+            titles=titles or list(range(1, 55)),
             verbose=verbose,
         )
 
@@ -1913,7 +1895,7 @@ def main() -> int:
         "--titles",
         type=int,
         nargs="+",
-        help="Title numbers to download (default: Phase 1 titles)",
+        help="Title numbers to download (e.g., '10 17 18'); if omitted, all titles 1-54",
     )
     download_parser.add_argument(
         "--dir",
@@ -1982,15 +1964,10 @@ def main() -> int:
         help="Ingest US Code titles into the database (all titles by default)",
     )
     ingest_titles_parser.add_argument(
-        "--phase1",
-        action="store_true",
-        help="Only ingest Phase 1 titles (10, 17, 18, 20, 22, 26, 42, 50)",
-    )
-    ingest_titles_parser.add_argument(
         "--titles",
         type=str,
         default=None,
-        help="Comma-separated title numbers to ingest (e.g., '10,17,18')",
+        help="Comma-separated title numbers to ingest (e.g., '10,17,18'); if omitted, all downloaded titles",
     )
     ingest_titles_parser.add_argument(
         "--dir",
@@ -2004,28 +1981,6 @@ def main() -> int:
         help="Re-download XML even if files exist",
     )
     ingest_titles_parser.add_argument(
-        "--force-parse",
-        action="store_true",
-        help="Re-parse and update existing records",
-    )
-
-    # Keep ingest-phase1 as an alias for backwards compatibility
-    ingest_phase1_parser = subparsers.add_parser(
-        "ingest-phase1",
-        help="(Deprecated: use ingest-titles --phase1) Ingest Phase 1 titles",
-    )
-    ingest_phase1_parser.add_argument(
-        "--dir",
-        type=Path,
-        default=Path("data/olrc"),
-        help="OLRC XML directory (default: data/olrc)",
-    )
-    ingest_phase1_parser.add_argument(
-        "--force-download",
-        action="store_true",
-        help="Re-download XML even if files exist",
-    )
-    ingest_phase1_parser.add_argument(
         "--force-parse",
         action="store_true",
         help="Re-parse and update existing records",
@@ -2449,7 +2404,7 @@ Examples:
         "--titles",
         type=int,
         nargs="+",
-        help="Title numbers to process (default: Phase 1 titles)",
+        help="Title numbers to process (e.g., '10 17 18'); if omitted, all titles 1-54",
     )
     initial_commit_parser.add_argument(
         "--dir",
@@ -2504,7 +2459,7 @@ Examples:
         "--titles",
         type=int,
         nargs="+",
-        help="Title numbers to validate (default: Phase 1 titles)",
+        help="Title numbers to validate (e.g., '10 17 18'); if omitted, all downloaded titles",
     )
     validate_rp_parser.add_argument(
         "--dir",
@@ -2798,7 +2753,7 @@ Examples:
     set_pipeline_cache(_cli_cache)
 
     if args.command == "download":
-        titles = args.titles or PHASE_1_TITLES
+        titles = args.titles or list(range(1, 55))
         logger.info(f"Downloading titles: {titles}")
         results = asyncio.run(download_titles(titles, args.dir, args.force))
 
@@ -2839,26 +2794,14 @@ Examples:
         )
 
     elif args.command == "ingest-titles":
-        if args.titles:
-            title_list = [int(t.strip()) for t in args.titles.split(",")]
-        elif args.phase1:
-            from pipeline.olrc.downloader import PHASE_1_TITLES as _p1
-
-            title_list = _p1
-        else:
-            title_list = None  # all titles
+        title_list = (
+            [int(t.strip()) for t in args.titles.split(",")]
+            if args.titles
+            else None  # all downloaded titles
+        )
         return asyncio.run(
             ingest_titles_command(
                 title_list=title_list,
-                download_dir=args.dir,
-                force_download=args.force_download,
-                force_parse=args.force_parse,
-            )
-        )
-
-    elif args.command == "ingest-phase1":
-        return asyncio.run(
-            ingest_phase1(
                 download_dir=args.dir,
                 force_download=args.force_download,
                 force_parse=args.force_parse,

--- a/backend/pipeline/olrc/README.md
+++ b/backend/pipeline/olrc/README.md
@@ -38,9 +38,6 @@ downloader = OLRCDownloader(download_dir="data/olrc")
 # Download a single title
 xml_path = await downloader.download_title(17)  # Title 17 - Copyrights
 
-# Download all Phase 1 titles
-results = await downloader.download_phase1_titles()
-
 # Check what's already downloaded
 downloaded = downloader.get_downloaded_titles()  # [17, 18, 26, ...]
 ```
@@ -99,8 +96,8 @@ async with AsyncSession(engine) as session:
     print(log.status)           # "completed"
     print(log.records_created)  # 171
 
-    # Ingest all Phase 1 titles
-    logs = await service.ingest_phase1_titles()
+    # Ingest a title
+    log = await service.ingest_title(17)
 ```
 
 **Features:**
@@ -148,7 +145,7 @@ from pipeline.olrc.initial_commit import InitialCommitService
 service = InitialCommitService(session)
 rp = await service.create_initial_commit(
     release_point="113-21",
-    titles=[10, 17, 18, 20, 22, 26, 42, 50],
+    titles=list(range(1, 55)),  # or omit for all titles
 )
 ```
 
@@ -205,7 +202,6 @@ Key constants that may need updates (see inline documentation for sources):
 | Constant | File | Description |
 |----------|------|-------------|
 | `DEFAULT_RELEASE_POINT` | downloader.py | OLRC release point (e.g., `119-72not60`) |
-| `PHASE_1_TITLES` | downloader.py | Priority titles for initial ingestion |
 | `POSITIVE_LAW_TITLES` | parser.py | Fallback list of positive law titles |
 
 ## Database Tables

--- a/backend/pipeline/olrc/downloader.py
+++ b/backend/pipeline/olrc/downloader.py
@@ -65,9 +65,6 @@ TITLE_XML_URL_PATTERN = (
     "xml_usc{title_number:02d}@{congress}-{public_law}.zip"
 )
 
-# Phase 1 target titles (from Task 0.8)
-PHASE_1_TITLES = [10, 17, 18, 20, 22, 26, 42, 50]
-
 
 class OLRCDownloader:
     """Download US Code XML files from the OLRC website."""
@@ -188,24 +185,6 @@ class OLRCDownloader:
         except zipfile.BadZipFile as e:
             logger.error(f"Invalid ZIP file for Title {title_number}: {e}")
             return None
-
-    async def download_phase1_titles(
-        self, force: bool = False
-    ) -> dict[int, Path | None]:
-        """Download all Phase 1 target titles.
-
-        Args:
-            force: If True, download even if files exist.
-
-        Returns:
-            Dictionary mapping title numbers to their XML file paths.
-        """
-
-        async def _one(n: int) -> tuple[int, Path | None]:
-            return n, await self.download_title(n, force=force)
-
-        pairs = await asyncio.gather(*[_one(n) for n in PHASE_1_TITLES])
-        return dict(pairs)
 
     def get_downloaded_titles(self) -> list[int]:
         """Get list of title numbers that have been downloaded.

--- a/backend/pipeline/olrc/ingestion.py
+++ b/backend/pipeline/olrc/ingestion.py
@@ -285,30 +285,3 @@ class USCodeIngestionService:
         self.session.add(section)
         await self.session.flush()
         return section
-
-    async def ingest_phase1_titles(
-        self, force_download: bool = False, force_parse: bool = False
-    ) -> list[DataIngestionLog]:
-        """Ingest all Phase 1 target titles.
-
-        Args:
-            force_download: If True, download even if files exist.
-            force_parse: If True, re-parse and update even if already ingested.
-
-        Returns:
-            List of ingestion log records.
-        """
-        from pipeline.olrc.downloader import PHASE_1_TITLES
-
-        logs = []
-        for title_number in PHASE_1_TITLES:
-            logger.info(f"Ingesting Title {title_number}...")
-            log = await self.ingest_title(
-                title_number,
-                force_download=force_download,
-                force_parse=force_parse,
-            )
-            logs.append(log)
-            logger.info(f"Title {title_number}: {log.status}")
-
-        return logs

--- a/backend/pipeline/olrc/initial_commit.py
+++ b/backend/pipeline/olrc/initial_commit.py
@@ -1,7 +1,7 @@
 """Initial commit service — establish base state from first OLRC release point.
 
 This module creates the "initial commit" in the version control model by:
-1. Downloading the first OLRC release point for Phase 1 titles
+1. Downloading the first OLRC release point for the specified titles
 2. Parsing all sections (provisions + notes)
 3. Storing initial SectionHistory records (version_number=1)
 4. Creating OLRCReleasePoint record (is_initial=True)
@@ -19,7 +19,7 @@ from app.models import (
     USCodeSection,
 )
 from app.models.release_point import OLRCReleasePoint
-from pipeline.olrc.downloader import PHASE_1_TITLES, OLRCDownloader
+from pipeline.olrc.downloader import OLRCDownloader
 from pipeline.olrc.ingestion import USCodeIngestionService
 from pipeline.olrc.release_point import parse_release_point_identifier
 
@@ -54,12 +54,12 @@ class InitialCommitService:
 
         Args:
             release_point: Release point identifier (e.g., "113-21").
-            titles: Title numbers to process (default: Phase 1 titles).
+            titles: Title numbers to process. If None, all downloaded titles are used.
 
         Returns:
             The created OLRCReleasePoint record.
         """
-        titles = titles or PHASE_1_TITLES
+        titles = titles or list(range(1, 55))
         congress, law_identifier = parse_release_point_identifier(release_point)
 
         # Check if already exists

--- a/backend/tests/pipeline/test_downloader.py
+++ b/backend/tests/pipeline/test_downloader.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from pipeline.olrc.downloader import PHASE_1_TITLES, OLRCDownloader
+from pipeline.olrc.downloader import OLRCDownloader
 
 
 class TestOLRCDownloader:
@@ -79,25 +79,6 @@ class TestOLRCDownloader:
         path = downloader.get_xml_path(99)
 
         assert path is None
-
-
-class TestPhase1Titles:
-    """Tests for Phase 1 title configuration."""
-
-    def test_phase1_titles_defined(self) -> None:
-        """Test that Phase 1 titles are defined."""
-        assert len(PHASE_1_TITLES) > 0
-
-    def test_phase1_titles_valid_range(self) -> None:
-        """Test that Phase 1 titles are in valid range (1-54)."""
-        for title in PHASE_1_TITLES:
-            assert 1 <= title <= 54
-
-    def test_phase1_includes_key_titles(self) -> None:
-        """Test that Phase 1 includes key titles for the project."""
-        # Title 17 (Copyrights) and Title 18 (Crimes) are commonly referenced
-        assert 17 in PHASE_1_TITLES
-        assert 18 in PHASE_1_TITLES
 
 
 class TestDownloadTitleAtReleasePoint:


### PR DESCRIPTION
## Summary

- Drops the `PHASE_1_TITLES` constant (`[10, 17, 18, 20, 22, 26, 42, 50]`) and all code gated on it
- `download`, `initial-commit`, and `validate-release-point` commands now default to all 54 US Code titles instead of the original 8
- Removes `download_phase1_titles()`, `ingest_phase1_titles()`, the `ingest-phase1` CLI alias, and the `--phase1` flag on `ingest-titles`
- Cleans up all references in `CLAUDE.md`, pipeline `README.md`, docstrings, and help text

## Test plan

- [ ] All 714 existing tests pass (`uv run pytest`)
- [ ] `pipeline download --help` shows updated help text (no Phase 1 mention)
- [ ] `pipeline ingest-titles --help` shows no `--phase1` flag
- [ ] `pipeline ingest-phase1` is no longer a valid command

🤖 Generated with [Claude Code](https://claude.com/claude-code)