### PR TITLE
feat: wire fan-out bootstrap into CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check seed-related file changes
         id: check
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qE '^backend/(alembic|pipeline)/|^backend/scripts/seed\.sh|^\.github/workflows/cd\.yml$'; then
+          if git diff --name-only HEAD~1 HEAD | grep -qE '^backend/(alembic|pipeline)/|^backend/scripts/seed|^\.github/workflows/cd\.yml$'; then
             echo "seed_needed=true" >> "$GITHUB_OUTPUT"
           else
             echo "seed_needed=false" >> "$GITHUB_OUTPUT"
@@ -227,8 +227,8 @@ jobs:
             --memory 512Mi \
             --quiet
 
-  # Only runs when alembic/, pipeline/, or seed.sh changed. Wipes and reseeds
-  # from scratch — see backend/scripts/seed.sh.
+  # Only runs when alembic/, pipeline/, or seed scripts changed.
+  # Three-phase fan-out pipeline: init → bootstrap (54 tasks) → finalize.
   seed:
     name: Seed Database
     needs: [deploy-backend, check-seed]
@@ -248,21 +248,64 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
-      - name: Run seed job
+      - name: Phase 1 — Init (wipe DB + migrate)
         run: |
-          gcloud run jobs deploy cwlb-seed \
-            --image "$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:$GITHUB_SHA" \
+          IMAGE="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:$GITHUB_SHA"
+          gcloud run jobs deploy cwlb-seed-init \
+            --image "$IMAGE" \
+            --region "$GCP_REGION" \
+            --set-secrets "DATABASE_URL=DATABASE_URL:latest" \
+            --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
+            --memory 512Mi \
+            --cpu 1 \
+            --task-timeout 10m \
+            --max-retries 1 \
+            --command "bash" \
+            --args "scripts/seed_init.sh" \
+            --quiet
+          gcloud run jobs execute cwlb-seed-init \
+            --region "$GCP_REGION" \
+            --wait \
+            --quiet
+
+      - name: Phase 2 — Bootstrap fan-out (54 parallel tasks, one title each)
+        run: |
+          IMAGE="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:$GITHUB_SHA"
+          gcloud run jobs deploy cwlb-seed-bootstrap \
+            --image "$IMAGE" \
+            --region "$GCP_REGION" \
+            --tasks 54 \
+            --parallelism 54 \
+            --set-secrets "DATABASE_URL=DATABASE_URL:latest,GCS_CACHE_BUCKET=GCS_CACHE_BUCKET:latest" \
+            --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
+            --memory 2Gi \
+            --cpu 1 \
+            --task-timeout 30m \
+            --max-retries 3 \
+            --command "bash" \
+            --args "scripts/seed_bootstrap.sh" \
+            --quiet
+          gcloud run jobs execute cwlb-seed-bootstrap \
+            --region "$GCP_REGION" \
+            --wait \
+            --quiet
+
+      - name: Phase 3 — Finalize (mark INGESTED + govinfo + law history + advance)
+        run: |
+          IMAGE="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:$GITHUB_SHA"
+          gcloud run jobs deploy cwlb-seed-finalize \
+            --image "$IMAGE" \
             --region "$GCP_REGION" \
             --set-secrets "DATABASE_URL=DATABASE_URL:latest,GCS_CACHE_BUCKET=GCS_CACHE_BUCKET:latest,GOVINFO_API_KEY=GOVINFO_API_KEY:latest,CONGRESS_API_KEY=CONGRESS_API_KEY:latest" \
             --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
-            --cpu 4 \
-            --memory 16Gi \
-            --task-timeout 120m \
-            --max-retries 2 \
+            --memory 8Gi \
+            --cpu 2 \
+            --task-timeout 90m \
+            --max-retries 1 \
             --command "bash" \
-            --args "scripts/seed.sh" \
+            --args "scripts/seed_finalize.sh" \
             --quiet
-          gcloud run jobs execute cwlb-seed \
+          gcloud run jobs execute cwlb-seed-finalize \
             --region "$GCP_REGION" \
             --wait \
             --quiet

