### PR TITLE
feat: distributed bootstrap via Cloud Run Job fan-out

### DIFF
--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -2613,6 +2614,38 @@ Examples:
         default=Path("data/olrc"),
         help="OLRC XML directory (default: data/olrc)",
     )
+    chrono_bootstrap_parser.add_argument(
+        "--task-index",
+        type=int,
+        default=None,
+        dest="task_index",
+        help="Cloud Run Job task index (0-based). "
+        "Overridden by CLOUD_RUN_TASK_INDEX env var when running in Cloud Run.",
+    )
+    chrono_bootstrap_parser.add_argument(
+        "--task-count",
+        type=int,
+        default=None,
+        dest="task_count",
+        help="Total Cloud Run Job task count. "
+        "Overridden by CLOUD_RUN_TASK_COUNT env var when running in Cloud Run.",
+    )
+
+    chrono_bootstrap_finalize_parser = subparsers.add_parser(
+        "chrono-bootstrap-finalize",
+        help="Mark a bootstrap revision INGESTED after all fan-out tasks complete",
+    )
+    chrono_bootstrap_finalize_parser.add_argument(
+        "release_point",
+        type=str,
+        help="Release point identifier (e.g., '113-21')",
+    )
+    chrono_bootstrap_finalize_parser.add_argument(
+        "--dir",
+        type=Path,
+        default=Path("data/olrc"),
+        help="OLRC XML directory (default: data/olrc)",
+    )
 
     chrono_ingest_rp_parser = subparsers.add_parser(
         "chrono-ingest-rp",
@@ -3113,6 +3146,16 @@ Examples:
                 titles=title_list,
                 force=args.force,
                 download_dir=args.dir,
+                task_index=args.task_index,
+                task_count=args.task_count,
+            )
+        )
+
+    elif args.command == "chrono-bootstrap-finalize":
+        return asyncio.run(
+            chrono_bootstrap_finalize_command(
+                release_point=args.release_point,
+                download_dir=args.dir,
             )
         )
 
@@ -3392,14 +3435,31 @@ async def chrono_bootstrap_command(
     titles: list[int] | None,
     force: bool,
     download_dir: Path,
+    task_index: int | None = None,
+    task_count: int | None = None,
 ) -> int:
     """Bootstrap the chronological pipeline from an OLRC release point.
+
+    If CLOUD_RUN_TASK_INDEX / CLOUD_RUN_TASK_COUNT env vars are set (or
+    --task-index / --task-count flags), runs in Cloud Run Job fan-out mode:
+    each task processes its assigned title slice and exits. Call
+    chrono-bootstrap-finalize after all tasks complete to mark the revision
+    INGESTED. Otherwise runs the standard single-process path.
 
     If release_point is None, auto-detects the oldest available RP.
     """
     from app.models.base import async_session_maker
     from pipeline.olrc.bootstrap import BootstrapService
     from pipeline.olrc.release_point import ReleasePointRegistry
+
+    # Cloud Run sets these env vars for every task in a job.
+    env_task_index = os.environ.get("CLOUD_RUN_TASK_INDEX")
+    env_task_count = os.environ.get("CLOUD_RUN_TASK_COUNT")
+    if env_task_index is not None and env_task_count is not None:
+        task_index = int(env_task_index)
+        task_count = int(env_task_count)
+
+    fan_out_mode = task_index is not None and task_count is not None
 
     if release_point is None:
         registry = ReleasePointRegistry()
