### PR TITLE
fix: parse <note topic="amendments"> XML correctly (issue #216)

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1323,23 +1323,33 @@ class USLMParser:
                     parts.append(el.tail)
                 return
 
+            # <note topic="..."> without a <heading> child: synthesize [NH] from topic.
+            # Some USLM releases omit the heading element and rely solely on the
+            # topic attribute (e.g. <note topic="amendments"><p>...</p>).
+            if tag == "note":
+                topic = el.get("topic", "")
+                if topic:
+                    child_tags = {
+                        (c.tag.split("}")[-1] if "}" in c.tag else c.tag) for c in el
+                    }
+                    if "heading" not in child_tags:
+                        parts.append(f"[NH]{topic.title()}[/NH]")
+
             # Preserve paragraph boundaries with a special marker
             # We use [PARA] marker instead of \n\n because tail text often contains \n
             if tag == "p" and parts:
                 # Add paragraph break marker before this <p> element
                 parts.append("[PARA]")
 
-            # Check if this is a heading with smallCaps class
+            # Check if this is a heading element — always emit [NH] markers regardless
+            # of whether it has class="smallCaps".  Some USLM releases use
+            # <note topic="amendments"><heading>Amendments</heading> without the
+            # smallCaps class, but the element is still a structural note header.
             if tag == "heading":
-                css_class = el.get("class", "")
-                if "smallCaps" in css_class:
-                    # Apply title case to smallCaps headings
-                    # Mark with [NH] (Note Header) so downstream parsing can distinguish
-                    # from regular content
-                    text = "".join(el.itertext()).strip()
-                    if text:
-                        parts.append(f"[NH]{text.title()}[/NH]")
-                    return  # Don't process children
+                text = "".join(el.itertext()).strip()
+                if text:
+                    parts.append(f"[NH]{text.title()}[/NH]")
+                return  # Don't process children
 
             # Track bold/italic state
             new_in_bold = in_bold or tag == "b"

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1722,6 +1722,91 @@ class TestFlatNotesParser:
         assert len(notes.notes) == 0
 
 
+class TestNoteTopicAmendmentParsing:
+    """Regression tests for issue #216: <note topic="amendments"> not parsed.
+
+    Two patterns appear in USLM XML for amendment notes that previously broke:
+    - Editorial wrapper + inner <note topic="amendments"><heading>Amendments</heading>
+    - Flat <note topic="amendments"> without a <heading> child at all
+    """
+
+    def _parse_xml_notes(self, xml_snippet: str) -> object:
+        from lxml import etree
+
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+        from pipeline.olrc.parser import USLMParser
+
+        notes_elem = etree.fromstring(xml_snippet)
+        raw = USLMParser()._get_notes_text_content(notes_elem)
+        notes = SectionNotes()
+        _parse_notes_structure(raw, notes)
+        return notes
+
+    def test_editorial_wrapper_with_plain_heading(self) -> None:
+        """17 USC 403 pattern: <note class="editorial"> + inner <heading>Amendments</heading>.
+
+        The inner heading has no class="smallCaps" but must still emit [NH] so
+        _parse_editorial_notes can find and categorise it.
+        """
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<note class="editorial">'
+            '<heading class="smallCaps">Editorial Notes</heading>'
+            '<note topic="amendments">'
+            "<heading>Amendments</heading>"
+            "<p>1988—Pub. L. 100–568 amended section generally.</p>"
+            "</note>"
+            "</note>"
+            "</notes>"
+        )
+        notes = self._parse_xml_notes(xml)
+
+        assert any(n.header == "Amendments" for n in notes.notes)
+        assert len(notes.amendments) == 1
+        assert notes.amendments[0].year == 1988
+
+    def test_flat_topic_note_without_heading(self) -> None:
+        """17 USC 1005 pattern: <note topic="amendments"> with no <heading> child.
+
+        The topic attribute alone must synthesise the [NH] header so the fallback
+        flat-notes parser can categorise the content.
+        """
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<note topic="amendments">'
+            "<p>1993—Pub. L. 103–198 struck out at end"
+            ' "The Register shall submit a report."</p>'
+            "</note>"
+            "</notes>"
+        )
+        notes = self._parse_xml_notes(xml)
+
+        assert any(n.header == "Amendments" for n in notes.notes)
+        assert len(notes.amendments) == 1
+        assert notes.amendments[0].year == 1993
+
+    def test_flat_topic_note_with_heading(self) -> None:
+        """<note topic="amendments"><heading>Amendments</heading>: heading takes precedence."""
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<note topic="amendments">'
+            "<heading>Amendments</heading>"
+            "<p>1993—Pub. L. 103–198 struck out at end"
+            ' "The Register shall submit a report."</p>'
+            "</note>"
+            "</notes>"
+        )
+        notes = self._parse_xml_notes(xml)
+
+        # Should not produce duplicate Amendments notes
+        amendment_notes = [n for n in notes.notes if n.header == "Amendments"]
+        assert len(amendment_notes) == 1
+        assert len(notes.amendments) >= 1
+
+
 class TestCleanHeading:
     """Tests for _clean_heading function."""
 


### PR DESCRIPTION
## Summary

- `<note topic="amendments">` XML elements with a plain `<heading>Amendments</heading>` (no `class="smallCaps"`) were not emitting `[NH]` markers, so `_parse_editorial_notes` and `_parse_flat_notes` could never find them → `notes.amendments` stayed empty and `has_amendments` was always `false`
- `<note topic="amendments">` elements with **no heading child at all** had the same problem

## Root cause

`_get_notes_text_content` in `parser.py` only emitted `[NH]...[/NH]` markers for `<heading class="smallCaps">` elements. USLM release points for title 17 (and likely others) use `<heading>Amendments</heading>` without the class attribute, or omit the heading entirely and rely on the `topic` attribute.

## Changes

**`pipeline/olrc/parser.py`** — `_get_notes_text_content`:
1. Remove `smallCaps` guard from the heading handler — always emit `[NH]` for any `<heading>` in notes context
2. When a `<note topic="...">` element has no `<heading>` child, synthesise `[NH]{topic.title()}[/NH]` so the flat-notes fallback can categorise it

**`tests/pipeline/test_normalized_section.py`** — new `TestNoteTopicAmendmentParsing` class with 3 regression tests covering both patterns from the issue (§403 and §1005).

## Test plan
- [x] All 3 new regression tests pass
- [x] Full test suite: 694 passed, 0 failures

Closes #216