### PR TITLE
fix: note-targeting amendments now diff against normalized_notes (#197)

### DIFF
--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -184,6 +184,7 @@ def _amendment_to_schema(amendment: Any) -> ParsedAmendmentSchema:
             section=amendment.section_ref.section,
             subsection_path=amendment.section_ref.subsection_path,
             display=str(amendment.section_ref),
+            is_note=amendment.section_ref.is_note,
         )
 
     position_qualifier = None
@@ -894,6 +895,44 @@ def _build_hunks(
     return hunks
 
 
+def _notes_to_provisions(normalized_notes: Any) -> list[dict[str, Any]]:
+    """Flatten normalized_notes into provision-like dicts for text diffing.
+
+    Used when an amendment targets a section note (``section_ref.is_note``).
+    Strips intermediate XML serialization markers then splits raw_notes by
+    line, yielding one provision dict per non-empty line.
+    """
+    from pipeline.olrc.normalized_section import _strip_note_markers
+
+    if not isinstance(normalized_notes, dict):
+        return []
+    raw = normalized_notes.get("raw_notes", "") or ""
+    if not raw:
+        return []
+    clean = _strip_note_markers(raw)
+    provisions: list[dict[str, Any]] = []
+    line_num = 1
+    char_offset = 0
+    for line in clean.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        provisions.append(
+            {
+                "line_number": line_num,
+                "content": stripped,
+                "indent_level": 0,
+                "marker": None,
+                "is_header": False,
+                "start_char": char_offset,
+                "end_char": char_offset + len(stripped),
+            }
+        )
+        line_num += 1
+        char_offset += len(stripped) + 1
+    return provisions
+
+
 async def compute_law_diffs(
     session: AsyncSession, congress: int, law_number: int
 ) -> list[SectionDiffSchema]:
@@ -931,15 +970,28 @@ async def compute_law_diffs(
     diffs: list[SectionDiffSchema] = []
 
     for (title, section), section_amendments in groups.items():
-        # Separate note amendments from text-modifying amendments
+        # Separate add-note, note-text-modify, and body-text amendments
         note_amendments = [a for a in section_amendments if a.change_type == "Add_Note"]
-        text_amendments = [a for a in section_amendments if a.change_type != "Add_Note"]
+        note_text_amendments = [
+            a
+            for a in section_amendments
+            if a.change_type != "Add_Note"
+            and a.section_ref is not None
+            and a.section_ref.is_note
+        ]
+        text_amendments = [
+            a
+            for a in section_amendments
+            if a.change_type != "Add_Note"
+            and not (a.section_ref is not None and a.section_ref.is_note)
+        ]
 
         # Use batch-fetched "before" state
         state = section_states.get((title, section))
         raw = state.normalized_provisions if state else None
+        heading = state.heading if state else ""
 
-        # Handle text-modifying amendments (normal diff flow)
+        # Handle body text-modifying amendments (normal diff flow)
         if text_amendments:
             if not isinstance(raw, list) or not raw:
                 diffs.append(
@@ -947,7 +999,7 @@ async def compute_law_diffs(
                         title_number=title,
                         section_number=section,
                         section_key=f"{title} U.S.C. § {section}",
-                        heading=state.heading if state else "",
+                        heading=heading,
                         hunks=[],
                         total_lines=0,
                         amendments=text_amendments,
@@ -964,7 +1016,7 @@ async def compute_law_diffs(
                         title_number=title,
                         section_number=section,
                         section_key=f"{title} U.S.C. § {section}",
-                        heading=state.heading if state else "",
+                        heading=heading,
                         hunks=hunks,
                         total_lines=len(after),
                         amendments=text_amendments,
@@ -972,7 +1024,33 @@ async def compute_law_diffs(
                     )
                 )
 
-        # Handle note amendments as a separate "STATUTORY NOTES" diff card
+        # Handle note-targeting text amendments (e.g. "38 U.S.C. 5101 note")
+        if note_text_amendments:
+            raw_notes_dict = state.normalized_notes if state else None
+            note_before = _notes_to_provisions(raw_notes_dict)
+            if note_before:
+                note_after = _apply_amendments_to_provisions(
+                    note_before, note_text_amendments
+                )
+                note_hunks = _build_hunks(note_before, note_after)
+                note_prov_lines = [_provision_to_diff_line(p) for p in note_after]
+            else:
+                note_hunks = []
+                note_prov_lines = []
+            diffs.append(
+                SectionDiffSchema(
+                    title_number=title,
+                    section_number=section,
+                    section_key=f"{title} U.S.C. § {section}",
+                    heading=((heading or "") + " — STATUTORY NOTES").lstrip(" —"),
+                    hunks=note_hunks,
+                    total_lines=len(note_prov_lines),
+                    amendments=note_text_amendments,
+                    all_provisions=note_prov_lines,
+                )
+            )
+
+        # Handle add-note amendments as a separate "STATUTORY NOTES" diff card
         if note_amendments:
             note_hunks = _build_note_hunks(note_amendments)
             note_lines = [line for hunk in note_hunks for line in hunk.lines]

--- a/backend/app/schemas/law_viewer.py
+++ b/backend/app/schemas/law_viewer.py
@@ -42,6 +42,10 @@ class SectionReferenceSchema(BaseModel):
     section: str
     subsection_path: str | None = None
     display: str = Field("", description="Formatted display string")
+    is_note: bool = Field(
+        False,
+        description="True when the amendment targets a note to the section rather than its body",
+    )
 
 
 class PositionQualifierSchema(BaseModel):

--- a/backend/pipeline/legal_parser/amendment_parser.py
+++ b/backend/pipeline/legal_parser/amendment_parser.py
@@ -33,6 +33,7 @@ class SectionReference:
     title: int | None
     section: str
     subsection_path: str | None = None
+    is_note: bool = False
 
     def __str__(self) -> str:
         """Return formatted section reference."""

--- a/backend/pipeline/legal_parser/xml_parser.py
+++ b/backend/pipeline/legal_parser/xml_parser.py
@@ -5,6 +5,7 @@ Parses amendments from GovInfo USLM XML using semantic tags
 Falls back gracefully when XML structure is incomplete.
 """
 
+import dataclasses
 import logging
 import re
 import xml.etree.ElementTree as ET
@@ -384,6 +385,10 @@ class XMLAmendmentParser:
                 if ref is not None:
                     if ref.subsection_path is None:
                         ref = self._augment_subsection(ref, section)
+                    # Detect "38 U.S.C. 5101 note" — display text ends with "note"
+                    # while the href only points to the section itself.
+                    if _element_text(ref_elem).lower().endswith(" note"):
+                        ref = dataclasses.replace(ref, is_note=True)
                     return ref
 
         # Fallback: parse plain text content

--- a/backend/tests/pipeline/test_xml_parser.py
+++ b/backend/tests/pipeline/test_xml_parser.py
@@ -18,11 +18,17 @@ from pipeline.legal_parser.xml_parser import (
 _DATA_DIR = Path(__file__).resolve().parents[2] / "data" / "govinfo" / "plaw"
 
 _PL113_22_XML = _DATA_DIR / "PLAW-113publ22.xml"
+_PL113_59_XML = _DATA_DIR / "PLAW-113publ59.xml"
 _PL114_153_XML = _DATA_DIR / "PLAW-114publ153.xml"
 
 _skip_no_113_22 = pytest.mark.skipif(
     not _PL113_22_XML.exists(),
     reason="Cached PL 113-22 XML not available (run seed-laws first)",
+)
+
+_skip_no_113_59 = pytest.mark.skipif(
+    not _PL113_59_XML.exists(),
+    reason="Cached PL 113-59 XML not available (run seed-laws first)",
 )
 
 _skip_no_114_153 = pytest.mark.skipif(
@@ -137,6 +143,36 @@ class TestParsePL114_153:
         amendments = parser.parse(_load_pl114_153())
         for a in amendments:
             assert a.confidence >= 0.95
+
+
+@_skip_no_113_59
+class TestParsePL113_59:
+    """Regression tests for issue #197 — note-targeting amendment (38 USC 5101 note)."""
+
+    def _get_5101_amendment(self) -> object:
+        parser = XMLAmendmentParser(default_title=38)
+        amendments = parser.parse(_PL113_59_XML.read_text(encoding="utf-8"))
+        hits = [
+            a for a in amendments if a.section_ref and a.section_ref.section == "5101"
+        ]
+        assert hits, "Expected at least one amendment targeting § 5101"
+        return hits[0]
+
+    def test_is_note_flag_set(self) -> None:
+        a = self._get_5101_amendment()
+        assert a.section_ref is not None
+        assert a.section_ref.is_note is True
+
+    def test_old_new_text_extracted(self) -> None:
+        a = self._get_5101_amendment()
+        assert a.old_text == "December 31, 2013"
+        assert a.new_text == "December 31, 2014"
+
+    def test_section_ref_correct(self) -> None:
+        a = self._get_5101_amendment()
+        assert a.section_ref is not None
+        assert a.section_ref.title == 38
+        assert a.section_ref.section == "5101"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

PL 113-59 § 14 amends \"38 U.S.C. 5101 note\" — a note codified from PL 108-183 § 704(c), not the body of § 5101. The USLM `<ref>` has `href=\"/us/usc/t38/s5101\"` but display text \"38 U.S.C. 5101 note\". The previous parser stripped the \"note\" qualifier, treated the amendment as a body-text change, and searched `normalized_provisions` — where the note text doesn't live — producing empty hunks despite correct `old_text`/`new_text` extraction (confirmed by investigation in #197).

## Changes

**`pipeline/legal_parser/amendment_parser.py`**
- `SectionReference` gains `is_note: bool = False`

**`pipeline/legal_parser/xml_parser.py`**
- `_extract_section_ref` detects the \" note\" suffix in ref display text and sets `is_note=True` via `dataclasses.replace`

**`app/schemas/law_viewer.py`**
- `SectionReferenceSchema` exposes `is_note` to the API

**`app/crud/public_law.py`**
- `_amendment_to_schema` passes `is_note` through to the schema
- `compute_law_diffs` splits note-targeting text amendments into a separate path: `_notes_to_provisions` flattens `normalized_notes.raw_notes` (after marker stripping) into provision dicts, applies `_apply_amendments_to_provisions`, and emits a \"— STATUTORY NOTES\" diff card with real hunks

**`tests/pipeline/test_xml_parser.py`**
- Three regression tests on PL 113-59: `is_note` flag set, correct `old_text`/`new_text`, correct title/section

Closes #197