### PR TITLE
feat: show unclassified freestanding provisions in Standalone Provisions section

### DIFF
--- a/backend/app/api/v1/laws.py
+++ b/backend/app/api/v1/laws.py
@@ -9,6 +9,7 @@ from app.crud.public_law import (
     compute_law_diffs,
     get_law_history,
     get_law_metadata,
+    get_law_standalone_provisions,
     get_law_text,
     get_laws_list,
     parse_law_amendments,
@@ -20,6 +21,7 @@ from app.schemas.law_viewer import (
     LawTextSchema,
     ParsedAmendmentSchema,
     SectionDiffSchema,
+    StandaloneProvisionSchema,
 )
 
 router = APIRouter()
@@ -88,6 +90,21 @@ async def read_law_diffs(
 ) -> list[SectionDiffSchema]:
     """Compute per-section unified diffs for a law's amendments."""
     return await compute_law_diffs(session, congress, law_number)
+
+
+@router.get("/{congress}/{law_number}/standalone-provisions")
+async def read_standalone_provisions(
+    congress: int,
+    law_number: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> list[StandaloneProvisionSchema]:
+    """Return freestanding provisions from a law that don't amend the US Code.
+
+    These are sections like naming acts, sunset clauses, standalone
+    appropriations, and definitions scoped to the act itself. They are not
+    included in the codified amendments diff view.
+    """
+    return await get_law_standalone_provisions(session, congress, law_number)
 
 
 @router.get("/{congress}/{law_number}/history")

--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -36,6 +36,7 @@ from app.schemas.law_viewer import (
     PositionQualifierSchema,
     SectionDiffSchema,
     SectionReferenceSchema,
+    StandaloneProvisionSchema,
 )
 
 logger = logging.getLogger(__name__)
@@ -1115,6 +1116,130 @@ def _build_note_hunks(
             lines=lines,
         )
     ]
+
+
+# ---------------------------------------------------------------------------
+# Standalone provisions
+# ---------------------------------------------------------------------------
+
+_EXCERPT_LIMIT = 300
+_NS = "http://schemas.gpo.gov/xml/uslm"
+_INSTRUCTION_ROLES = frozenset({"instruction", "note"})
+
+
+def _uslm_tag(local: str) -> str:
+    return f"{{{_NS}}}{local}"
+
+
+def _iter_text(elem: Any) -> str:
+    """Return all text under *elem*, stripped."""
+    return "".join(elem.itertext()).strip()
+
+
+def _extract_standalone_provisions_from_xml(
+    xml_text: str, congress: int, law_number: int
+) -> list[StandaloneProvisionSchema]:
+    """Parse freestanding sections from USLM XML that are not amending instructions.
+
+    A "freestanding" section is any top-level <section> that:
+    - does not carry role="instruction" or role="note"
+    - is not a sidenote-only section already captured as Add_Note
+    - does not contain any <amendingAction> descendant
+
+    These are provisions like sunset clauses, naming acts, standalone
+    appropriations, and definitions scoped to the act itself.
+    """
+    import xml.etree.ElementTree as ET
+
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return []
+
+    action_tag = _uslm_tag("amendingAction")
+    section_tag = _uslm_tag("section")
+    num_tag = _uslm_tag("num")
+    heading_tag = _uslm_tag("heading")
+    sidenote_tag = _uslm_tag("sidenote")
+
+    govinfo_url = (
+        f"https://www.govinfo.gov/content/pkg/PLAW-{congress}publ{law_number}"
+        f"/htm/PLAW-{congress}publ{law_number}.htm"
+    )
+
+    provisions: list[StandaloneProvisionSchema] = []
+
+    for elem in root.iter(section_tag):
+        role = elem.get("role", "")
+        if role in _INSTRUCTION_ROLES:
+            continue
+
+        # Skip sections that contain any amending instruction
+        if any(True for _ in elem.iter(action_tag)):
+            continue
+
+        # Skip sidenote-only sections (already shown as Add_Note diffs)
+        has_sidenote = any(True for _ in elem.iter(sidenote_tag))
+        if has_sidenote:
+            continue
+
+        # Extract section number, heading, and full text
+        num_text = ""
+        num_elem = elem.find(num_tag)
+        if num_elem is not None:
+            num_text = _iter_text(num_elem)
+
+        heading_text: str | None = None
+        heading_elem = elem.find(heading_tag)
+        if heading_elem is not None:
+            heading_text = _iter_text(heading_elem)
+
+        full_text = _iter_text(elem)
+        if not full_text:
+            continue
+
+        # Skip sections whose full text is only the num/heading (empty body)
+        body = full_text
+        if num_text:
+            body = body.replace(num_text, "", 1).strip()
+        if heading_text:
+            body = body.replace(heading_text, "", 1).strip()
+        if not body:
+            continue
+
+        excerpt = full_text[:_EXCERPT_LIMIT]
+        if len(full_text) > _EXCERPT_LIMIT:
+            excerpt = excerpt.rstrip() + "…"
+
+        provisions.append(
+            StandaloneProvisionSchema(
+                section_num=num_text or "§",
+                heading=heading_text or None,
+                text_excerpt=excerpt,
+                full_text=full_text,
+                govinfo_url=govinfo_url,
+            )
+        )
+
+    return provisions
+
+
+async def get_law_standalone_provisions(
+    session: AsyncSession, congress: int, law_number: int
+) -> list[StandaloneProvisionSchema]:
+    """Return freestanding provisions from a law that don't amend the US Code.
+
+    Parses the law's USLM XML and returns all top-level sections that are
+    neither amending instructions nor note-section stubs. Falls back to an
+    empty list when XML is unavailable.
+    """
+    law_text = await get_law_text(session, congress, law_number, include_htm=False)
+    if not law_text or not law_text.xml_content:
+        return []
+
+    return _extract_standalone_provisions_from_xml(
+        law_text.xml_content, congress, law_number
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas/law_viewer.py
+++ b/backend/app/schemas/law_viewer.py
@@ -114,3 +114,15 @@ class SectionDiffSchema(BaseModel):
         default_factory=list,
         description="Full section lines for frontend expansion",
     )
+
+
+class StandaloneProvisionSchema(BaseModel):
+    """A freestanding provision from a Public Law that does not amend the US Code."""
+
+    section_num: str = Field(
+        ..., description="Section number within the law (e.g. 'Sec. 3')"
+    )
+    heading: str | None = Field(None, description="Section heading, if present")
+    text_excerpt: str = Field(..., description="First ~300 chars of the provision text")
+    full_text: str = Field(..., description="Full text content of the provision")
+    govinfo_url: str | None = Field(None, description="Link to the law on GovInfo")

--- a/backend/tests/api/test_standalone_provisions.py
+++ b/backend/tests/api/test_standalone_provisions.py
@@ -1,0 +1,202 @@
+"""Tests for the standalone-provisions endpoint and XML extraction logic."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.crud.public_law import _extract_standalone_provisions_from_xml
+from app.schemas.law_viewer import StandaloneProvisionSchema
+
+# ---------------------------------------------------------------------------
+# Minimal USLM XML fixtures
+# ---------------------------------------------------------------------------
+
+_INSTRUCTION_ONLY_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://schemas.gpo.gov/xml/uslm">
+  <section role="instruction" identifier="/us/pl/113/23/s2">
+    <num>Sec. 2.</num>
+    <heading>Amendments to title 16</heading>
+    <content>
+      <amendingAction type="insert"/>
+      <quotedText>new text here</quotedText>
+    </content>
+  </section>
+</document>
+"""
+
+_FREESTANDING_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://schemas.gpo.gov/xml/uslm">
+  <section role="instruction" identifier="/us/pl/113/23/s2">
+    <num>Sec. 2.</num>
+    <heading>Amendments to title 16</heading>
+    <content>
+      <amendingAction type="insert"/>
+    </content>
+  </section>
+  <section identifier="/us/pl/113/23/s3">
+    <num>Sec. 3.</num>
+    <heading>The bridge shall be known as the Liberty Bridge.</heading>
+    <content>The bridge located in Springfield shall henceforth be known as the Liberty Bridge.</content>
+  </section>
+  <section identifier="/us/pl/113/23/s4">
+    <num>Sec. 4.</num>
+    <heading>Effective Date.</heading>
+    <content>This Act shall take effect 90 days after the date of enactment.</content>
+  </section>
+</document>
+"""
+
+_SIDENOTE_SECTION_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://schemas.gpo.gov/xml/uslm">
+  <section identifier="/us/pl/113/23/s5">
+    <sidenote>16 U.S.C. 797 note</sidenote>
+    <num>Sec. 5.</num>
+    <content>This is a statutory note provision.</content>
+  </section>
+</document>
+"""
+
+_EMPTY_BODY_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://schemas.gpo.gov/xml/uslm">
+  <section identifier="/us/pl/113/23/s6">
+    <num>Sec. 6.</num>
+    <heading>Reserved</heading>
+  </section>
+</document>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _extract_standalone_provisions_from_xml
+# ---------------------------------------------------------------------------
+
+
+def test_no_standalone_provisions_when_instruction_only() -> None:
+    """Amending instruction sections are not returned as standalone provisions."""
+    result = _extract_standalone_provisions_from_xml(_INSTRUCTION_ONLY_XML, 113, 23)
+    assert result == []
+
+
+def test_extracts_freestanding_sections() -> None:
+    """Non-instruction, non-sidenote sections are returned as standalone provisions."""
+    result = _extract_standalone_provisions_from_xml(_FREESTANDING_XML, 113, 23)
+    assert len(result) == 2
+    nums = {p.section_num for p in result}
+    assert "Sec. 3." in nums
+    assert "Sec. 4." in nums
+
+
+def test_headings_are_extracted() -> None:
+    """Headings are extracted from freestanding sections."""
+    result = _extract_standalone_provisions_from_xml(_FREESTANDING_XML, 113, 23)
+    headings = {p.heading for p in result}
+    assert "Effective Date." in headings
+
+
+def test_sidenote_sections_are_excluded() -> None:
+    """Sections with sidenotes (Add_Note stubs) are not returned."""
+    result = _extract_standalone_provisions_from_xml(_SIDENOTE_SECTION_XML, 113, 23)
+    assert result == []
+
+
+def test_empty_body_sections_are_excluded() -> None:
+    """Sections with no text body after stripping num/heading are skipped."""
+    result = _extract_standalone_provisions_from_xml(_EMPTY_BODY_XML, 113, 23)
+    assert result == []
+
+
+def test_govinfo_url_is_set() -> None:
+    """GovInfo URL is constructed from congress and law_number."""
+    result = _extract_standalone_provisions_from_xml(_FREESTANDING_XML, 113, 23)
+    assert all(p.govinfo_url is not None for p in result)
+    assert all("PLAW-113publ23" in (p.govinfo_url or "") for p in result)
+
+
+def test_excerpt_truncated_at_limit() -> None:
+    """text_excerpt is truncated at 300 chars with an ellipsis."""
+    long_text = "x" * 500
+    xml = f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://schemas.gpo.gov/xml/uslm">
+  <section identifier="/us/pl/113/23/s3">
+    <num>Sec. 3.</num>
+    <content>{long_text}</content>
+  </section>
+</document>
+"""
+    result = _extract_standalone_provisions_from_xml(xml, 113, 23)
+    assert len(result) == 1
+    assert result[0].text_excerpt.endswith("…")
+    assert len(result[0].text_excerpt) <= 304  # 300 + ellipsis
+
+
+def test_full_text_is_not_truncated() -> None:
+    """full_text contains the complete provision text."""
+    long_text = "x" * 500
+    xml = f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns="http://schemas.gpo.gov/xml/uslm">
+  <section identifier="/us/pl/113/23/s3">
+    <num>Sec. 3.</num>
+    <content>{long_text}</content>
+  </section>
+</document>
+"""
+    result = _extract_standalone_provisions_from_xml(xml, 113, 23)
+    assert len(result) == 1
+    assert long_text in result[0].full_text
+
+
+def test_malformed_xml_returns_empty() -> None:
+    """Malformed XML is handled gracefully."""
+    result = _extract_standalone_provisions_from_xml("<not valid xml>>>", 113, 23)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "app.api.v1.laws.get_law_standalone_provisions",
+    new_callable=AsyncMock,
+)
+def test_endpoint_returns_provisions(mock_fn: AsyncMock, client: TestClient) -> None:
+    """The standalone-provisions endpoint returns provisions from the CRUD layer."""
+    mock_fn.return_value = [
+        StandaloneProvisionSchema(
+            section_num="Sec. 3.",
+            heading="Naming",
+            text_excerpt="The bridge shall be known…",
+            full_text="The bridge shall be known as the Liberty Bridge.",
+            govinfo_url="https://www.govinfo.gov/content/pkg/PLAW-113publ23/htm/PLAW-113publ23.htm",
+        )
+    ]
+
+    response = client.get("/api/v1/laws/113/23/standalone-provisions")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["section_num"] == "Sec. 3."
+    assert data[0]["heading"] == "Naming"
+    assert "govinfo_url" in data[0]
+
+
+@patch(
+    "app.api.v1.laws.get_law_standalone_provisions",
+    new_callable=AsyncMock,
+)
+def test_endpoint_returns_empty_list_when_none(
+    mock_fn: AsyncMock, client: TestClient
+) -> None:
+    """Returns an empty list when there are no standalone provisions."""
+    mock_fn.return_value = []
+
+    response = client.get("/api/v1/laws/113/23/standalone-provisions")
+    assert response.status_code == 200
+    assert response.json() == []

