### PR TITLE
perf: reduce per-section CPU overhead in parse and normalize steps

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -131,6 +131,29 @@ LEGAL_ABBREVIATIONS = {
     "Dec.",
 }
 
+# Compiled once: match any known abbreviation at the END of a string.
+# Sorted longest-first so overlapping patterns (e.g. "U.S.C." vs "U.S.") match correctly.
+_ABBREV_SUFFIX_RE = re.compile(
+    "(?:"
+    + "|".join(re.escape(a) for a in sorted(LEGAL_ABBREVIATIONS, key=len, reverse=True))
+    + ")$"
+)
+
+# Compiled once: match any known abbreviation (minus trailing ".") at the START of a string.
+# Used to detect ")(period)(space)(abbreviation)" — not a sentence boundary.
+_ABBREV_PREFIX_RE = re.compile(
+    "^(?:"
+    + "|".join(
+        re.escape(a[:-1])
+        for a in sorted(LEGAL_ABBREVIATIONS, key=len, reverse=True)
+        if len(a) > 1
+    )
+    + ")"
+)
+
+# Compiled once: sentence boundary requires whitespace then capital/open-paren/quote.
+_SENTENCE_FOLLOWS_RE = re.compile(r'\s+[A-Z("\'"\']')
+
 # Pattern for list item markers: (a), (1), (A), (i), (I), etc.
 # Also handles deeper nesting like (a)(1)(A)
 # This pattern is permissive; we filter out references in _is_reference_not_marker()
@@ -672,38 +695,20 @@ def _is_sentence_boundary(text: str, pos: int) -> bool:
         return True  # Only whitespace follows
 
     # Must be followed by whitespace + capital letter, open paren, or quote
-    follows_pattern = re.match(r'\s+[A-Z("\'"\']', remaining)
-    if not follows_pattern:
+    if not _SENTENCE_FOLLOWS_RE.match(remaining):
         return False
 
     # Check if this period is part of a known abbreviation
-    # Look back to find the word ending at this period
     before = text[: pos + 1]  # Include the period
-
-    # Check against known abbreviations
-    for abbrev in LEGAL_ABBREVIATIONS:
-        if before.endswith(abbrev):
-            return False
-
-    # Also check for single-letter abbreviations followed by period
-    # e.g., "U." in "U.S.C."
-    if (
-        pos >= 1
-        and text[pos - 1].isupper()
-        and (pos < 2 or not text[pos - 2].isalnum())
-    ):
-        # Single uppercase letter followed by period - likely abbreviation
-        # unless it's the end of a sentence like "Plan B."
-        pass  # Allow this for now, common abbreviations are in the list
+    if _ABBREV_SUFFIX_RE.search(before):
+        return False
 
     # In amendment citations, a period after a parenthetical reference like
     # "(a)(2)." followed by "Pub. L." is not a sentence boundary.
-    # Pattern: closing paren + period + spaces + known abbreviation start
     if pos >= 1 and text[pos - 1] == ")":
         after_stripped = remaining.lstrip()
-        for abbrev in LEGAL_ABBREVIATIONS:
-            if after_stripped.startswith(abbrev[:-1]):  # Match without trailing .
-                return False
+        if _ABBREV_PREFIX_RE.match(after_stripped):
+            return False
 
     return True
 
