### PR TITLE
fix: handle <continuation> elements in USLM XML parser

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -2125,6 +2125,29 @@ def _normalize_subsection_recursive(
             child, lines, line_counter, char_pos, child_indent
         )
 
+    # Emit continuation lines at the same indent as the chapeau/content.
+    # These are closing clauses that follow a numbered list (e.g. penalty
+    # text after sub-items in 18 U.S.C. § 1001(a)).
+    for cont_text in subsection.continuation:
+        sentences = _split_into_sentences(cont_text)
+        for sentence_text, _s_start, _s_end in sentences:
+            sentence_text = sentence_text.strip()
+            if sentence_text and sentence_text != PARAGRAPH_BREAK_MARKER:
+                line_counter[0] += 1
+                start_pos = char_pos[0]
+                char_pos[0] += len(sentence_text) + 1
+                lines.append(
+                    ParsedLine(
+                        line_number=line_counter[0],
+                        content=sentence_text,
+                        indent_level=base_indent,
+                        marker=None,
+                        is_header=False,
+                        start_char=start_pos,
+                        end_char=char_pos[0],
+                    )
+                )
+
 
 def normalize_parsed_section(
     parsed_section: ParsedSection,

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -163,7 +163,9 @@ class ParsedSubsection:
     content: str  # The text content (may include chapeau for list intros)
     children: list[ParsedSubsection] = field(default_factory=list)
     level: str = "subsection"  # subsection, paragraph, subparagraph, clause, subclause
-    continuation: list[str] = field(default_factory=list)  # Closing text after child list
+    continuation: list[str] = field(
+        default_factory=list
+    )  # Closing text after child list
 
 
 @dataclass
@@ -1143,9 +1145,9 @@ class USLMParser:
 
                 # Check for section-level continuation (closing text after the list)
                 section_continuation: list[str] = []
-                cont_elems = section_elem.findall("{*}continuation") or section_elem.findall(
-                    "continuation"
-                )
+                cont_elems = section_elem.findall(
+                    "{*}continuation"
+                ) or section_elem.findall("continuation")
                 for cont_elem in cont_elems:
                     cont_text = self._get_text_content(cont_elem, strip_footnotes=True)
                     if cont_text:

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -163,6 +163,7 @@ class ParsedSubsection:
     content: str  # The text content (may include chapeau for list intros)
     children: list[ParsedSubsection] = field(default_factory=list)
     level: str = "subsection"  # subsection, paragraph, subparagraph, clause, subclause
+    continuation: list[str] = field(default_factory=list)  # Closing text after child list
 
 
 @dataclass
@@ -1083,12 +1084,24 @@ class USLMParser:
             ):
                 children.append(self._parse_subsection(child_elem, child_level))
 
+        # Collect continuation elements (closing text that follows a numbered list,
+        # e.g. the penalty clause in 18 U.S.C. § 1001(a))
+        continuation: list[str] = []
+        continuation_elems = elem.findall("{*}continuation") or elem.findall(
+            "continuation"
+        )
+        for cont_elem in continuation_elems:
+            cont_text = self._get_text_content(cont_elem, strip_footnotes=True)
+            if cont_text:
+                continuation.append(cont_text)
+
         return ParsedSubsection(
             marker=marker,
             heading=heading,
             content=content,
             children=children,
             level=level,
+            continuation=continuation,
         )
 
     def _extract_subsections(
@@ -1128,6 +1141,16 @@ class USLMParser:
                     else ""
                 )
 
+                # Check for section-level continuation (closing text after the list)
+                section_continuation: list[str] = []
+                cont_elems = section_elem.findall("{*}continuation") or section_elem.findall(
+                    "continuation"
+                )
+                for cont_elem in cont_elems:
+                    cont_text = self._get_text_content(cont_elem, strip_footnotes=True)
+                    if cont_text:
+                        section_continuation.append(cont_text)
+
                 # Parse each paragraph
                 children = []
                 for para_elem in para_elems:
@@ -1141,6 +1164,7 @@ class USLMParser:
                         content=chapeau_text,
                         children=children,
                         level="subsection",
+                        continuation=section_continuation,
                     )
                 )
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -966,6 +966,156 @@ class TestNormalizeParsedSectionDirectParagraphs:
         assert result.provisions[4].indent_level == 2
 
 