--- a/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
+++ b/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
@@ -155,7 +155,12 @@ export default function LawViewerPage() {
           ))}
 
         {activeTab === 'diff' && (
-          <LawDiffViewer diffs={diffs ?? []} isLoading={diffsLoading} />
+          <LawDiffViewer
+            congress={congress}
+            lawNumber={lawNumber}
+            diffs={diffs ?? []}
+            isLoading={diffsLoading}
+          />
         )}
 
         {activeTab === 'history' &&

--- a/frontend/src/components/law-viewer/LawDiffViewer.tsx
+++ b/frontend/src/components/law-viewer/LawDiffViewer.tsx
@@ -8,10 +8,14 @@ import type {
   TitleStructure,
 } from '@/lib/types';
 import { useTitleStructure } from '@/hooks/useTitleStructure';
+import { useLawStandaloneProvisions } from '@/hooks/useLaw';
 import AffectedSectionsTree from './AffectedSectionsTree';
 import UnifiedDiffCard from './UnifiedDiffCard';
+import StandaloneProvisionsPanel from './StandaloneProvisionsPanel';
 
 interface LawDiffViewerProps {
+  congress: number;
+  lawNumber: string;
   diffs: SectionDiff[];
   isLoading: boolean;
 }
@@ -118,12 +122,20 @@ function SectionBreadcrumb({
 
 /** Unified diff view of parsed amendments grouped by section. */
 export default function LawDiffViewer({
+  congress,
+  lawNumber,
   diffs,
   isLoading,
 }: LawDiffViewerProps) {
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const sectionRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const mainPanelRef = useRef<HTMLDivElement>(null);
+
+  const { data: standaloneProvisions } = useLawStandaloneProvisions(
+    congress,
+    lawNumber,
+    !isLoading
+  );
 
   // Flatten amendments from all diffs for the sidebar tree
   const allAmendments = useMemo(
@@ -244,6 +256,10 @@ export default function LawDiffViewer({
           ))}
         </div>
       </div>
+
+      {standaloneProvisions && standaloneProvisions.length > 0 && (
+        <StandaloneProvisionsPanel provisions={standaloneProvisions} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/law-viewer/StandaloneProvisionsPanel.test.tsx
+++ b/frontend/src/components/law-viewer/StandaloneProvisionsPanel.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import StandaloneProvisionsPanel from './StandaloneProvisionsPanel';
+import type { StandaloneProvision } from '@/lib/types';
+
+const makeProvision = (
+  overrides: Partial<StandaloneProvision> = {}
+): StandaloneProvision => ({
+  section_num: 'Sec. 3.',
+  heading: 'Liberty Bridge Naming',
+  text_excerpt: 'The bridge shall be known as the Liberty Bridge.',
+  full_text: 'The bridge shall be known as the Liberty Bridge.',
+  govinfo_url:
+    'https://www.govinfo.gov/content/pkg/PLAW-113publ23/htm/PLAW-113publ23.htm',
+  ...overrides,
+});
+
+describe('StandaloneProvisionsPanel', () => {
+  it('renders collapsed by default', () => {
+    render(<StandaloneProvisionsPanel provisions={[makeProvision()]} />);
+    expect(
+      screen.queryByText('The bridge shall be known as the Liberty Bridge.')
+    ).toBeNull();
+  });
+
+  it('shows count badge with correct singular form', () => {
+    render(<StandaloneProvisionsPanel provisions={[makeProvision()]} />);
+    expect(screen.getByText('1 provision')).toBeTruthy();
+  });
+
+  it('shows count badge with correct plural form', () => {
+    render(
+      <StandaloneProvisionsPanel
+        provisions={[
+          makeProvision(),
+          makeProvision({ section_num: 'Sec. 4.' }),
+        ]}
+      />
+    );
+    expect(screen.getByText('2 provisions')).toBeTruthy();
+  });
+
+  it('expands when header is clicked', () => {
+    render(<StandaloneProvisionsPanel provisions={[makeProvision()]} />);
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    expect(
+      screen.getByText('The bridge shall be known as the Liberty Bridge.')
+    ).toBeTruthy();
+  });
+
+  it('shows section number and heading when expanded', () => {
+    render(<StandaloneProvisionsPanel provisions={[makeProvision()]} />);
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    expect(screen.getByText('Sec. 3.')).toBeTruthy();
+    expect(screen.getByText('Liberty Bridge Naming')).toBeTruthy();
+  });
+
+  it('shows "Not codified in US Code" label', () => {
+    render(<StandaloneProvisionsPanel provisions={[makeProvision()]} />);
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    expect(screen.getByText('Not codified in US Code')).toBeTruthy();
+  });
+
+  it('shows GovInfo link when expanded', () => {
+    render(<StandaloneProvisionsPanel provisions={[makeProvision()]} />);
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    const link = screen.getByText('View on GovInfo →');
+    expect(link.getAttribute('href')).toContain('govinfo.gov');
+  });
+
+  it('does not show GovInfo link when url is null', () => {
+    render(
+      <StandaloneProvisionsPanel
+        provisions={[makeProvision({ govinfo_url: null })]}
+      />
+    );
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    expect(screen.queryByText('View on GovInfo →')).toBeNull();
+  });
+
+  it('shows "Show full text" button when provision is truncated', () => {
+    const longText = 'x'.repeat(600);
+    const excerpt = longText.slice(0, 300) + '…';
+    render(
+      <StandaloneProvisionsPanel
+        provisions={[
+          makeProvision({ text_excerpt: excerpt, full_text: longText }),
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    expect(screen.getByText('Show full text')).toBeTruthy();
+  });
+
+  it('does not show "Show full text" button when text is short', () => {
+    const text = 'Short text.';
+    render(
+      <StandaloneProvisionsPanel
+        provisions={[makeProvision({ text_excerpt: text, full_text: text })]}
+      />
+    );
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    expect(screen.queryByText('Show full text')).toBeNull();
+  });
+
+  it('expands individual provision text on "Show full text" click', () => {
+    const fullText = 'x'.repeat(600);
+    const excerpt = fullText.slice(0, 300) + '…';
+    render(
+      <StandaloneProvisionsPanel
+        provisions={[
+          makeProvision({ text_excerpt: excerpt, full_text: fullText }),
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    fireEvent.click(screen.getByText('Show full text'));
+    expect(screen.getByText('Show less')).toBeTruthy();
+  });
+
+  it('renders no heading when heading is null', () => {
+    render(
+      <StandaloneProvisionsPanel
+        provisions={[makeProvision({ heading: null })]}
+      />
+    );
+    fireEvent.click(screen.getByText('Standalone Provisions'));
+    // Section num should still appear
+    expect(screen.getByText('Sec. 3.')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/law-viewer/StandaloneProvisionsPanel.tsx
+++ b/frontend/src/components/law-viewer/StandaloneProvisionsPanel.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+import type { StandaloneProvision } from '@/lib/types';
+
+interface StandaloneProvisionsPanelProps {
+  provisions: StandaloneProvision[];
+}
+
+function ProvisionCard({ provision }: { provision: StandaloneProvision }) {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = provision.full_text.length > provision.text_excerpt.length;
+  const displayText = expanded ? provision.full_text : provision.text_excerpt;
+
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-4">
+      <div className="mb-2 flex flex-wrap items-start gap-2">
+        <span className="font-mono text-sm font-semibold text-gray-800">
+          {provision.section_num}
+        </span>
+        {provision.heading && (
+          <span className="text-sm font-medium text-gray-700">
+            {provision.heading}
+          </span>
+        )}
+        <span className="ml-auto shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+          Not codified in US Code
+        </span>
+      </div>
+
+      <p className="whitespace-pre-wrap text-sm leading-relaxed text-gray-600">
+        {displayText}
+      </p>
+
+      <div className="mt-3 flex flex-wrap items-center gap-3">
+        {isLong && (
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="text-xs font-medium text-primary-600 hover:underline"
+          >
+            {expanded ? 'Show less' : 'Show full text'}
+          </button>
+        )}
+        {provision.govinfo_url && (
+          <a
+            href={provision.govinfo_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-medium text-primary-600 hover:underline"
+          >
+            View on GovInfo →
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Collapsible panel listing freestanding law provisions not codified in the US Code. */
+export default function StandaloneProvisionsPanel({
+  provisions,
+}: StandaloneProvisionsPanelProps) {
+  const [open, setOpen] = useState(false);
+  const count = provisions.length;
+
+  return (
+    <div className="mt-6 rounded-lg border border-gray-200">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left"
+        aria-expanded={open}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className="text-sm text-gray-500 transition-transform duration-150"
+            style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)' }}
+          >
+            ▶
+          </span>
+          <span className="text-sm font-semibold text-gray-900">
+            Standalone Provisions
+          </span>
+          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+            {count} {count === 1 ? 'provision' : 'provisions'}
+          </span>
+        </div>
+        <span className="text-xs text-gray-400">
+          Sections not codified in the US Code
+        </span>
+      </button>
+
+      {open && (
+        <div className="border-t border-gray-200 px-4 py-4">
+          <div className="space-y-3">
+            {provisions.map((p, i) => (
+              <ProvisionCard key={i} provision={p} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useLaw.ts
+++ b/frontend/src/hooks/useLaw.ts
@@ -6,6 +6,7 @@ import {
   fetchLawAmendments,
   fetchLawDiffs,
   fetchLawHistory,
+  fetchLawStandaloneProvisions,
 } from '@/lib/api';
 
 /** Fetches all public law summaries. */
@@ -73,6 +74,19 @@ export function useLawHistory(
   return useQuery({
     queryKey: ['lawHistory', congress, lawNumber],
     queryFn: () => fetchLawHistory(congress, lawNumber),
+    enabled,
+  });
+}
+
+/** Fetches freestanding provisions that don't amend the US Code. Only fires when enabled. */
+export function useLawStandaloneProvisions(
+  congress: number,
+  lawNumber: string,
+  enabled: boolean = true
+) {
+  return useQuery({
+    queryKey: ['lawStandaloneProvisions', congress, lawNumber],
+    queryFn: () => fetchLawStandaloneProvisions(congress, lawNumber),
     enabled,
   });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   LegislativeHistory,
   ParsedAmendment,
   SectionDiff,
+  StandaloneProvision,
   HeadRevision,
 } from './types';
 
@@ -180,6 +181,22 @@ export async function fetchLawHistory(
   if (!res.ok) {
     throw new Error(
       `Failed to fetch history for PL ${congress}-${lawNumber}: ${res.status}`
+    );
+  }
+  return res.json();
+}
+
+/** Fetch freestanding provisions from a law that don't amend the US Code. */
+export async function fetchLawStandaloneProvisions(
+  congress: number,
+  lawNumber: string
+): Promise<StandaloneProvision[]> {
+  const res = await fetch(
+    `${API_BASE}/laws/${congress}/${encodeURIComponent(lawNumber)}/standalone-provisions`
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch standalone provisions for PL ${congress}-${lawNumber}: ${res.status}`
     );
   }
   return res.json();

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -365,6 +365,15 @@ export interface LegislativeHistory {
   related_bills: RelatedBill[];
 }
 
+/** A freestanding provision from a Public Law that does not amend the US Code. */
+export interface StandaloneProvision {
+  section_num: string;
+  heading: string | null;
+  text_excerpt: string;
+  full_text: string;
+  govinfo_url: string | null;
+}
+
 /** Full section view returned by the section detail endpoint. */
 export interface SectionView {
   title_number: number;


### PR DESCRIPTION
## Summary

Closes #249. Sub-issue of #92.

- **Backend**: New `GET /laws/{congress}/{law_number}/standalone-provisions` endpoint that parses USLM XML and extracts top-level sections that are not amending instructions, not sidenote-only stubs (already shown as Add_Note diffs), and not empty-body placeholders.
- **Frontend**: New `StandaloneProvisionsPanel` component rendered at the bottom of the Amendments tab — collapsed by default with a count badge ("3 provisions"), each card showing the section number, heading, "Not codified in US Code" badge, an expandable text body, and a GovInfo link.

The panel is hidden when there are no standalone provisions (no empty state shown).

## Changes

**Backend**
- `StandaloneProvisionSchema` (section_num, heading, text_excerpt, full_text, govinfo_url)
- `_extract_standalone_provisions_from_xml`: filters instruction/sidenote/empty sections
- `get_law_standalone_provisions` CRUD function
- New API route registered in `app/api/v1/laws.py`
- 11 backend tests covering XML extraction edge cases and the API endpoint

**Frontend**
- `StandaloneProvision` type in `types.ts`
- `fetchLawStandaloneProvisions` in `api.ts`
- `useLawStandaloneProvisions` hook
- `StandaloneProvisionsPanel` component (collapsed default, expand/collapse per card, GovInfo link)
- `LawDiffViewer` updated to accept `congress`/`lawNumber` props and render the panel
- 12 frontend tests

## Test plan

- [x] Backend: `uv run pytest` — 740 passed, 0 failed
- [x] Frontend: `npx vitest run` — 180 passed, 0 failed (12 new)
- [x] mypy: no issues in 40 source files
- [x] TypeScript: `tsc --noEmit` clean
- [ ] Manually verify PL 113-23 Amendments tab shows § 7 (DOE study) in Standalone Provisions
- [ ] Verify panel is hidden for a law with no standalone provisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)