--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -2593,7 +2593,10 @@ Examples:
     chrono_bootstrap_finalize_parser.add_argument(
         "release_point",
         type=str,
-        help="Release point identifier (e.g., '113-21')",
+        nargs="?",
+        default=None,
+        help="Release point identifier (e.g., '113-21'). "
+        "If omitted, auto-detects the current INGESTING bootstrap revision.",
     )
     chrono_bootstrap_finalize_parser.add_argument(
         "--dir",
@@ -3447,10 +3450,13 @@ async def chrono_bootstrap_command(
 
 
 async def chrono_bootstrap_finalize_command(
-    release_point: str,
+    release_point: str | None,
     download_dir: Path,
 ) -> int:
-    """Mark a bootstrap revision INGESTED after all fan-out tasks complete."""
+    """Mark a bootstrap revision INGESTED after all fan-out tasks complete.
+
+    If release_point is omitted, auto-detects the current INGESTING revision.
+    """
     from app.models.base import async_session_maker
     from pipeline.olrc.bootstrap import BootstrapService
 
@@ -3461,12 +3467,16 @@ async def chrono_bootstrap_finalize_command(
             session, downloader, session_factory=async_session_maker
         )
         try:
-            revision_id = await service.finalize_revision(release_point)
+            if release_point is None:
+                rp_identifier, revision_id = await service.finalize_latest_ingesting()
+            else:
+                revision_id = await service.finalize_revision(release_point)
+                rp_identifier = release_point
         except ValueError as exc:
             logger.error(str(exc))
             return 1
 
-    print(f"\nFinalized revision {revision_id} for {release_point} → INGESTED")
+    print(f"\nFinalized revision {revision_id} for {rp_identifier} → INGESTED")
     return 0
 
 

--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -643,6 +643,48 @@ class BootstrapService:
         )
         return revision.revision_id
 
+    async def finalize_latest_ingesting(self) -> tuple[str, int]:
+        """Find and finalize the most recent INGESTING bootstrap revision.
+
+        Used when the release point identifier is not known at finalize time
+        (e.g. when called from seed_finalize.sh without an explicit RP arg).
+
+        Returns:
+            (rp_identifier, revision_id) of the finalized revision.
+
+        Raises:
+            ValueError: If no INGESTING bootstrap revision is found.
+        """
+        stmt = (
+            select(CodeRevision, OLRCReleasePoint)
+            .join(
+                OLRCReleasePoint,
+                CodeRevision.release_point_id == OLRCReleasePoint.release_point_id,
+            )
+            .where(
+                CodeRevision.status == RevisionStatus.INGESTING.value,
+                CodeRevision.is_ground_truth.is_(True),
+            )
+            .order_by(CodeRevision.revision_id.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        row = result.one_or_none()
+
+        if row is None:
+            raise ValueError(
+                "No INGESTING bootstrap revision found. "
+                "Ensure bootstrap fan-out tasks completed before finalizing."
+            )
+
+        revision, rp = row
+        revision.status = RevisionStatus.INGESTED.value
+        await self.session.commit()
+        logger.info(
+            f"Revision {revision.revision_id} for {rp.full_identifier} marked INGESTED"
+        )
+        return rp.full_identifier, revision.revision_id
+
     async def _ensure_revision_record(self, rp_identifier: str) -> CodeRevision:
         """Create + commit release point and revision records (task 0 only).
 

--- a/backend/scripts/seed_bootstrap.sh
+++ b/backend/scripts/seed_bootstrap.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# seed_bootstrap.sh — Phase 2 of the fan-out seed pipeline.
+# Each Cloud Run Job task ingests one title. Cloud Run sets
+# CLOUD_RUN_TASK_INDEX (0-based) and CLOUD_RUN_TASK_COUNT automatically
+# when the job is deployed with --tasks N.
+#
+# Task 0 creates the OLRCReleasePoint + CodeRevision records and ingests
+# its title slice. Tasks 1+ poll until the records appear, then ingest
+# their slice. The revision is marked INGESTED by chrono-bootstrap-finalize
+# in seed_finalize.sh after all tasks complete.
+set -euo pipefail
+
+echo "=== Bootstrap: task ${CLOUD_RUN_TASK_INDEX:-0}/${CLOUD_RUN_TASK_COUNT:-1} ==="
+uv run python -m pipeline.cli chrono-bootstrap
+echo "=== Bootstrap task complete ==="

--- a/backend/scripts/seed_finalize.sh
+++ b/backend/scripts/seed_finalize.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# seed_finalize.sh — Phase 3 of the fan-out seed pipeline.
+# Runs after all bootstrap fan-out tasks complete. Finalizes the bootstrap
+# revision (marks it INGESTED), then runs the rest of the seed pipeline.
+set -euo pipefail
+
+echo "=== Finalizing bootstrap revision ==="
+uv run python -m pipeline.cli chrono-bootstrap-finalize
+
+echo "=== Ingesting Congress 113 laws ==="
+uv run python -m pipeline.cli govinfo-ingest-congress 113
+
+echo "=== Seeding legislative history for Congress 113 ==="
+uv run python -m pipeline.cli seed-congress-law-history 113
+
+echo "=== Advancing chronological pipeline (2 revisions) ==="
+uv run python -m pipeline.cli chrono-advance --count 2
+
+echo "=== Seed complete ==="

--- a/backend/scripts/seed_init.sh
+++ b/backend/scripts/seed_init.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# seed_init.sh — Phase 1 of the fan-out seed pipeline.
+# Wipes the database and runs migrations so the bootstrap fan-out tasks
+# start from a clean, migrated schema. Runs as a single Cloud Run task
+# before cwlb-seed-bootstrap is launched.
+set -euo pipefail
+
+echo "=== Wiping database schema ==="
+uv run python -c "
+import asyncio, asyncpg, os
+
+async def wipe():
+    url = os.environ['DATABASE_URL'].replace('postgresql+asyncpg://', 'postgresql://')
+    conn = await asyncpg.connect(url)
+    await conn.execute('DROP SCHEMA IF EXISTS public CASCADE')
+    await conn.execute('CREATE SCHEMA public')
+    await conn.close()
+
+asyncio.run(wipe())
+"
+
+echo "=== Running migrations ==="
+uv run alembic upgrade head
+
+echo "=== Init complete ==="

--- a/backend/tests/pipeline/test_bootstrap.py
+++ b/backend/tests/pipeline/test_bootstrap.py
@@ -898,3 +898,54 @@ class TestFinalizeRevision:
         service = BootstrapService(session, downloader)
         with pytest.raises(ValueError, match="FAILED"):
             await service.finalize_revision("113-21")
+
+
+class TestFinalizeLatestIngesting:
+    """Tests for BootstrapService.finalize_latest_ingesting (auto-detect)."""
+
+    @pytest.mark.asyncio
+    async def test_finds_and_marks_ingested(self) -> None:
+        """Finds the INGESTING revision and marks it INGESTED."""
+        from app.models.release_point import OLRCReleasePoint
+        from app.models.revision import CodeRevision
+
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        mock_rp = MagicMock(spec=OLRCReleasePoint)
+        mock_rp.full_identifier = "113-21"
+        mock_rp.release_point_id = 1
+
+        mock_rev = MagicMock(spec=CodeRevision)
+        mock_rev.revision_id = 7
+        mock_rev.status = RevisionStatus.INGESTING.value
+        mock_rev.is_ground_truth = True
+
+        mock_row = MagicMock()
+        mock_row.__iter__ = MagicMock(return_value=iter([mock_rev, mock_rp]))
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = mock_row
+        session.execute = AsyncMock(return_value=mock_result)
+
+        service = BootstrapService(session, downloader)
+        rp_id, rev_id = await service.finalize_latest_ingesting()
+
+        assert rp_id == "113-21"
+        assert rev_id == 7
+        assert mock_rev.status == RevisionStatus.INGESTED.value
+        session.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_none_found(self) -> None:
+        """ValueError raised if no INGESTING revision exists."""
+        session = _make_mock_session()
+        downloader = _make_mock_downloader()
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        service = BootstrapService(session, downloader)
+        with pytest.raises(ValueError, match="No INGESTING bootstrap revision"):
+            await service.finalize_latest_ingesting()


### PR DESCRIPTION
## Context

PR #254 implemented the fan-out CLI support (`CLOUD_RUN_TASK_INDEX`/`CLOUD_RUN_TASK_COUNT` awareness in `chrono-bootstrap`), but the CD pipeline still ran a single-task `cwlb-seed` job. This PR wires the fan-out into the actual deploy pipeline and files a bug for the PR #253 seed failure.

## Changes

### CD pipeline (`.github/workflows/cd.yml`)
Replaced the single `cwlb-seed` job with three sequential Cloud Run Job phases, each with appropriate sizing:

| Phase | Job | Tasks | Memory | Timeout |
|---|---|---|---|---|
| Init | `cwlb-seed-init` | 1 | 512Mi | 10m |
| Bootstrap | `cwlb-seed-bootstrap` | 54 | 2Gi each | 30m |
| Finalize | `cwlb-seed-finalize` | 1 | 8Gi | 90m |

Also updated `check-seed` pattern from `seed\.sh` → `seed` to catch all three new scripts.

### New scripts (`backend/scripts/`)
- `seed_init.sh` — wipe DB + run migrations
- `seed_bootstrap.sh` — fan-out bootstrap task (single title per task, driven by `CLOUD_RUN_TASK_INDEX`)
- `seed_finalize.sh` — `chrono-bootstrap-finalize` + govinfo ingest + law history + `chrono-advance`

Original `seed.sh` is preserved for local dev reset.

### `bootstrap.py` + `cli.py`
- `BootstrapService.finalize_latest_ingesting()` — auto-detects the current INGESTING bootstrap revision so `seed_finalize.sh` doesn't need to pass an explicit RP identifier
- `chrono-bootstrap-finalize` — `release_point` arg is now optional; omitting it triggers auto-detect

### Bug filed
- Issue #256 — seed job failed on PR #253 deploy; GCP Console logs for execution `cwlb-seed-smccm` needed to confirm root cause

Closes #181