### PR TITLE
perf: asyncpg COPY for snapshot inserts + pool_size=1 at parallelism 20

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -269,14 +269,14 @@ jobs:
             --wait \
             --quiet
 
-      - name: Phase 2 — Bootstrap fan-out (54 tasks, 8 parallel)
+      - name: Phase 2 — Bootstrap fan-out (54 tasks, 20 parallel)
         run: |
           IMAGE="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/$AR_REPO/cwlb-backend:$GITHUB_SHA"
           gcloud run jobs deploy cwlb-seed-bootstrap \
             --image "$IMAGE" \
             --region "$GCP_REGION" \
             --tasks 54 \
-            --parallelism 8 \
+            --parallelism 20 \
             --set-secrets "DATABASE_URL=DATABASE_URL:latest,GCS_CACHE_BUCKET=GCS_CACHE_BUCKET:latest" \
             --set-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
             --memory 2Gi \

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,5 +1,6 @@
 """Base model class and database session configuration."""
 
+import os
 from collections.abc import AsyncGenerator
 from datetime import datetime
 
@@ -47,12 +48,18 @@ class TimestampMixin:
     )
 
 
-# Async engine and session
+# Async engine and session.
+# PIPELINE_POOL_SIZE=1 is set by fan-out bootstrap tasks so each of the N
+# parallel Cloud Run tasks holds at most one connection, keeping total
+# connections within Cloud SQL limits even at high parallelism.
+_pool_size = int(os.environ.get("PIPELINE_POOL_SIZE", "5"))
+_max_overflow = 0 if _pool_size <= 1 else 10
+
 engine = create_async_engine(
     settings.database_url,
     echo=settings.debug,
-    pool_size=5,
-    max_overflow=10,
+    pool_size=_pool_size,
+    max_overflow=_max_overflow,
     pool_pre_ping=True,
     pool_recycle=1800,  # Recycle connections after 30 min
 )

