### PR TITLE
fix: exclude SectionNoteSchema.content from normalized_notes JSONB

### DIFF
--- a/backend/pipeline/olrc/bootstrap.py
+++ b/backend/pipeline/olrc/bootstrap.py
@@ -123,12 +123,15 @@ def _build_snapshot_rows(
 
         notes_json = None
         if normalized.section_notes is not None:
-            # Exclude raw_notes: it duplicates the `notes` TEXT column already
-            # stored separately, and including it roughly doubles JSONB size for
-            # heavily-amended sections (Title 42, Title 22) causing OOM and slow
-            # COPY during the fan-out bootstrap.
+            # Exclude redundant raw-form fields to keep normalized_notes JSONB small.
+            # - raw_notes: duplicates the `notes` TEXT column (already stored separately)
+            # - notes[*].content: duplicates notes[*].lines — same text, less structure;
+            #   NoteBlock renders from lines and falls back to content only when lines
+            #   is empty (which doesn't happen after full normalization)
+            # See issue #292 for the planned model-level cleanup.
             notes_json = normalized.section_notes.model_dump(
-                mode="json", exclude={"raw_notes"}
+                mode="json",
+                exclude={"raw_notes": True, "notes": {"__all__": {"content"}}},
             )
 
         rows.append(


### PR DESCRIPTION
## Summary

Extends the JSONB size reduction from PR #291 to also exclude `SectionNoteSchema.content`.

`content` is a flat raw string of the note text. `lines` is the same text structured as `CodeLineSchema` objects for rendering. Both are stored in the `normalized_notes` JSONB — pure duplication.

For a 200-amendment section, a single "Amendments" note stores ~20KB in `content` and ~60KB in `lines`. Removing `content` cuts that note's JSONB from ~80KB to ~60KB. Across a section with 10 notes and Title 42's 6,549 sections, the savings are substantial.

`NoteBlock` already prefers `lines` and only falls back to `content` when `lines` is empty — which doesn't happen after full normalization. The fallback exists for debugging/stub cases where normalization is skipped entirely (those sections have empty `notes` lists anyway).

## What's not changing yet

- `SectionNoteSchema.content` stays in the Python/TypeScript schema — no breaking change
- `NoteBlock.tsx` fallback stays in place
- Model-level cleanup is tracked in issue #293, conditional on this exclusion delivering the expected perf improvement

## Test plan

- [x] 706 tests pass
- [ ] Bootstrap insert times for Title 42 / Title 22 drop below previous 1200s+ readings

Closes #292 (partially — `SourceLawSchema.raw_text` and `NoteReferenceSchema.display_text` remain for a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)