+class TestNormalizeParsedSectionContinuation:
+    """Tests for <continuation> elements in parsed sections.
+
+    Regression tests for Issue #251: continuation text (closing statutory
+    clauses that follow a numbered list, e.g. penalty clauses) was silently
+    dropped from the normalized output.
+    """
+
+    def test_continuation_appended_after_children(self) -> None:
+        """Continuation text appears after child items at the same indent as the chapeau.
+
+        Models 18 U.S.C. § 1001(a): chapeau + three paragraphs + penalty clause.
+        The penalty clause (continuation) must appear at indent_level == 0,
+        matching the chapeau's indent level.
+        """
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        section = ParsedSection(
+            section_number="1001",
+            heading="Statements or entries generally",
+            full_citation="18 U.S.C. § 1001",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="(a)",
+                    heading=None,
+                    content="Whoever knowingly and willfully—",
+                    level="subsection",
+                    children=[
+                        ParsedSubsection(
+                            marker="(1)",
+                            heading=None,
+                            content="falsifies a material fact;",
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(2)",
+                            heading=None,
+                            content="makes any false statement; or",
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(3)",
+                            heading=None,
+                            content="makes or uses any false writing;",
+                            level="paragraph",
+                        ),
+                    ],
+                    continuation=[
+                        "shall be fined under this title or imprisoned not more than 5 years, or both."
+                    ],
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+
+        # Expected lines:
+        #   0: "(a) Whoever knowingly and willfully—"  indent 0
+        #   1: "(1) falsifies a material fact;"         indent 1
+        #   2: "(2) makes any false statement; or"      indent 1
+        #   3: "(3) makes or uses any false writing;"   indent 1
+        #   4: "shall be fined under this title..."     indent 0  (continuation)
+        assert result.provision_count == 5
+
+        chapeau_line = result.provisions[0]
+        assert "(a)" in chapeau_line.content
+        assert "knowingly" in chapeau_line.content
+        assert chapeau_line.indent_level == 0
+
+        assert result.provisions[1].indent_level == 1
+        assert "(1)" in result.provisions[1].content
+
+        assert result.provisions[2].indent_level == 1
+        assert "(2)" in result.provisions[2].content
+
+        assert result.provisions[3].indent_level == 1
+        assert "(3)" in result.provisions[3].content
+
+        continuation_line = result.provisions[4]
+        assert "shall be fined" in continuation_line.content
+        assert continuation_line.indent_level == 0
+        assert continuation_line.marker is None
+
+    def test_continuation_indent_matches_chapeau_not_children(self) -> None:
+        """Continuation is at the same indent as the enclosing chapeau, not the children."""
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        section = ParsedSection(
+            section_number="1001",
+            heading="Test",
+            full_citation="18 U.S.C. § 1001",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="(a)",
+                    heading=None,
+                    content="Intro text—",
+                    level="subsection",
+                    children=[
+                        ParsedSubsection(
+                            marker="(1)",
+                            heading=None,
+                            content="item one;",
+                            level="paragraph",
+                        ),
+                    ],
+                    continuation=["closing clause."],
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+
+        # Lines: chapeau (indent 0), child (indent 1), continuation (indent 0)
+        assert result.provision_count == 3
+        chapeau_indent = result.provisions[0].indent_level
+        child_indent = result.provisions[1].indent_level
+        continuation_indent = result.provisions[2].indent_level
+
+        assert child_indent > chapeau_indent
+        assert continuation_indent == chapeau_indent
+
+    def test_no_continuation_when_absent(self) -> None:
+        """Sections without continuation produce no extra lines at the end."""
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        section = ParsedSection(
+            section_number="102",
+            heading="Test",
+            full_citation="17 U.S.C. § 102",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="(a)",
+                    heading=None,
+                    content="Single item.",
+                    level="subsection",
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+        assert result.provision_count == 1
+        assert result.provisions[0].content == "(a) Single item."
+
+
 class TestNormalizeNoteContent:
     """Tests for normalize_note_content function (notes parsing)."""
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -244,6 +244,97 @@ class TestUSLMParser:
         assert para2.children[0].marker == "(A)"
         assert para2.children[1].marker == "(B)"
 
+    def test_parse_subsection_continuation_element(self, parser: USLMParser) -> None:
+        """_parse_subsection collects <continuation> elements into the continuation field.
+
+        Regression test for Issue #251: continuation text (e.g. penalty clauses
+        closing a list of items) was silently dropped by the parser.
+        """
+        xml = """<subsection xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t18/s1001/a">
+          <num value="a">(a)</num>
+          <chapeau>Except as otherwise provided in this section, whoever, in any matter
+          within the jurisdiction of the executive, legislative, or judicial branch of
+          the Government of the United States, knowingly and willfully—</chapeau>
+          <paragraph identifier="/us/usc/t18/s1001/a/1">
+            <num value="1">(1)</num>
+            <content>falsifies, conceals, or covers up by any trick, scheme, or device
+            a material fact;</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t18/s1001/a/2">
+            <num value="2">(2)</num>
+            <content>makes any materially false, fictitious, or fraudulent statement
+            or representation; or</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t18/s1001/a/3">
+            <num value="3">(3)</num>
+            <content>makes or uses any false writing or document knowing the same to
+            contain any materially false, fictitious, or fraudulent statement or
+            entry;</content>
+          </paragraph>
+          <continuation>shall be fined under this title, imprisoned not more than 5
+          years or, if the offense involves international or domestic terrorism, not
+          more than 8 years, or both.</continuation>
+        </subsection>"""
+        elem = etree.fromstring(xml)
+        result = parser._parse_subsection(elem, "subsection")
+
+        assert result.marker == "(a)"
+        assert "knowingly and willfully" in result.content
+        assert len(result.children) == 3
+        assert len(result.continuation) == 1
+        assert "shall be fined" in result.continuation[0]
+        assert "imprisoned not more than 5" in result.continuation[0]
+
+    def test_parse_subsection_no_continuation(self, parser: USLMParser) -> None:
+        """_parse_subsection produces an empty continuation list when there is none."""
+        xml = """<subsection xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t17/s101/a">
+          <num value="a">(a)</num>
+          <content>A work is created when fixed in a tangible medium.</content>
+        </subsection>"""
+        elem = etree.fromstring(xml)
+        result = parser._parse_subsection(elem, "subsection")
+
+        assert result.continuation == []
+
+    def test_extract_subsections_continuation_in_subsection(
+        self, parser: USLMParser
+    ) -> None:
+        """Continuation text inside a <subsection> element is captured and accessible.
+
+        Regression test for Issue #251: models 18 U.S.C. § 1001(a) where the
+        penalty clause follows three numbered paragraphs inside subsection (a).
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t18/s1001">
+          <num value="1001">§ 1001.</num>
+          <heading>Statements or entries generally</heading>
+          <subsection identifier="/us/usc/t18/s1001/a">
+            <num value="a">(a)</num>
+            <chapeau>Whoever knowingly and willfully—</chapeau>
+            <paragraph identifier="/us/usc/t18/s1001/a/1">
+              <num value="1">(1)</num>
+              <content>falsifies a material fact;</content>
+            </paragraph>
+            <paragraph identifier="/us/usc/t18/s1001/a/2">
+              <num value="2">(2)</num>
+              <content>makes any false statement; or</content>
+            </paragraph>
+            <continuation>shall be fined under this title or imprisoned not more
+            than 5 years, or both.</continuation>
+          </subsection>
+        </section>"""
+        elem = etree.fromstring(xml)
+        subsections = parser._extract_subsections(elem)
+
+        assert len(subsections) == 1
+        sub_a = subsections[0]
+        assert sub_a.marker == "(a)"
+        assert len(sub_a.children) == 2
+        assert len(sub_a.continuation) == 1
+        assert "shall be fined" in sub_a.continuation[0]
+
 
 class TestToTitleCase:
     """Tests for to_title_case function."""


### PR DESCRIPTION
## Summary

The USLM XML parser's `_parse_subsection()` silently dropped `<continuation>` elements — the closing text (e.g. penalty clauses) that follows a numbered list of paragraphs within a subsection. For example, 18 U.S.C. § 1001(a) lists three prohibited acts but the entire penalty clause ("shall be fined under this title, imprisoned not more than 5 years…") was missing from the API response.

## Changes

- **`pipeline/olrc/parser.py`**: Added a `continuation: list[str]` field to `ParsedSubsection`. `_parse_subsection()` now finds all `{*}continuation` child elements and collects their text. `_extract_subsections()` does the same at the section level.
- **`pipeline/olrc/normalized_section.py`**: `_normalize_subsection_recursive()` now emits continuation texts as `ParsedLine` entries at `base_indent` (same level as the chapeau), after all child items are emitted.
- **`tests/pipeline/test_parser.py`**: New tests verify `<continuation>` text is captured in `ParsedSubsection.continuation`.
- **`tests/pipeline/test_normalized_section.py`**: New tests verify continuation lines appear in normalized output at the correct indent level.

Closes #251