### PR TITLE
perf: batch-fetch parent states + cache for finalize phase bottlenecks

### DIFF
--- a/backend/app/crud/revision.py
+++ b/backend/app/crud/revision.py
@@ -61,7 +61,7 @@ async def _get_chain(session: AsyncSession) -> list[int] | None:
     head_id = await svc.get_head_revision_id()
     if head_id is None:
         return None
-    chain = await svc._get_revision_chain(head_id)
+    chain = await svc.get_revision_chain(head_id)
     if chain:
         revision_cache.set(head_id, chain)
     return chain if chain else None

--- a/backend/app/crud/us_code.py
+++ b/backend/app/crud/us_code.py
@@ -108,7 +108,7 @@ async def _resolve_head_and_chain(
     """
     if revision_id is not None:
         svc = SnapshotService(session)
-        chain = await svc._get_revision_chain(revision_id)
+        chain = await svc.get_revision_chain(revision_id)
         return revision_id, chain
 
     # Try the cache first
@@ -121,7 +121,7 @@ async def _resolve_head_and_chain(
     head_id = await svc.get_head_revision_id()
     if head_id is None:
         return None, []
-    chain = await svc._get_revision_chain(head_id)
+    chain = await svc.get_revision_chain(head_id)
     revision_cache.set(head_id, chain)
     return head_id, chain
 

--- a/backend/pipeline/chrono/play_forward.py
+++ b/backend/pipeline/chrono/play_forward.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,11 +25,15 @@ from app.models.public_law import PublicLaw
 from app.models.revision import CodeRevision
 from pipeline.chrono.checkpoint import CheckpointResult, validate_checkpoint
 from pipeline.chrono.revision_builder import RevisionBuilder
+from pipeline.govinfo.client import GovInfoClient
 from pipeline.legal_parser.law_change_service import LawChangeService
 from pipeline.olrc.downloader import OLRCDownloader
 from pipeline.olrc.rp_ingestor import RPIngestor
 from pipeline.olrc.snapshot_service import SnapshotService
 from pipeline.timeline import TimelineBuilder, TimelineEvent, TimelineEventType
+
+if TYPE_CHECKING:
+    from pipeline.cache import PipelineCache
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +64,17 @@ class PlayForwardEngine:
         self,
         session: AsyncSession,
         downloader: OLRCDownloader,
+        cache: PipelineCache | None = None,
     ):
         self.session = session
         self.timeline_builder = TimelineBuilder(session)
         self.rp_ingestor = RPIngestor(session, downloader)
         self.revision_builder = RevisionBuilder(session)
         self.snapshot_service = SnapshotService(session)
-        self.law_change_service = LawChangeService(session)
+        govinfo_client = GovInfoClient(cache=cache) if cache is not None else None
+        self.law_change_service = LawChangeService(
+            session, govinfo_client=govinfo_client
+        )
 
     async def advance(self, count: int = 1) -> AdvanceResult:
         """Advance the timeline by processing the next `count` events.

--- a/backend/pipeline/chrono/revision_builder.py
+++ b/backend/pipeline/chrono/revision_builder.py
@@ -25,7 +25,7 @@ from pipeline.chrono.amendment_applicator import (
 )
 from pipeline.chrono.notes_updater import update_notes_for_applied_law
 from pipeline.olrc.parser import compute_text_hash
-from pipeline.olrc.snapshot_service import SnapshotService
+from pipeline.olrc.snapshot_service import SectionState, SnapshotService
 
 logger = logging.getLogger(__name__)
 
@@ -466,14 +466,21 @@ class RevisionBuilder:
             key = (change.title_number, change.section_number)
             section_groups.setdefault(key, []).append(change)
 
-        # 5. Process each section group
+        # 5. Batch-fetch all parent states in a single query instead of
+        # per-section lookups (each of which would rebuild the revision chain).
+        keys = list(section_groups.keys())
+        parent_states = await self.snapshot_service.get_sections_at_revision(
+            keys, parent_revision_id
+        )
+
+        # 6. Process each section group
         for (title_num, section_num), section_changes in section_groups.items():
             await self._apply_section_changes(
                 revision=revision,
                 title_number=title_num,
                 section_number=section_num,
                 section_changes=section_changes,
-                parent_revision_id=parent_revision_id,
+                parent_state=parent_states.get((title_num, section_num)),
                 law=law,
                 result=result,
             )
@@ -503,16 +510,11 @@ class RevisionBuilder:
         title_number: int,
         section_number: str,
         section_changes: list[LawChange],
-        parent_revision_id: int,
+        parent_state: SectionState | None,
         law: PublicLaw,
         result: RevisionBuildResult,
     ) -> None:
         """Apply all changes for a single section and create a snapshot."""