--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -141,12 +142,82 @@ def _build_snapshot_rows(
     return rows
 
 
+# Ordered column list for asyncpg binary COPY — must stay in sync with the
+# snapshot_dicts keys built in ingest_title. snapshot_id is omitted; the
+# sequence generates it automatically.
+_COPY_COLUMNS = [
+    "revision_id",
+    "title_number",
+    "section_number",
+    "heading",
+    "text_content",
+    "normalized_provisions",
+    "notes",
+    "normalized_notes",
+    "text_hash",
+    "notes_hash",
+    "full_citation",
+    "is_deleted",
+    "group_id",
+    "sort_order",
+    "created_at",
+    "updated_at",
+]
+
+
+async def _copy_snapshots_to_db(
+    session: AsyncSession,
+    snapshot_dicts: list[dict],
+) -> None:
+    """Bulk-insert snapshot rows via asyncpg binary COPY.
+
+    COPY bypasses the SQL parser and the RETURNING clause that SQLAlchemy's
+    bulk INSERT adds (to retrieve generated PKs we don't use). Expected
+    speedup: 5-10× over the executemany path for large titles.
+
+    asyncpg's JSONB codec (registered by SQLAlchemy's asyncpg dialect) handles
+    Python list/dict → JSONB encoding automatically in binary COPY format.
+    """
+    records = [
+        (
+            d["revision_id"],
+            d["title_number"],
+            d["section_number"],
+            d["heading"],
+            d["text_content"],
+            d["normalized_provisions"],  # list | None — asyncpg JSONB codec
+            d["notes"],
+            d["normalized_notes"],  # dict | None — asyncpg JSONB codec
+            d["text_hash"],
+            d["notes_hash"],
+            d["full_citation"],
+            d["is_deleted"],
+            d["group_id"],  # uuid.UUID | None
+            d["sort_order"],
+            d["created_at"],
+            d["updated_at"],
+        )
+        for d in snapshot_dicts
+    ]
+
+    conn = await session.connection()
+    raw = await conn.get_raw_connection()
+    asyncpg_conn = raw.driver_connection
+    await asyncpg_conn.copy_records_to_table(
+        "section_snapshot",
+        records=records,
+        columns=_COPY_COLUMNS,
+        schema_name="public",
+    )
+
+
 async def ingest_title(
     session: AsyncSession,
     downloader: OLRCDownloader,
     title_num: int,
     rp_identifier: str,
     revision_id: int,
+    use_copy: bool = False,
 ) -> int | None:
     """Download, parse, and store snapshots for one title.
 
@@ -163,6 +234,9 @@ async def ingest_title(
         title_num: US Code title number to ingest.
         rp_identifier: Release point identifier (e.g., "113-21").
         revision_id: The revision ID to attach snapshots to.
+        use_copy: If True, use asyncpg binary COPY instead of INSERT for the
+            snapshot bulk-write. Faster for large titles but requires a real
+            asyncpg connection (not available in tests with mock sessions).
 
     Returns:
         Number of sections ingested, or None if the title was skipped.
@@ -262,7 +336,10 @@ async def ingest_title(
             }
         )
 
-    await session.execute(insert(SectionSnapshot), snapshot_dicts)
+    if use_copy:
+        await _copy_snapshots_to_db(session, snapshot_dicts)
+    else:
+        await session.execute(insert(SectionSnapshot), snapshot_dicts)
     t_insert = time.monotonic()
 
     count = len(rows)
@@ -562,6 +639,7 @@ class BootstrapService:
         titles_processed = 0
         titles_skipped = 0
         total_sections = 0
+        use_copy = os.environ.get("PIPELINE_USE_COPY", "0") == "1"
 
         for title_num in title_list:
             async with self._session_factory() as s:
@@ -572,6 +650,7 @@ class BootstrapService:
                         title_num,
                         rp_identifier,
                         revision.revision_id,
+                        use_copy=use_copy,
                     )
                     await s.commit()
                 except Exception:

--- a/backend/scripts/seed_bootstrap.sh
+++ b/backend/scripts/seed_bootstrap.sh
@@ -10,6 +10,15 @@
 # in seed_finalize.sh after all tasks complete.
 set -euo pipefail
 
+# Each task processes one title sequentially — one connection is sufficient.
+# Keeping pool_size=1 prevents connection storms when many tasks start together.
+export PIPELINE_POOL_SIZE=1
+
+# Use asyncpg binary COPY instead of INSERT for the snapshot bulk-write.
+# Avoids the RETURNING clause SQLAlchemy adds (we don't need the generated PKs)
+# and streams rows via the binary protocol — ~5-10x faster than executemany.
+export PIPELINE_USE_COPY=1
+
 echo "=== Bootstrap: task ${CLOUD_RUN_TASK_INDEX:-0}/${CLOUD_RUN_TASK_COUNT:-1} ==="
 uv run python -m pipeline.cli chrono-bootstrap
 echo "=== Bootstrap task complete ==="


### PR DESCRIPTION
## Summary

Two bootstrap performance improvements measured against the per-title timing from `cwlb-seed-bootstrap-fhf4q`:

| Title | Sections | Insert before | Insert after (est.) | Total before | Total after (est.) |
|---|---|---|---|---|---|
| Title 42 | 6,549 | 16.1s | ~2s | 46.5s | ~34s |
| Title 10 | 3,412 | 9.7s | ~1s | 24.1s | ~16s |
| Title 26 | 1,592 | 5.2s | ~0.5s | 15.7s | ~11s |

Phase 2 estimate: ~15 min → **~4–5 min** (3 rounds of 20 × ~34s max-title).

## Changes

### asyncpg COPY (closes #262)

`_copy_snapshots_to_db()` in `bootstrap.py` extracts the raw asyncpg connection from the SQLAlchemy session and calls `copy_records_to_table()`. This bypasses:
- The `RETURNING snapshot_id` clause SQLAlchemy adds (we never use the returned PKs)
- SQL parsing and planning overhead
- The ORM's per-row network round-trips

Activated via `PIPELINE_USE_COPY=1` in `seed_bootstrap.sh`. `ingest_title` gains a `use_copy: bool = False` param; the existing INSERT path is unchanged for `create_initial_commit`, RPIngestor, and tests.

### pool_size=1 per fan-out task (closes #263)

`PIPELINE_POOL_SIZE=1` in `seed_bootstrap.sh` sets `app/models/base.py`'s engine pool to 1 connection per task (with `max_overflow=0`). Each fan-out task processes exactly one title sequentially and never needs more than one connection. At parallelism=20, this keeps total Cloud SQL connections at 20 instead of 100+ (20 × default pool_size of 5).

`--parallelism` raised from 8 → 20 in `cd.yml` now that connection pressure is controlled.

## What's not changed

- Tests: all 741 pass; mock sessions use the `use_copy=False` default path
- `create_initial_commit` (local dev / non-fan-out): unchanged, uses INSERT
- RPIngestor: unchanged

Closes #262
Closes #263