### PR TITLE
fix: surface per-law failure reasons in seed_congress error_message

### DIFF
--- a/backend/pipeline/congress/law_history_ingestion.py
+++ b/backend/pipeline/congress/law_history_ingestion.py
@@ -169,6 +169,7 @@ class LawHistoryIngestionService:
         total_created = 0
         total_processed = 0
         failed = 0
+        failure_reasons: list[str] = []
 
         for law in laws:
             child_log = await self.seed_law(
@@ -178,11 +179,13 @@ class LawHistoryIngestionService:
             total_created += child_log.records_created or 0
             if child_log.status == "failed":
                 failed += 1
+                reason = child_log.error_message or "unknown error"
+                failure_reasons.append(f"PL {law.congress}-{law.law_number}: {reason}")
                 logger.warning(
                     "Failed to seed PL %d-%s: %s",
                     law.congress,
                     law.law_number,
-                    child_log.error_message,
+                    reason,
                 )
 
         log.status = "failed" if failed > 0 and total_created == 0 else "completed"
@@ -191,6 +194,11 @@ class LawHistoryIngestionService:
         log.details = (
             f"{len(laws)} laws processed, {failed} failed, {total_created} rows created"
         )
+        if log.status == "failed" and failure_reasons:
+            # Surface the first reason so callers get a useful message rather than None
+            first = failure_reasons[0]
+            summary = f"{failed}/{len(laws)} laws failed — first: {first}"
+            log.error_message = summary
         await self.session.commit()
         return log
 


### PR DESCRIPTION
## Problem

`seed-congress-law-history 113` was failing with `ERROR [__main__] Congress 113: None` — the `None` is because `seed_congress()` never set `log.error_message` on the aggregate log, only per-law warnings. When all laws failed, callers got an opaque null.

## Fix

Collect each per-law failure reason and set `log.error_message` to a summary when the aggregate status is `"failed"`:

```
Congress 113: 5/5 laws failed — first: PL 113-1: Could not resolve bill reference for PL 113-1
```

This doesn't fix the root cause (all laws failing — likely a Congress.gov API key or rate-limit issue, see #256 for investigation), but makes the next failure diagnostic instead of silent.

Closes #256

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>