@@ -3416,17 +3476,54 @@ async def chrono_bootstrap_command(
         service = BootstrapService(
             session, downloader, session_factory=async_session_maker
         )
-        result = await service.create_initial_commit(
-            release_point, titles=titles, force=force
-        )
 
-    print(f"\nBootstrap result for {result.rp_identifier}:")
+        if fan_out_mode:
+            print(f"Fan-out mode: task {task_index}/{task_count} for {release_point}")
+            result = await service.ingest_titles_for_task(
+                release_point,
+                task_index=task_index,
+                task_count=task_count,
+                force=force,
+            )
+        else:
+            result = await service.create_initial_commit(
+                release_point, titles=titles, force=force
+            )
+
+    if fan_out_mode:
+        print(f"\nTask {task_index}/{task_count} result for {result.rp_identifier}:")
+    else:
+        print(f"\nBootstrap result for {result.rp_identifier}:")
     print(f"  Revision ID:      {result.revision_id}")
     print(f"  Titles processed: {result.titles_processed}")
     print(f"  Titles skipped:   {result.titles_skipped}")
     print(f"  Total sections:   {result.total_sections}")
     print(f"  Elapsed:          {result.elapsed_seconds:.1f}s")
 
+    return 0
+
+
+async def chrono_bootstrap_finalize_command(
+    release_point: str,
+    download_dir: Path,
+) -> int:
+    """Mark a bootstrap revision INGESTED after all fan-out tasks complete."""
+    from app.models.base import async_session_maker
+    from pipeline.olrc.bootstrap import BootstrapService
+
+    downloader = OLRCDownloader(download_dir=download_dir, cache=_cli_cache)
+
+    async with async_session_maker() as session:
+        service = BootstrapService(
+            session, downloader, session_factory=async_session_maker
+        )
+        try:
+            revision_id = await service.finalize_revision(release_point)
+        except ValueError as exc:
+            logger.error(str(exc))
+            return 1
+
+    print(f"\nFinalized revision {revision_id} for {release_point} → INGESTED")
     return 0
 
 

--- a/backend/pipeline/job/README.md
+++ b/backend/pipeline/job/README.md
@@ -1,0 +1,145 @@
+# Cloud Run Job: Bootstrap Fan-out
+
+This directory documents how to run the bootstrap pipeline as a distributed
+Cloud Run Job, where each task processes one (or a few) US Code titles in
+parallel rather than running all 54 titles in a single container.
+
+## Why fan-out?
+
+The single-container bootstrap uses `asyncio.gather` with a semaphore
+(concurrency cap: 6). Fan-out breaks the work across independent Cloud Run Job
+tasks, giving each title its own CPU and memory allocation and enabling
+per-title retry on failure without re-running the whole job.
+
+## How it works
+
+Cloud Run Jobs sets two environment variables on every task:
+
+| Variable | Description |
+|---|---|
+| `CLOUD_RUN_TASK_INDEX` | 0-based index of this task |
+| `CLOUD_RUN_TASK_COUNT` | Total number of tasks in the job |
+
+The `chrono-bootstrap` CLI reads these variables and partitions titles using
+round-robin: task `i` processes `ALL_TITLES[i::task_count]`. With 54 tasks,
+each task processes exactly one title.
+
+**Coordination**: Task 0 creates the `OLRCReleasePoint` and `CodeRevision`
+records in the database, then commits. Non-zero tasks poll for these records
+(up to 120 s) before inserting snapshots, satisfying the FK constraint.
+
+**Finalization**: Tasks exit after ingesting their titles. The revision remains
+in `INGESTING` status. Run `chrono-bootstrap-finalize` after the job completes
+to mark it `INGESTED`.
+
+## Workflow
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Cloud Run Job (54 tasks, parallelism 54)           │
+│                                                     │
+│  Task 0: creates revision records, ingests title 1  │
+│  Task 1: waits for records, ingests title 2         │
+│  Task 2: waits for records, ingests title 3         │
+│  ...                                                │
+│  Task 53: waits for records, ingests title 54       │
+└─────────────────────────────────────────────────────┘
+                        ↓ job completes
+  chrono-bootstrap-finalize 113-21   (marks INGESTED)
+```
+
+## Running the fan-out job
+
+### Prerequisites
+
+- Docker image built and pushed to Artifact Registry
+- Cloud Run Job service account with Cloud SQL Client role
+- `CLOUD_SQL_DATABASE_URL` secret in Secret Manager
+
+### One-time: create the job
+
+```bash
+IMAGE="us-central1-docker.pkg.dev/YOUR_PROJECT/cwlb/backend:latest"
+PROJECT="YOUR_PROJECT"
+REGION="us-central1"
+SQL_CONN="YOUR_PROJECT:us-central1:cwlb-db"
+DB_URL_SECRET="projects/YOUR_PROJECT/secrets/CLOUD_SQL_DATABASE_URL/versions/latest"
+
+gcloud run jobs create bootstrap-fanout \
+    --image "$IMAGE" \
+    --region "$REGION" \
+    --project "$PROJECT" \
+    --tasks 54 \
+    --parallelism 54 \
+    --max-retries 3 \
+    --task-timeout 3600 \
+    --memory 4Gi \
+    --cpu 2 \
+    --set-cloudsql-instances "$SQL_CONN" \
+    --set-secrets "CLOUD_SQL_DATABASE_URL=$DB_URL_SECRET" \
+    --command "uv" \
+    --args "run,pipeline,chrono-bootstrap,113-21"
+```
+
+### Execute the job
+
+```bash
+gcloud run jobs execute bootstrap-fanout \
+    --region "$REGION" \
+    --project "$PROJECT" \
+    --wait
+```
+
+### Finalize after the job completes
+
+```bash
+# Connect to a Cloud Run instance or run locally with DB access:
+uv run pipeline chrono-bootstrap-finalize 113-21
+```
+
+### Or: override the release point at execute time
+
+```bash
+gcloud run jobs execute bootstrap-fanout \
+    --region "$REGION" \
+    --project "$PROJECT" \
+    --update-args "run,pipeline,chrono-bootstrap,119-72not60" \
+    --wait
+```
+
+## Local testing (single-task simulation)
+
+Test a specific task without Cloud Run:
+
+```bash
+# Simulate task 3 of 54
+CLOUD_RUN_TASK_INDEX=3 CLOUD_RUN_TASK_COUNT=54 \
+    uv run pipeline chrono-bootstrap 113-21
+
+# Or use CLI flags directly
+uv run pipeline chrono-bootstrap 113-21 --task-index 3 --task-count 54
+```
+
+## Adjusting parallelism
+
+To balance cost vs. speed, use fewer tasks (each processes more titles):
+
+```bash
+# 27 tasks, each handles 2 titles
+gcloud run jobs update bootstrap-fanout \
+    --tasks 27 --parallelism 27 ...
+```
+
+The CLI handles any `task_count` value via round-robin partitioning.
+
+## Resource sizing
+
+| Task count | Titles per task | Recommended memory | Recommended CPU |
+|---|---|---|---|
+| 54 | 1 | 2 Gi | 1 |
+| 27 | 2 | 3 Gi | 2 |
+| 18 | 3 | 4 Gi | 2 |
+| 9 | 6 | 8 Gi | 4 |
+
+Large titles (e.g., Title 26 / Internal Revenue Code) require more memory.
+When using fewer tasks, size for the largest title in each group.

--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -36,6 +36,42 @@ SessionFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
 # Default title range: all 54 titles of the US Code
 ALL_TITLES = list(range(1, 55))
 
+# Cloud Run Job fan-out: seconds between polls for the revision record
+_REVISION_POLL_INTERVAL: float = 5.0
+# Maximum seconds non-zero tasks wait for task 0 to commit revision records
+_REVISION_POLL_TIMEOUT: float = 120.0
+
+
+def partition_titles(
+    task_index: int,
+    task_count: int,
+    all_titles: list[int] | None = None,
+) -> list[int]:
+    """Return the title slice assigned to this Cloud Run Job task.
+
+    Uses round-robin distribution: task i processes all_titles[i::task_count].
+    With task_count=54, each task processes exactly one title.
+
+    Args:
+        task_index: 0-based task index (CLOUD_RUN_TASK_INDEX).
+        task_count: Total number of tasks (CLOUD_RUN_TASK_COUNT).
+        all_titles: Full title list. Defaults to ALL_TITLES (1–54).
+
+    Returns:
+        Titles assigned to this task, in ascending order.
+
+    Raises:
+        ValueError: If task_index or task_count are invalid.
+    """
+    if task_count < 1:
+        raise ValueError(f"task_count must be >= 1, got {task_count}")
+    if not (0 <= task_index < task_count):
+        raise ValueError(
+            f"task_index {task_index} out of range for task_count {task_count}"
+        )
+    titles = all_titles if all_titles is not None else ALL_TITLES
+    return titles[task_index::task_count]
+
 
 class _SectionRow(NamedTuple):
     """Pre-computed data for one SectionSnapshot row, built in a thread pool."""
@@ -260,6 +296,7 @@ class BootstrapService:
         downloader: OLRCDownloader,
         session_factory: SessionFactory | None = None,
         concurrency: int = 6,
+        poll_timeout: float = _REVISION_POLL_TIMEOUT,
     ) -> None:
         self.session = session
         self.downloader = downloader
@@ -268,6 +305,7 @@ class BootstrapService:
         # on a 4-CPU instance, targeting ~60% CPU while leaving headroom before
         # Cloud SQL write pressure becomes a factor on large titles (10/26).
         self._concurrency = concurrency
+        self._poll_timeout = poll_timeout
 
         if session_factory is not None:
             self._session_factory = session_factory
@@ -467,3 +505,214 @@ class BootstrapService:
         self.session.add(revision)
         await self.session.flush()
         return revision
+
+    # ------------------------------------------------------------------
+    # Cloud Run Job fan-out API
+    # ------------------------------------------------------------------
+
+    async def ingest_titles_for_task(
+        self,
+        rp_identifier: str,
+        task_index: int,
+        task_count: int,
+        force: bool = False,
+    ) -> BootstrapResult:
+        """Process one Cloud Run Job task's share of titles.
+
+        Task 0 creates + commits the release point and revision records so FK
+        constraints are satisfied before any task inserts snapshots. Non-zero
+        tasks poll until the revision record appears (up to
+        _REVISION_POLL_TIMEOUT seconds). Titles are processed sequentially
+        within the task — cloud-level parallelism comes from running many tasks.
+
+        Args:
+            rp_identifier: Release point identifier (e.g., "113-21").
+            task_index: 0-based task index (CLOUD_RUN_TASK_INDEX).
+            task_count: Total task count (CLOUD_RUN_TASK_COUNT).
+            force: Re-ingest even if the revision is already INGESTED.
+
+        Returns:
+            BootstrapResult with this task's ingestion statistics.
+        """
+        start_time = time.monotonic()
+        title_list = partition_titles(task_index, task_count)
+
+        if task_index == 0:
+            revision = await self._ensure_revision_record(rp_identifier)
+        else:
+            revision = await self._wait_for_revision_record(
+                rp_identifier, timeout=self._poll_timeout
+            )
+
+        if revision.status == RevisionStatus.INGESTED.value and not force:
+            elapsed = time.monotonic() - start_time
+            logger.info(
+                f"Task {task_index}: {rp_identifier} already INGESTED "
+                f"(revision {revision.revision_id}), skipping"
+            )
+            return BootstrapResult(
+                revision_id=revision.revision_id,
+                rp_identifier=rp_identifier,
+                titles_processed=0,
+                titles_skipped=0,
+                total_sections=0,
+                elapsed_seconds=elapsed,
+            )
+
+        titles_processed = 0
+        titles_skipped = 0
+        total_sections = 0
+
+        for title_num in title_list:
+            async with self._session_factory() as s:
+                try:
+                    count = await ingest_title(
+                        s,
+                        self.downloader,
+                        title_num,
+                        rp_identifier,
+                        revision.revision_id,
+                    )
+                    await s.commit()
+                except Exception:
+                    logger.error(
+                        f"Task {task_index}, title {title_num}: ingest failed",
+                        exc_info=True,
+                    )
+                    count = None
+
+            if count is None:
+                titles_skipped += 1
+            else:
+                titles_processed += 1
+                total_sections += count
+
+        elapsed = time.monotonic() - start_time
+        logger.info(
+            f"Task {task_index}/{task_count} complete: "
+            f"{titles_processed} titles, {total_sections} sections in {elapsed:.1f}s"
+        )
+        return BootstrapResult(
+            revision_id=revision.revision_id,
+            rp_identifier=rp_identifier,
+            titles_processed=titles_processed,
+            titles_skipped=titles_skipped,
+            total_sections=total_sections,
+            elapsed_seconds=elapsed,
+        )
+
+    async def finalize_revision(self, rp_identifier: str) -> int:
+        """Mark the bootstrap revision INGESTED after all fan-out tasks complete.
+
+        Call this after the Cloud Run Job finishes. Idempotent: if the revision
+        is already INGESTED it returns without error.
+
+        Args:
+            rp_identifier: Release point identifier (e.g., "113-21").
+
+        Returns:
+            revision_id that was finalized.
+
+        Raises:
+            ValueError: If no revision exists, or if it is in FAILED status.
+        """
+        release_point, revision = await self._get_or_create_records(rp_identifier)
+
+        if revision is None:
+            raise ValueError(
+                f"No revision found for {rp_identifier}. "
+                "Run fan-out tasks before finalizing."
+            )
+
+        if revision.status == RevisionStatus.INGESTED.value:
+            logger.info(
+                f"Revision {revision.revision_id} for {rp_identifier} already INGESTED"
+            )
+            return revision.revision_id
+
+        if revision.status == RevisionStatus.FAILED.value:
+            raise ValueError(
+                f"Revision {revision.revision_id} for {rp_identifier} has FAILED "
+                "status. Inspect task logs before retrying."
+            )
+
+        revision.status = RevisionStatus.INGESTED.value
+        await self.session.commit()
+        logger.info(
+            f"Revision {revision.revision_id} for {rp_identifier} marked INGESTED"
+        )
+        return revision.revision_id
+
+    async def _ensure_revision_record(self, rp_identifier: str) -> CodeRevision:
+        """Create + commit release point and revision records (task 0 only).
+
+        After committing, the rows are visible to all other Cloud Run task
+        sessions, satisfying the section_snapshot.revision_id FK constraint.
+        """
+        release_point, revision = await self._get_or_create_records(rp_identifier)
+
+        if release_point is None:
+            release_point = await self._upsert_release_point(rp_identifier)
+
+        if revision is None:
+            revision = await self._create_revision(release_point)
+
+        # Commit so the revision row is visible to all worker task sessions.
+        await self.session.commit()
+        return revision
+
+    async def _wait_for_revision_record(
+        self,
+        rp_identifier: str,
+        timeout: float = _REVISION_POLL_TIMEOUT,
+    ) -> CodeRevision:
+        """Poll until the revision record appears in the DB (tasks 1+ only).
+
+        Task 0 creates and commits the record. This lets other tasks block
+        until it is visible before inserting snapshots (FK constraint).
+
+        Args:
+            rp_identifier: Release point identifier.
+            timeout: Max seconds to wait before raising TimeoutError.
+
+        Raises:
+            TimeoutError: If the record doesn't appear within timeout seconds.
+        """
+        deadline = time.monotonic() + timeout
+        poll_count = 0
+
+        while time.monotonic() < deadline:
+            async with self._session_factory() as s:
+                rp_result = await s.execute(
+                    select(OLRCReleasePoint).where(
+                        OLRCReleasePoint.full_identifier == rp_identifier
+                    )
+                )
+                rp = rp_result.scalar_one_or_none()
+
+                if rp is not None:
+                    rev_result = await s.execute(
+                        select(CodeRevision).where(
+                            CodeRevision.release_point_id == rp.release_point_id
+                        )
+                    )
+                    revision = rev_result.scalar_one_or_none()
+                    if revision is not None:
+                        if poll_count > 0:
+                            logger.info(
+                                f"Revision record for {rp_identifier} found "
+                                f"after {poll_count} poll(s)"
+                            )
+                        return revision
+
+            poll_count += 1
+            logger.debug(
+                f"Waiting for revision record ({rp_identifier}), "
+                f"poll {poll_count} (next in {_REVISION_POLL_INTERVAL:.0f}s)"
+            )
+            await asyncio.sleep(_REVISION_POLL_INTERVAL)
+
+        raise TimeoutError(
+            f"Revision record for {rp_identifier} not found after {timeout:.0f}s. "
+            "Ensure task 0 completed successfully."
+        )

--- a/backend/tests/pipeline/test_bootstrap.py
+++ b/backend/tests/pipeline/test_bootstrap.py
@@ -1,4 +1,4 @@
-"""Tests for the bootstrap service (Task 1.19)."""
+"""Tests for the bootstrap service (Task 1.19) and Cloud Run fan-out (issue #181)."""
 
 from __future__ import annotations
 
@@ -9,7 +9,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.models.enums import RevisionStatus, RevisionType
-from pipeline.olrc.bootstrap import BootstrapResult, BootstrapService
+from pipeline.olrc.bootstrap import (
+    ALL_TITLES,
+    BootstrapResult,
+    BootstrapService,
+    partition_titles,
+)
 from pipeline.olrc.parser import ParsedGroup, ParsedSection, USLMParseResult
 
 # ---------------------------------------------------------------------------
@@ -565,3 +570,331 @@ class TestSnapshotFieldMapping:
         assert "parent_commit" in events
         assert "worker_session_open" in events
         assert events.index("parent_commit") < events.index("worker_session_open")
+
+
+# ---------------------------------------------------------------------------
+# Tests: partition_titles
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionTitles:
+    """Tests for the partition_titles helper used by Cloud Run fan-out."""
+
+    def test_single_task_gets_all_titles(self) -> None:
+        result = partition_titles(0, 1)
+        assert result == ALL_TITLES
+
+    def test_round_robin_two_tasks(self) -> None:
+        titles = list(range(1, 7))  # [1, 2, 3, 4, 5, 6]
+        task0 = partition_titles(0, 2, all_titles=titles)
+        task1 = partition_titles(1, 2, all_titles=titles)
+        assert task0 == [1, 3, 5]
+        assert task1 == [2, 4, 6]
+        assert sorted(task0 + task1) == titles
+
+    def test_54_tasks_one_title_each(self) -> None:
+        all_slices = [partition_titles(i, 54) for i in range(54)]
+        assert all(len(s) == 1 for s in all_slices)
+        combined = sorted(t for s in all_slices for t in s)
+        assert combined == ALL_TITLES
+
+    def test_uneven_split(self) -> None:
+        titles = list(range(1, 6))  # 5 titles, 3 tasks
+        task0 = partition_titles(0, 3, all_titles=titles)
+        task1 = partition_titles(1, 3, all_titles=titles)
+        task2 = partition_titles(2, 3, all_titles=titles)
+        assert sorted(task0 + task1 + task2) == titles
+
+    def test_invalid_task_count(self) -> None:
+        with pytest.raises(ValueError, match="task_count"):
+            partition_titles(0, 0)
+
+    def test_invalid_task_index(self) -> None:
+        with pytest.raises(ValueError, match="task_index"):
+            partition_titles(5, 5)  # index 5 out of range [0, 5)
+
+    def test_custom_all_titles(self) -> None:
+        custom = [10, 17, 26]
+        assert partition_titles(0, 3, all_titles=custom) == [10]
+        assert partition_titles(1, 3, all_titles=custom) == [17]
+        assert partition_titles(2, 3, all_titles=custom) == [26]
+
+
+# ---------------------------------------------------------------------------
+# Tests: ingest_titles_for_task
+# ---------------------------------------------------------------------------
+
+
+class TestIngestTitlesForTask:
+    """Tests for the Cloud Run Job fan-out ingestion method."""
+
+    @pytest.mark.asyncio
+    async def test_task0_creates_revision_and_ingests(self) -> None:
+        """Task 0 creates records and ingests its assigned title."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        mock_parser = _make_parser_mock()
+
+        service = BootstrapService(session, downloader)
+
+        with (
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
+            patch("pipeline.olrc.bootstrap.partition_titles", return_value=[17]),
+        ):
+            result = await service.ingest_titles_for_task(
+                "113-21", task_index=0, task_count=1
+            )
+
+        assert result.rp_identifier == "113-21"
+        assert result.titles_processed == 1
+        assert result.total_sections == 1
+        # Task 0 must commit (to make revision visible)
+        session.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_task0_returns_early_when_already_ingested(self) -> None:
+        """Task 0 returns early if revision is already INGESTED."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.release_point_id = 1
+
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 42
+        mock_rev.status = RevisionStatus.INGESTED.value
+
+        call_count = 0
+
+        def fake_execute(_stmt):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = (
+                mock_rp if call_count == 1 else mock_rev
+            )
+            return result
+
+        session.execute = AsyncMock(side_effect=fake_execute)
+
+        service = BootstrapService(session, downloader)
+
+        with patch("pipeline.olrc.bootstrap.partition_titles", return_value=[17]):
+            result = await service.ingest_titles_for_task(
+                "113-21", task_index=0, task_count=1
+            )
+
+        assert result.revision_id == 42
+        assert result.titles_processed == 0
+        downloader.download_title_at_release_point.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_nonzero_task_waits_then_ingests(self) -> None:
+        """Non-zero task polls for the revision record then ingests."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+        mock_parser = _make_parser_mock(_make_parse_result(title_number=18))
+
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.release_point_id = 1
+
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 7
+        mock_rev.status = RevisionStatus.INGESTING.value
+
+        worker_session = _make_mock_session()
+        poll_call_count = 0
+
+        def fake_worker_execute(_stmt):
+            nonlocal poll_call_count
+            poll_call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = (
+                mock_rp if poll_call_count % 2 == 1 else mock_rev
+            )
+            return result
+
+        worker_session.execute = AsyncMock(side_effect=fake_worker_execute)
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def factory():
+            yield worker_session
+
+        service = BootstrapService(session, downloader, session_factory=factory)
+
+        with (
+            patch("pipeline.olrc.bootstrap.partition_titles", return_value=[18]),
+            patch("pipeline.olrc.bootstrap.USLMParser", return_value=mock_parser),
+            patch(
+                "pipeline.olrc.bootstrap.normalize_parsed_section",
+                side_effect=lambda s: s,
+            ),
+            patch("pipeline.olrc.bootstrap.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await service.ingest_titles_for_task(
+                "113-21", task_index=1, task_count=2
+            )
+
+        assert result.titles_processed == 1
+        assert result.revision_id == 7
+
+    @pytest.mark.asyncio
+    async def test_nonzero_task_raises_on_timeout(self) -> None:
+        """Non-zero task raises TimeoutError if revision never appears."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        worker_session = _make_mock_session()
+        never_found = MagicMock()
+        never_found.scalar_one_or_none.return_value = None
+        worker_session.execute = AsyncMock(return_value=never_found)
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def factory():
+            yield worker_session
+
+        # poll_timeout=0.0 forces the while loop to exit immediately
+        service = BootstrapService(
+            session, downloader, session_factory=factory, poll_timeout=0.0
+        )
+
+        with (
+            patch("pipeline.olrc.bootstrap.partition_titles", return_value=[18]),
+            patch("pipeline.olrc.bootstrap.asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(TimeoutError, match="113-21"),
+        ):
+            await service.ingest_titles_for_task("113-21", task_index=1, task_count=2)
+
+
+# ---------------------------------------------------------------------------
+# Tests: finalize_revision
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeRevision:
+    """Tests for BootstrapService.finalize_revision."""
+
+    @pytest.mark.asyncio
+    async def test_marks_ingesting_as_ingested(self) -> None:
+        """INGESTING revision is updated to INGESTED."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.release_point_id = 1
+
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 99
+        mock_rev.status = RevisionStatus.INGESTING.value
+
+        call_count = 0
+
+        def fake_execute(_stmt):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = (
+                mock_rp if call_count == 1 else mock_rev
+            )
+            return result
+
+        session.execute = AsyncMock(side_effect=fake_execute)
+
+        service = BootstrapService(session, downloader)
+        revision_id = await service.finalize_revision("113-21")
+
+        assert revision_id == 99
+        assert mock_rev.status == RevisionStatus.INGESTED.value
+        session.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_when_already_ingested(self) -> None:
+        """Already INGESTED revision does not error."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.release_point_id = 1
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 99
+        mock_rev.status = RevisionStatus.INGESTED.value
+
+        call_count = 0
+
+        def fake_execute(_stmt):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = (
+                mock_rp if call_count == 1 else mock_rev
+            )
+            return result
+
+        session.execute = AsyncMock(side_effect=fake_execute)
+
+        service = BootstrapService(session, downloader)
+        revision_id = await service.finalize_revision("113-21")
+
+        assert revision_id == 99
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_revision(self) -> None:
+        """ValueError raised if no revision exists."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        service = BootstrapService(session, downloader)
+        with pytest.raises(ValueError, match="No revision found"):
+            await service.finalize_revision("113-21")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_failed(self) -> None:
+        """ValueError raised if revision is in FAILED status."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.release_point_id = 1
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 5
+        mock_rev.status = RevisionStatus.FAILED.value
+
+        call_count = 0
+
+        def fake_execute(_stmt):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = (
+                mock_rp if call_count == 1 else mock_rev
+            )
+            return result
+
+        session.execute = AsyncMock(side_effect=fake_execute)
+
+        service = BootstrapService(session, downloader)
+        with pytest.raises(ValueError, match="FAILED"):
+            await service.finalize_revision("113-21")


### PR DESCRIPTION
## Context

Bootstrap currently processes all 54 US Code titles in a single Cloud Run Job task using `asyncio.gather` with a concurrency cap of 6. This ties up a single container's CPU/memory and means a single failure aborts the whole job.

Cloud Run Jobs supports `--tasks N --parallelism N`, where each task gets a `CLOUD_RUN_TASK_INDEX` env var. This PR adds the plumbing to distribute title ingestion across tasks so each title runs in its own container.

## Changes

**`pipeline/olrc/bootstrap.py`**
- `partition_titles(task_index, task_count)` — round-robin title slice for task `i` (`ALL_TITLES[i::task_count]`)
- `BootstrapService.ingest_titles_for_task()` — fan-out entrypoint: task 0 creates + commits revision records (making the FK visible to other tasks); non-zero tasks poll for the revision (up to 120 s) before inserting snapshots; titles processed sequentially within the task
- `BootstrapService.finalize_revision()` — marks the revision `INGESTED` after all tasks complete; idempotent
- `BootstrapService._ensure_revision_record()` / `._wait_for_revision_record()` — coordinator and poller helpers
- `poll_timeout` constructor param for testability

**`pipeline/cli.py`**
- `chrono-bootstrap` auto-detects `CLOUD_RUN_TASK_INDEX` / `CLOUD_RUN_TASK_COUNT` env vars; falls back to `--task-index` / `--task-count` flags for local testing
- New `chrono-bootstrap-finalize` command to mark the revision `INGESTED` after the job

**`pipeline/job/README.md`** — setup guide: `gcloud run jobs create` command, workflow diagram, resource sizing table, local simulation instructions

**`tests/pipeline/test_bootstrap.py`** — 15 new tests covering `partition_titles`, `ingest_titles_for_task` (task 0 coordinator, non-zero waits, timeout), and `finalize_revision` (happy path, idempotent, missing, failed status)

## Workflow

```
# 1. Execute the fan-out job (54 tasks, one title each)
gcloud run jobs execute bootstrap-fanout --wait

# 2. Finalize after the job completes
uv run pipeline chrono-bootstrap-finalize 113-21
```

## Local simulation

```bash
# Simulate task 3 of 54 without Cloud Run
CLOUD_RUN_TASK_INDEX=3 CLOUD_RUN_TASK_COUNT=54 \
    uv run pipeline chrono-bootstrap 113-21

# Or with explicit flags
uv run pipeline chrono-bootstrap 113-21 --task-index 3 --task-count 54
```

Closes #181