### PR TITLE
fix: parse Congress.gov law response correctly in _resolve_bill_ref

### DIFF
--- a/backend/pipeline/congress/law_history_ingestion.py
+++ b/backend/pipeline/congress/law_history_ingestion.py
@@ -268,11 +268,9 @@ class LawHistoryIngestionService:
         if data is None:
             return None
 
-        congress_data = data.get("congress", {})
-        bills = congress_data.get("bills", [])
-        if not bills:
-            return None
-        bill_ref = bills[0]
+        # Congress.gov /law/{congress}/{type}/{number} returns:
+        # {"law": {"bill": {"type": "HR", "number": "667", ...}}}
+        bill_ref = data.get("law", {}).get("bill", {})
         b_type = (bill_ref.get("type") or "").lower()
         b_number = bill_ref.get("number")
         if not b_type or not b_number:

--- a/backend/scripts/seed_finalize.sh
+++ b/backend/scripts/seed_finalize.sh
@@ -11,10 +11,9 @@ echo "=== Ingesting Congress 113 laws ==="
 uv run python -m pipeline.cli govinfo-ingest-congress 113
 
 echo "=== Seeding legislative history for Congress 113 ==="
-# Non-fatal: Congress.gov API issues (#256) should not block the rest of the
-# seed pipeline. chrono-advance and the app itself work without law history.
+# Non-fatal: individual law failures should not block chrono-advance.
 uv run python -m pipeline.cli seed-congress-law-history 113 || \
-    echo "WARNING: seed-congress-law-history failed (see issue #256), continuing"
+    echo "WARNING: seed-congress-law-history failed, continuing"
 
 echo "=== Advancing chronological pipeline (2 revisions) ==="
 uv run python -m pipeline.cli chrono-advance --count 2

--- a/backend/tests/pipeline/test_law_history_ingestion.py
+++ b/backend/tests/pipeline/test_law_history_ingestion.py
@@ -1,0 +1,112 @@
+"""Tests for LawHistoryIngestionService._resolve_bill_ref.
+
+Covers the Congress.gov /law/{congress}/{type}/{number} response structure,
+which returns {"law": {"bill": {"type": ..., "number": ...}}} at the top level.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pipeline.congress.law_history_ingestion import LawHistoryIngestionService
+
+
+def _make_service() -> LawHistoryIngestionService:
+    session = MagicMock()
+    return LawHistoryIngestionService(session=session)
+
+
+def _make_law(*, law_number: str = "23", congress: int = 113, origin_bill=None):
+    law = MagicMock()
+    law.law_number = law_number
+    law.congress = congress
+    law.origin_bill = origin_bill
+    return law
+
+
+class TestResolveBillRef:
+    @pytest.mark.asyncio
+    async def test_resolves_from_origin_bill_fk(self) -> None:
+        """When origin_bill FK is populated, skip the API call entirely."""
+        bill = MagicMock()
+        bill.bill_number = "667"
+        bill.bill_type.value = "HR"
+        law = _make_law(origin_bill=bill)
+
+        client = AsyncMock()
+        service = _make_service()
+
+        result = await service._resolve_bill_ref(law, client)
+
+        assert result == ("hr", 667)
+        client.get_law_bill_info.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolves_from_congress_api_response(self) -> None:
+        """Falls back to Congress.gov API and parses {"law": {"bill": {...}}} correctly."""
+        law = _make_law(origin_bill=None)
+        client = AsyncMock()
+        client.get_law_bill_info.return_value = {
+            "law": {
+                "bill": {
+                    "type": "HR",
+                    "number": "667",
+                    "originChamber": "House",
+                },
+                "number": "23",
+                "type": "PUBLIC_LAW",
+            },
+            "request": {},
+        }
+
+        service = _make_service()
+        result = await service._resolve_bill_ref(law, client)
+
+        assert result == ("hr", 667)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_api_returns_none(self) -> None:
+        law = _make_law(origin_bill=None)
+        client = AsyncMock()
+        client.get_law_bill_info.return_value = None
+
+        service = _make_service()
+        result = await service._resolve_bill_ref(law, client)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_bill_missing_from_response(self) -> None:
+        """API response has a law key but no nested bill."""
+        law = _make_law(origin_bill=None)
+        client = AsyncMock()
+        client.get_law_bill_info.return_value = {"law": {}, "request": {}}
+
+        service = _make_service()
+        result = await service._resolve_bill_ref(law, client)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_api_raises(self) -> None:
+        law = _make_law(origin_bill=None)
+        client = AsyncMock()
+        client.get_law_bill_info.side_effect = Exception("timeout")
+
+        service = _make_service()
+        result = await service._resolve_bill_ref(law, client)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_senate_bill_type_lowercased(self) -> None:
+        law = _make_law(origin_bill=None)
+        client = AsyncMock()
+        client.get_law_bill_info.return_value = {
+            "law": {"bill": {"type": "S", "number": "42"}},
+        }
+
+        service = _make_service()
+        result = await service._resolve_bill_ref(law, client)
+
+        assert result == ("s", 42)


### PR DESCRIPTION
## Summary

- `_resolve_bill_ref` in `law_history_ingestion.py` was parsing the Congress.gov `/law/{congress}/{type}/{number}` API response with the wrong key path (`data["congress"]["bills"][0]`)
- The actual response shape is `{"law": {"bill": {"type": "HR", "number": "667"}}}`, so the old code always returned an empty dict and raised "Could not resolve bill reference" for every law
- Fixed to use `data.get("law", {}).get("bill", {})` — a 3-line simplification that also drops the now-unnecessary list handling
- Added `tests/pipeline/test_law_history_ingestion.py` with 6 cases covering: FK shortcut path, correct API parsing, missing bill, API returning None, API raising, and senate bill type lowercasing
- Updated `seed_finalize.sh` comment to remove stale issue reference

## Impact

This was the root cause of **all** history tabs showing empty timelines and no sponsors. With this fix, the next seed run (`seed-congress-law-history 113` in Phase 3 finalize) should successfully populate `law_bill_action` and `law_sponsor` for all congress 113 laws that have bill data in Congress.gov.

Issue #200 (PublicLaw rows missing for PL 113-10 through 113-28) is already addressed by `govinfo-ingest-congress 113` in `seed_finalize.sh` — a fresh seed will fill that gap.

## Test plan

- [x] `uv run python -m pytest tests/pipeline/test_law_history_ingestion.py -v` — 6/6 pass
- [x] Full test suite — 741 passed, no regressions
- [ ] After merging, trigger a seed run and verify `/laws/113/23?tab=history` shows a timeline

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)