### PR TITLE
ci: add workflow_dispatch trigger to CD for manual re-runs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,7 @@ name: CD
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Only one deployment at a time
 concurrency:


### PR DESCRIPTION
Allows triggering the CD pipeline from the GitHub Actions UI (Run workflow button) without needing a dummy commit. Useful when a deploy was cancelled or skipped due to queueing.