### PR TITLE
fix: serialize JSONB fields before asyncpg binary COPY

### DIFF
--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -8,6 +8,7 @@ SectionSnapshot records for each section, creating the root CodeRevision
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -175,8 +176,9 @@ async def _copy_snapshots_to_db(
     bulk INSERT adds (to retrieve generated PKs we don't use). Expected
     speedup: 5-10× over the executemany path for large titles.
 
-    asyncpg's JSONB codec (registered by SQLAlchemy's asyncpg dialect) handles
-    Python list/dict → JSONB encoding automatically in binary COPY format.
+    SQLAlchemy's asyncpg JSONB codec expects a pre-serialized JSON string
+    (it prefixes with the JSONB version byte then calls .encode()). Raw
+    Python list/dict values must be serialized with json.dumps() first.
     """
     records = [
         (
@@ -185,9 +187,13 @@ async def _copy_snapshots_to_db(
             d["section_number"],
             d["heading"],
             d["text_content"],
-            d["normalized_provisions"],  # list | None — asyncpg JSONB codec
+            json.dumps(d["normalized_provisions"])
+            if d["normalized_provisions"] is not None
+            else None,
             d["notes"],
-            d["normalized_notes"],  # dict | None — asyncpg JSONB codec
+            json.dumps(d["normalized_notes"])
+            if d["normalized_notes"] is not None
+            else None,
             d["text_hash"],
             d["notes_hash"],
             d["full_citation"],


### PR DESCRIPTION
## Root cause

PR #266 introduced \`PIPELINE_USE_COPY=1\` for the bootstrap pipeline. The \`_copy_snapshots_to_db\` function passed raw Python \`list\`/\`dict\` values for the \`normalized_provisions\` and \`normalized_notes\` JSONB columns. SQLAlchemy's asyncpg JSONB codec (registered via \`add_custom_codec\`) expects a **pre-serialized JSON string** — it prepends the JSONB version byte then calls \`.encode()\`:

\`\`\`python
return b"\x01" + str_value.encode()  # str_value must be a JSON string
\`\`\`

Passing a raw \`list\` caused \`AttributeError: 'list' object has no attribute 'encode'\` for every title that had provisions. The error was caught per-title (logged as "Task N, title M: ingest failed") and each task exited 0 — so the seed job reported success while writing nothing to \`section_snapshot\`.

## Evidence

Cloud Run bootstrap execution \`cwlb-seed-bootstrap-7srbh\` (2026-05-18 CD run):
- 18 tasks logged "ingest failed"
- 23 tasks reported "Titles processed: 0"
- Result: \`/api/v1/titles\` returns \`[]\` in production

## Fix

Serialize JSONB fields with \`json.dumps()\` before passing to \`copy_records_to_table\`.

Closes #278