-        # Fetch parent state
-        parent_state = await self.snapshot_service.get_section_at_revision(
-            title_number, section_number, parent_revision_id
-        )
-
         current_text = parent_state.text_content if parent_state else None
         is_deleted = False
         is_new_section = parent_state is None

--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -3861,7 +3861,7 @@ async def chrono_advance_command(
     downloader = OLRCDownloader(download_dir=download_dir, cache=_cli_cache)
 
     async with async_session_maker() as session:
-        engine = PlayForwardEngine(session, downloader)
+        engine = PlayForwardEngine(session, downloader, cache=_cli_cache)
         try:
             result = await engine.advance(count=count)
         except RuntimeError as exc:
@@ -3893,7 +3893,7 @@ async def chrono_advance_to_command(
     downloader = OLRCDownloader(download_dir=download_dir, cache=_cli_cache)
 
     async with async_session_maker() as session:
-        engine = PlayForwardEngine(session, downloader)
+        engine = PlayForwardEngine(session, downloader, cache=_cli_cache)
         try:
             result = await engine.advance_to(release_point)
         except (RuntimeError, ValueError) as exc:

--- a/backend/pipeline/govinfo/ingestion.py
+++ b/backend/pipeline/govinfo/ingestion.py
@@ -72,7 +72,7 @@ class PublicLawIngestionService:
             skipped = 0
 
             # Fetch all law details in parallel, respecting API rate limits
-            sem = asyncio.Semaphore(10)
+            sem = asyncio.Semaphore(20)
 
             async def _fetch_detail(package_id: str) -> PLAWPackageDetail:
                 async with sem:
@@ -209,7 +209,7 @@ class PublicLawIngestionService:
             skipped = 0
 
             # Fetch all law details in parallel, respecting API rate limits
-            sem = asyncio.Semaphore(10)
+            sem = asyncio.Semaphore(20)
 
             async def _fetch_detail(package_id: str) -> PLAWPackageDetail:
                 async with sem:

--- a/backend/pipeline/olrc/snapshot_service.py
+++ b/backend/pipeline/olrc/snapshot_service.py
@@ -87,13 +87,13 @@ class SnapshotService:
             section_number: Section number (e.g., "106", "80a-3a").
             revision_id: The revision to query at.
             chain: Pre-built revision chain (newest-first). If not provided,
-                built internally via ``_get_revision_chain()``.
+                built internally via ``get_revision_chain()``.
 
         Returns:
             SectionState or None if the section doesn't exist at this revision.
         """
         if chain is None:
-            chain = await self._get_revision_chain(revision_id)
+            chain = await self.get_revision_chain(revision_id)
         if not chain:
             return None
 
@@ -149,7 +149,7 @@ class SnapshotService:
         Returns:
             List of SectionState for all live sections at this revision.
         """
-        chain = await self._get_revision_chain(revision_id)
+        chain = await self.get_revision_chain(revision_id)
         if not chain:
             return []
 
@@ -242,7 +242,7 @@ class SnapshotService:
             keys: List of (title_number, section_number) pairs to fetch.
             revision_id: The revision to query at.
             chain: Pre-built revision chain (newest-first). If not provided,
-                built internally via ``_get_revision_chain()``.
+                built internally via ``get_revision_chain()``.
 
         Returns:
             Dict mapping (title_number, section_number) to SectionState.
@@ -251,7 +251,7 @@ class SnapshotService:
         if not keys:
             return {}
         if chain is None:
-            chain = await self._get_revision_chain(revision_id)
+            chain = await self.get_revision_chain(revision_id)
         if not chain:
             return {}
 
@@ -322,7 +322,7 @@ class SnapshotService:
 
         return [self._snapshot_to_state(snap) for snap in snapshots]
 
-    async def _get_revision_chain(self, revision_id: int) -> list[int]:
+    async def get_revision_chain(self, revision_id: int) -> list[int]:
         """Build the chain of revision IDs from target back to initial.
 
         Uses a recursive CTE to fetch the entire chain in a single query

--- a/backend/tests/pipeline/test_revision_builder.py
+++ b/backend/tests/pipeline/test_revision_builder.py
@@ -147,9 +147,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=parent_state,
+            return_value={(26, "401"): parent_state},
         ):
             result = await builder.build_revision(
                 law, parent_revision_id=1, sequence_number=2
@@ -188,9 +188,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=parent_state,
+            return_value={(26, "401"): parent_state},
         ):
             result = await builder.build_revision(
                 law, parent_revision_id=1, sequence_number=2
@@ -220,9 +220,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=None,  # No parent state — new section
+            return_value={},  # No parent state — new section
         ):
             result = await builder.build_revision(
                 law, parent_revision_id=1, sequence_number=2
@@ -251,9 +251,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=parent_state,
+            return_value={(26, "401"): parent_state},
         ):
             result = await builder.build_revision(
                 law, parent_revision_id=1, sequence_number=2
@@ -284,9 +284,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=parent_state,
+            return_value={(26, "401"): parent_state},
         ):
             result = await builder.build_revision(
                 law, parent_revision_id=1, sequence_number=2
@@ -340,9 +340,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=parent_state,
+            return_value={(26, "401"): parent_state},
         ):
             result = await builder.build_revision(
                 law, parent_revision_id=1, sequence_number=2
@@ -369,9 +369,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=parent_state,
+            return_value={(26, "401"): parent_state},
         ):
             await builder.build_revision(law, parent_revision_id=1, sequence_number=2)
 
@@ -402,9 +402,9 @@ class TestRevisionBuilder:
 
         with patch.object(
             builder.snapshot_service,
-            "get_section_at_revision",
+            "get_sections_at_revision",
             new_callable=AsyncMock,
-            return_value=parent_state,
+            return_value={(26, "401"): parent_state},
         ):
             result = await builder.build_revision(
                 law, parent_revision_id=1, sequence_number=2


### PR DESCRIPTION
## Summary

Addresses the three most impactful Phase 3 (`cwlb-seed-finalize`) performance bottlenecks identified in #267:

- **RevisionBuilder batch-fetch**: replaced N separate `get_section_at_revision` calls (each executing a recursive CTE + DISTINCT ON) with a single `get_sections_at_revision` batch query. For a law touching K sections this drops from K CTEs + K queries to 1 CTE + 1 query — the biggest win at full 54-title scale.
- **PlayForwardEngine cache**: `LawChangeService` previously created a `GovInfoClient` without any cache on each invocation. `PlayForwardEngine` now accepts the CLI's `PipelineCache` and passes it through, so law-text HTTP fetches during `chrono-advance` benefit from in-process caching.
- **govinfo-ingest-congress concurrency**: bumped API fetch semaphore from 10 → 20, roughly halving the round-trip time for the 296-law Congress 113 ingest step.

Also makes `SnapshotService._get_revision_chain` a public method (`get_revision_chain`) — it's already called externally from `crud/us_code.py` and `crud/revision.py`.

## Test plan

- [ ] All 720 existing tests pass (`uv run python -m pytest`)
- [ ] No new mypy errors in changed files
- [ ] CI green on this PR
- [ ] Deploy to staging and compare Phase 3 wall-clock time vs the 5m 43s baseline from PR #266

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)