@@ -2168,6 +2173,22 @@ def normalize_parsed_section(
     Returns:
         The same ParsedSection with provision fields populated.
     """
+    # Fast path: repealed/reserved stubs have no subsections, no notes, no citations.
+    # Skip the full pipeline and return immediately with just the raw text fallback.
+    if (
+        not parsed_section.subsections
+        and not parsed_section.notes
+        and not parsed_section.source_credit_refs
+        and not parsed_section.act_refs
+        and not parsed_section.notes_refs
+    ):
+        if parsed_section.text_content:
+            fallback = normalize_section(parsed_section.text_content)
+            parsed_section.provisions = fallback.provisions
+            parsed_section.normalized_text = fallback.normalized_text
+        parsed_section.section_notes = SectionNotes()
+        return parsed_section
+
     lines: list[ParsedLine] = []
     line_counter = [0]  # Mutable counter
     char_pos = [0]  # Mutable position tracker

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -121,6 +121,10 @@ NAMESPACES = {
     "xhtml": "http://www.w3.org/1999/xhtml",
 }
 
+# Compiled once at module level — _get_text_content is called O(sections × subsections)
+_WS_RE = re.compile(r"\s+")
+_PUNCT_RE = re.compile(r" ([;,.])")
+
 
 @dataclass
 class ParsedGroup:
@@ -991,10 +995,10 @@ class USLMParser:
         # collapse runs of whitespace to a single space.  Using "".join
         # (instead of " ".join) avoids inserting extra spaces at inline
         # element boundaries like <date> or <ref>.
-        text = re.sub(r"\s+", " ", "".join(parts)).strip()
+        text = _WS_RE.sub(" ", "".join(parts)).strip()
         # Remove stray spaces before punctuation that arise from inline
         # element boundaries (e.g. "<ref>Pub. L. 94–455</ref> ;")
-        text = re.sub(r" ([;,.])", r"\1", text)
+        text = _PUNCT_RE.sub(r"\1", text)
         return text
 
     @staticmethod

--- a/backend/pipeline/olrc/profile_parse_normalize.py
+++ b/backend/pipeline/olrc/profile_parse_normalize.py
@@ -1,0 +1,210 @@
+"""Profiling script for USLMParser.parse_file and normalize_parsed_section.
+
+Usage (from backend/ directory):
+    uv run python -m pipeline.olrc.profile_parse_normalize [xml_path...]
+
+If no paths are given, a synthetic XML file is generated that mimics the
+structure of a large title (deep nesting, continuation elements, notes).
+
+Output: cProfile stats sorted by cumulative time, written to stdout and
+optionally to a .prof file for visualization with snakeviz:
+    uv run snakeviz parse_normalize.prof
+"""
+
+from __future__ import annotations
+
+import cProfile
+import io
+import pstats
+import sys
+import tempfile
+import time
+from pathlib import Path
+from textwrap import dedent
+
+from pipeline.olrc.normalized_section import normalize_parsed_section
+from pipeline.olrc.parser import USLMParser, USLMParseResult
+
+# ---------------------------------------------------------------------------
+# Synthetic XML generation
+# ---------------------------------------------------------------------------
+
+_SECTION_TMPL = """\
+<section identifier="/us/usc/t26/s{num}" number="{num}">
+  <num value="{num}">§ {num}.</num>
+  <heading>{heading}</heading>
+  <subsection identifier="/us/usc/t26/s{num}/ss_a">
+    <num>(a)</num>
+    <heading>General rule</heading>
+    <chapeau>In the case of any individual, gross income includes all of the following:</chapeau>
+    <paragraph identifier="/us/usc/t26/s{num}/ss_a/p1">
+      <num>(1)</num>
+      <content>Compensation for services, including fees, commissions, fringe benefits, and similar items.</content>
+    </paragraph>
+    <paragraph identifier="/us/usc/t26/s{num}/ss_a/p2">
+      <num>(2)</num>
+      <content>Gross income derived from business.</content>
+    </paragraph>
+    <paragraph identifier="/us/usc/t26/s{num}/ss_a/p3">
+      <num>(3)</num>
+      <heading>Capital gains</heading>
+      <chapeau>Gains derived from dealings in property including:</chapeau>
+      <subparagraph>
+        <num>(A)</num>
+        <content>Real property.</content>
+      </subparagraph>
+      <subparagraph>
+        <num>(B)</num>
+        <content>Personal property held for investment.</content>
+      </subparagraph>
+      <continuation>to the extent not excluded under subsection (b).</continuation>
+    </paragraph>
+  </subsection>
+  <subsection identifier="/us/usc/t26/s{num}/ss_b">
+    <num>(b)</num>
+    <heading>Exclusions from gross income</heading>
+    <content>The following items shall be excluded from gross income:
+    amounts received under workmen's compensation acts; amounts received
+    through accident or health insurance; the value of property acquired by
+    gift, bequest, devise, or inheritance.</content>
+  </subsection>
+  <sourceCredit>(Pub. L. 86-272, title I, § {num}, Aug. 28, 1958, 72 Stat. 1606.)</sourceCredit>
+  <notes>
+    <note type="historicalAndRevision"><heading class="smallCaps">Historical and Revision Notes</heading>
+    <p>Based on 26 U.S.C., 1940 ed., § {num} (Feb. 10, 1939, ch. 2, § {num}, 53 Stat. 5).</p>
+    <p>Minor changes were made in phraseology.</p>
+    </note>
+  </notes>
+</section>
+"""
+
+
+def _make_synthetic_xml(section_count: int = 500) -> str:
+    """Generate a synthetic USLM XML document with *section_count* sections."""
+    sections = "\n".join(
+        _SECTION_TMPL.format(num=i + 1, heading=f"Definition of item {i + 1}")
+        for i in range(section_count)
+    )
+    return dedent(f"""\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <usc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+          <meta>
+            <docNumber>26</docNumber>
+            <property role="is-positive-law">no</property>
+          </meta>
+          <main>
+            <title identifier="/us/usc/t26" number="26">
+              <num value="26">Title 26</num>
+              <heading>INTERNAL REVENUE CODE</heading>
+              <chapter identifier="/us/usc/t26/ch1" number="1">
+                <heading>Normal Taxes and Surtaxes</heading>
+                {sections}
+              </chapter>
+            </title>
+          </main>
+        </usc>
+    """)
+
+
+# ---------------------------------------------------------------------------
+# Profiling helpers
+# ---------------------------------------------------------------------------
+
+
+def _print_stats(pr: cProfile.Profile, top_n: int = 25) -> None:
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
+    ps.print_stats(top_n)
+    print(s.getvalue())
+
+
+def profile_parse(xml_path: Path, save_prof: Path | None = None) -> USLMParseResult:
+    print(f"\n{'=' * 60}")
+    print(f"PARSE: {xml_path.name}")
+    print("=" * 60)
+
+    pr = cProfile.Profile()
+    pr.enable()
+    t0 = time.monotonic()
+    result = USLMParser().parse_file(xml_path)
+    elapsed = time.monotonic() - t0
+    pr.disable()
+
+    section_count = len(result.sections)
+    ms_per_section = elapsed * 1000 / section_count if section_count else 0
+    print(f"  {section_count} sections in {elapsed:.2f}s  ({ms_per_section:.2f} ms/§)")
+    _print_stats(pr)
+
+    if save_prof:
+        pr.dump_stats(str(save_prof))
+        print(f"  Profile saved → {save_prof}")
+
+    return result
+
+
+def profile_normalize(
+    result: USLMParseResult, title_label: str = "", save_prof: Path | None = None
+) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"NORMALIZE: {title_label or 'unknown'}")
+    print("=" * 60)
+
+    pr = cProfile.Profile()
+    pr.enable()
+    t0 = time.monotonic()
+    for section in result.sections:
+        normalize_parsed_section(section)
+    elapsed = time.monotonic() - t0
+    pr.disable()
+
+    section_count = len(result.sections)
+    ms_per_section = elapsed * 1000 / section_count if section_count else 0
+    print(f"  {section_count} sections in {elapsed:.2f}s  ({ms_per_section:.2f} ms/§)")
+    _print_stats(pr)
+
+    if save_prof:
+        pr.dump_stats(str(save_prof))
+        print(f"  Profile saved → {save_prof}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> None:
+    xml_paths: list[Path] = [Path(p) for p in argv if argv]
+
+    if not xml_paths:
+        print(
+            "No XML paths given — generating synthetic Title-26-style XML (500 sections)…"
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".xml", delete=False, mode="w", encoding="utf-8"
+        ) as f:
+            f.write(_make_synthetic_xml(section_count=500))
+            tmp_path = Path(f.name)
+        xml_paths = [tmp_path]
+        cleanup = True
+    else:
+        cleanup = False
+
+    try:
+        for xml_path in xml_paths:
+            parse_prof = Path(f"parse_{xml_path.stem}.prof")
+            norm_prof = Path(f"normalize_{xml_path.stem}.prof")
+
+            result = profile_parse(xml_path, save_prof=parse_prof)
+            profile_normalize(result, title_label=xml_path.name, save_prof=norm_prof)
+
+        print(
+            "\nTip: visualize with  uv run snakeviz parse_<name>.prof\n"
+            "     or              uv run snakeviz normalize_<name>.prof"
+        )
+    finally:
+        if cleanup:
+            tmp_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary

Three optimizations targeting the hot paths identified in #264 (parse ~2ms/§, normalize ~2ms/§):

- **parser.py**: Precompile `_WS_RE` and `_PUNCT_RE` at module level. `_get_text_content` is called O(sections × subsections × elements) per title — re-compiling `\s+` and ` ([;,.])` on every invocation was burning CPU needlessly.

- **normalized_section.py**: Replace the two O(n_abbreviations) linear loops in `_is_sentence_boundary` with compiled regex anchored to the string boundary (`_ABBREV_SUFFIX_RE`, `_ABBREV_PREFIX_RE`). Also precompile the `follows_pattern` sentinel. `_is_sentence_boundary` is called for every `.` in every section's text; each call previously iterated ~100 abbreviations twice.

- **normalized_section.py**: Add a fast-path early-exit in `normalize_parsed_section` for repealed/reserved stubs (no subsections, no notes, no citation refs). These skip the full recursive normalization pipeline.

Also adds `profile_parse_normalize.py` — a cProfile harness runnable against real title XML files or synthetic USLM-shaped XML, producing `.prof` files for snakeviz visualization. This directly addresses the "Proposed investigation" items 1–3 from the issue.

## Test plan

- [x] 712 existing tests pass (`uv run --extra dev python -m pytest tests/ -q`)
- [x] mypy clean on all three changed files
- [ ] Run profiler against real title XML (`uv run python -m pipeline.olrc.profile_parse_normalize /path/to/usc26.xml`) to verify speedup and check if deeper investigation is still needed for thread-pool saturation (item 4)

Closes #264