### PR TITLE
perf: prefetch API data on Link hover for instant navigation

### DIFF
--- a/frontend/src/app/laws/LawsTable.tsx
+++ b/frontend/src/app/laws/LawsTable.tsx
@@ -2,8 +2,10 @@
 
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { formatLawDate } from '@/components/ui/LawLine';
 import PageHeader from '@/components/ui/PageHeader';
+import { fetchLawMeta } from '@/lib/api';
 import type { LawSummary } from '@/lib/types';
 
 type SortKey = 'enacted_date' | 'pl_id' | 'title' | 'sections_affected';
@@ -49,6 +51,7 @@ const columns: { key: SortKey; label: string; align: string }[] = [
 export default function LawsTable({ laws }: { laws: LawSummary[] }) {
   const [sortKey, setSortKey] = useState<SortKey>('enacted_date');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const queryClient = useQueryClient();
 
   const sorted = useMemo(() => {
     const copy = [...laws];
@@ -112,6 +115,14 @@ export default function LawsTable({ laws }: { laws: LawSummary[] }) {
                   <Link
                     href={`/laws/${law.congress}/${law.law_number}`}
                     className="font-medium text-primary-600 hover:text-primary-700"
+                    onMouseEnter={() => {
+                      queryClient.prefetchQuery({
+                        queryKey: ['lawMeta', law.congress, law.law_number],
+                        queryFn: () =>
+                          fetchLawMeta(law.congress, law.law_number),
+                        staleTime: 5 * 60 * 1000,
+                      });
+                    }}
                   >
                     PL {law.congress}-{law.law_number}
                   </Link>

--- a/frontend/src/app/titles/page.test.tsx
+++ b/frontend/src/app/titles/page.test.tsx
@@ -1,6 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import TitlesPage from './page';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
 
 vi.mock('next/link', () => ({
   default: ({
@@ -47,14 +59,14 @@ describe('TitlesPage', () => {
   });
 
   it('renders the page heading', async () => {
-    render(await TitlesPage());
+    render(await TitlesPage(), { wrapper: makeWrapper() });
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Browse the US Code'
     );
   });
 
   it('renders titles as directory items', async () => {
-    render(await TitlesPage());
+    render(await TitlesPage(), { wrapper: makeWrapper() });
     expect(screen.getByText(/Armed Forces/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Armed Forces/ })).toHaveAttribute(
       'href',

--- a/frontend/src/components/directory/DirectoryTable.tsx
+++ b/frontend/src/components/directory/DirectoryTable.tsx
@@ -11,6 +11,7 @@ type SortDir = 'asc' | 'desc';
 
 interface DirectoryTableProps {
   items: DirectoryItem[];
+  onItemMouseEnter?: (item: DirectoryItem) => void;
 }
 
 function compareItems(
@@ -45,7 +46,10 @@ function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
 }
 
 /** Table showing child items with sortable ID, Name, # Sections, Last Amendment, and Date columns. */
-export default function DirectoryTable({ items }: DirectoryTableProps) {
+export default function DirectoryTable({
+  items,
+  onItemMouseEnter,
+}: DirectoryTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>('id');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
 
@@ -124,6 +128,9 @@ export default function DirectoryTable({ items }: DirectoryTableProps) {
             <tr
               key={item.href}
               className="border-b border-gray-100 hover:bg-gray-50"
+              onMouseEnter={
+                onItemMouseEnter ? () => onItemMouseEnter(item) : undefined
+              }
             >
               <td className="whitespace-nowrap py-2 pr-2">
                 <Link

--- a/frontend/src/components/directory/DirectoryView.test.tsx
+++ b/frontend/src/components/directory/DirectoryView.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import DirectoryView from './DirectoryView';
 import type { DirectoryItem } from '@/lib/types';
 
@@ -18,6 +19,19 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+vi.mock('next/navigation', () => ({ usePathname: () => '/' }));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
 const items: DirectoryItem[] = [
   {
     id: 'Ch. 1',
@@ -35,7 +49,8 @@ describe('DirectoryView', () => {
         title="Copyrights"
         breadcrumbs={[{ label: 'Title 17' }]}
         items={items}
-      />
+      />,
+      { wrapper: makeWrapper() }
     );
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Copyrights'
@@ -51,7 +66,8 @@ describe('DirectoryView', () => {
           { label: 'Chapter 4' },
         ]}
         items={items}
-      />
+      />,
+      { wrapper: makeWrapper() }
     );
     const titleLink = screen.getByRole('link', { name: 'Title 17' });
     expect(titleLink).toHaveAttribute('href', '/titles/17');
@@ -59,7 +75,9 @@ describe('DirectoryView', () => {
   });
 
   it('renders the Code tab as active', () => {
-    render(<DirectoryView title="Test" items={items} />);
+    render(<DirectoryView title="Test" items={items} />, {
+      wrapper: makeWrapper(),
+    });
     expect(screen.getByRole('tab', { name: 'Code' })).toHaveAttribute(
       'aria-selected',
       'true'
@@ -67,7 +85,9 @@ describe('DirectoryView', () => {
   });
 
   it('renders directory table items', () => {
-    render(<DirectoryView title="Test" items={items} />);
+    render(<DirectoryView title="Test" items={items} />, {
+      wrapper: makeWrapper(),
+    });
     expect(
       screen.getByRole('link', { name: /Subject Matter/ })
     ).toBeInTheDocument();

--- a/frontend/src/components/directory/DirectoryView.tsx
+++ b/frontend/src/components/directory/DirectoryView.tsx
@@ -3,11 +3,13 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import type {
   DirectoryItem,
   BreadcrumbSegment,
   HeadRevision,
 } from '@/lib/types';
+import { fetchTitleStructure } from '@/lib/api';
 import PageHeader from '@/components/ui/PageHeader';
 import TabBar from '@/components/ui/TabBar';
 import DirectoryTable from './DirectoryTable';
@@ -145,6 +147,19 @@ export default function DirectoryView({
   revision,
 }: DirectoryViewProps) {
   const [activeTab, setActiveTab] = useState('code');
+  const queryClient = useQueryClient();
+
+  function handleItemMouseEnter(item: DirectoryItem) {
+    const titleMatch = item.href.match(/^\/titles\/(\d+)$/);
+    if (titleMatch) {
+      const titleNumber = Number(titleMatch[1]);
+      queryClient.prefetchQuery({
+        queryKey: ['titleStructure', titleNumber, revision ?? 'head'],
+        queryFn: () => fetchTitleStructure(titleNumber, revision),
+        staleTime: 5 * 60 * 1000,
+      });
+    }
+  }
 
   return (
     <div>
@@ -162,7 +177,9 @@ export default function DirectoryView({
         }
       />
       <TabBar tabs={TABS} activeTab={activeTab} onTabChange={setActiveTab} />
-      {activeTab === 'code' && <DirectoryTable items={items} />}
+      {activeTab === 'code' && (
+        <DirectoryTable items={items} onItemMouseEnter={handleItemMouseEnter} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/tree/GroupNode.test.tsx
+++ b/frontend/src/components/tree/GroupNode.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import GroupNode from './GroupNode';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
 
 vi.mock('next/link', () => ({
   default: ({
@@ -43,7 +49,8 @@ const group = {
 describe('GroupNode', () => {
   it('renders the group name as a link', () => {
     render(
-      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />
+      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />,
+      { wrapper }
     );
     const link = screen.getByRole('link', {
       name: /Subject Matter and Scope of Copyright/,
@@ -53,7 +60,8 @@ describe('GroupNode', () => {
 
   it('does not show children until expanded', () => {
     render(
-      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />
+      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />,
+      { wrapper }
     );
     expect(screen.queryByText('Subject matter')).not.toBeInTheDocument();
   });
@@ -61,7 +69,8 @@ describe('GroupNode', () => {
   it('icon click expands to show children', async () => {
     const user = userEvent.setup();
     render(
-      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />
+      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />,
+      { wrapper }
     );
     await user.click(screen.getByRole('button', { name: 'Expand' }));
     expect(screen.getByText(/The Works/)).toBeInTheDocument();
@@ -71,7 +80,8 @@ describe('GroupNode', () => {
   it('icon click collapses children', async () => {
     const user = userEvent.setup();
     render(
-      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />
+      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />,
+      { wrapper }
     );
     await user.click(screen.getByRole('button', { name: 'Expand' }));
     expect(screen.getByText('Subject matter')).toBeInTheDocument();
@@ -82,7 +92,8 @@ describe('GroupNode', () => {
   it('sections render as links to section viewer', async () => {
     const user = userEvent.setup();
     render(
-      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />
+      <GroupNode group={group} titleNumber={17} parentPath="/titles/17" />,
+      { wrapper }
     );
     await user.click(screen.getByRole('button', { name: 'Expand' }));
     const sectionLink = screen.getByRole('link', { name: /Subject matter/ });

--- a/frontend/src/components/tree/SectionNode.test.tsx
+++ b/frontend/src/components/tree/SectionNode.test.tsx
@@ -1,7 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import SectionNode from './SectionNode';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
 
 vi.mock('next/link', () => ({
   default: ({
@@ -27,26 +39,34 @@ const section = {
 
 describe('SectionNode', () => {
   it('renders the heading as a link to the section directory', () => {
-    render(<SectionNode section={section} titleNumber={17} />);
+    render(<SectionNode section={section} titleNumber={17} />, {
+      wrapper: makeWrapper(),
+    });
     const link = screen.getByRole('link', { name: 'Mask work notice' });
     expect(link).toHaveAttribute('href', '/sections/17/909');
   });
 
   it('shows section number as sub-header when expanded', async () => {
     const user = userEvent.setup();
-    render(<SectionNode section={section} titleNumber={17} />);
+    render(<SectionNode section={section} titleNumber={17} />, {
+      wrapper: makeWrapper(),
+    });
     await user.click(screen.getByRole('button', { name: 'Expand' }));
     expect(screen.getByText(/§/)).toBeInTheDocument();
   });
 
   it('shows folder icon with expand/collapse toggle', () => {
-    render(<SectionNode section={section} titleNumber={17} />);
+    render(<SectionNode section={section} titleNumber={17} />, {
+      wrapper: makeWrapper(),
+    });
     expect(screen.getByRole('button', { name: 'Expand' })).toBeInTheDocument();
   });
 
   it('expands to show code file and note files on icon click', async () => {
     const user = userEvent.setup();
-    render(<SectionNode section={section} titleNumber={17} />);
+    render(<SectionNode section={section} titleNumber={17} />, {
+      wrapper: makeWrapper(),
+    });
 
     await user.click(screen.getByRole('button', { name: 'Expand' }));
 
@@ -63,7 +83,9 @@ describe('SectionNode', () => {
   });
 
   it('auto-expands when isActive', () => {
-    render(<SectionNode section={section} titleNumber={17} isActive />);
+    render(<SectionNode section={section} titleNumber={17} isActive />, {
+      wrapper: makeWrapper(),
+    });
     expect(
       screen.getByRole('link', { name: 'EDITORIAL_NOTES' })
     ).toBeInTheDocument();
@@ -71,7 +93,8 @@ describe('SectionNode', () => {
 
   it('applies active styling when isActive', () => {
     const { container } = render(
-      <SectionNode section={section} titleNumber={17} isActive />
+      <SectionNode section={section} titleNumber={17} isActive />,
+      { wrapper: makeWrapper() }
     );
     const row = container.querySelector('.bg-primary-50');
     expect(row).toBeInTheDocument();

--- a/frontend/src/components/tree/SectionNode.tsx
+++ b/frontend/src/components/tree/SectionNode.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useQueryClient } from '@tanstack/react-query';
 import type { SectionSummary } from '@/lib/types';
 import { detectStatus } from '@/lib/statusStyles';
+import { fetchSection } from '@/lib/api';
 import TreeIndicator from './TreeIndicator';
 import FileIcon from './icons/FileIcon';
 
@@ -26,6 +28,7 @@ export default function SectionNode({
   isActive,
 }: SectionNodeProps) {
   const [expanded, setExpanded] = useState(!!isActive);
+  const queryClient = useQueryClient();
   const basePath = `/sections/${titleNumber}/${section.section_number}`;
   const noteCategories = section.note_categories ?? [];
   const noteFiles = NOTE_FILES.filter(({ category }) =>
@@ -46,6 +49,18 @@ export default function SectionNode({
         <Link
           href={basePath}
           className="min-w-0 truncate hover:text-primary-700"
+          onMouseEnter={() => {
+            queryClient.prefetchQuery({
+              queryKey: [
+                'section',
+                titleNumber,
+                section.section_number,
+                'head',
+              ],
+              queryFn: () => fetchSection(titleNumber, section.section_number),
+              staleTime: 5 * 60 * 1000,
+            });
+          }}
         >
           {section.heading}
         </Link>


### PR DESCRIPTION
## Summary

- On hover of title list items (`/titles`), prefetch title structure via `DirectoryView` → `DirectoryTable`'s new `onItemMouseEnter` prop
- On hover of law links in `LawsTable` (`/laws`), prefetch law metadata (`lawMeta`)
- On hover of section links in `SectionNode`, prefetch section content (`section`)
- React Query deduplicates in-flight requests, so no risk of over-fetching on rapid hover

## How it works

`DirectoryView` detects `/titles/{n}` hrefs via regex and fires `prefetchQuery` with the correct revision (or `'head'` when viewing latest). `LawsTable` and `SectionNode` each call `useQueryClient().prefetchQuery` directly on `onMouseEnter`. All prefetches use `staleTime: 5 * 60 * 1000` to skip re-fetching data that's already warm.

## Test changes

Four test files (`SectionNode`, `DirectoryView`, `GroupNode`, `TitlesPage`) now wrap renders in `QueryClientProvider` since the components call `useQueryClient()`.

Closes #276