### PR TITLE
fix: reduce bootstrap parallelism to 8 to avoid Cloud SQL connection limit

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -268,14 +268,14 @@ jobs:
             --wait \
             --quiet
 
-      - name: Phase 2 — Bootstrap fan-out (54 parallel tasks, one title each)
+      - name: Phase 2 — Bootstrap fan-out (54 tasks, 8 parallel)
         run: |
           IMAGE="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:$GITHUB_SHA"
           gcloud run jobs deploy cwlb-seed-bootstrap \
             --image "$IMAGE" \
             --region "$GCP_REGION" \
             --tasks 54 \
-            --parallelism 54 \
+            --parallelism 8 \
             --set-secrets "DATABASE_URL=DATABASE_URL:latest,GCS_CACHE_BUCKET=GCS_CACHE_BUCKET:latest" \
             --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
             --memory 2Gi \


### PR DESCRIPTION
## Problem

With `--parallelism 54`, all 54 bootstrap tasks start simultaneously and each opens a SQLAlchemy asyncpg connection pool. 54 pools × default pool_size (~5) = ~270 simultaneous connections, exhausting Cloud SQL's `max_connections`:

```
asyncpg.exceptions.TooManyConnectionsError: remaining connection slots are reserved for non-replication superuser connections
```

## Fix

Keep `--tasks 54` (preserves per-title retry isolation) but cap `--parallelism 8` so only 8 tasks run at a time. 8 tasks × 1-2 active connections = well within Cloud SQL limits.

This makes Phase 2 take ~7 rounds × (time per title) instead of 1 round, but avoids the connection storm entirely.

## Longer-term option

Configure the asyncpg pool to `pool_size=1` for fan-out tasks (each processes one title sequentially, so one connection is sufficient), which would allow safely increasing parallelism again.

Closes #256