### PR TITLE
feat: distinguish 'no text' vs 'no amendments' in Changes tab empty state

### DIFF
--- a/backend/app/api/v1/laws.py
+++ b/backend/app/api/v1/laws.py
@@ -17,10 +17,10 @@ from app.crud.public_law import (
 from app.models.base import get_async_session
 from app.schemas.law_history import LegislativeHistorySchema
 from app.schemas.law_viewer import (
+    LawDiffsResponse,
     LawSummarySchema,
     LawTextSchema,
     ParsedAmendmentSchema,
-    SectionDiffSchema,
     StandaloneProvisionSchema,
 )
 
@@ -87,7 +87,7 @@ async def read_law_diffs(
     congress: int,
     law_number: int,
     session: AsyncSession = Depends(get_async_session),
-) -> list[SectionDiffSchema]:
+) -> LawDiffsResponse:
     """Compute per-section unified diffs for a law's amendments."""
     return await compute_law_diffs(session, congress, law_number)
 

--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -30,6 +30,7 @@ from app.schemas.law_history import (
 from app.schemas.law_viewer import (
     DiffHunkSchema,
     DiffLineSchema,
+    LawDiffsResponse,
     LawSummarySchema,
     LawTextSchema,
     ParsedAmendmentSchema,
@@ -936,7 +937,7 @@ def _notes_to_provisions(normalized_notes: Any) -> list[dict[str, Any]]:
 
 async def compute_law_diffs(
     session: AsyncSession, congress: int, law_number: int
-) -> list[SectionDiffSchema]:
+) -> LawDiffsResponse:
     """Compute per-section unified diffs for a law's amendments.
 
     Groups amendments by (title, section), fetches before provisions,
@@ -944,15 +945,23 @@ async def compute_law_diffs(
     """
     from pipeline.olrc.snapshot_service import SnapshotService
 
+    # Check law text existence first so we can distinguish "no text" from
+    # "text present but no codified amendments found".
+    law_text = await get_law_text(
+        session, congress, law_number, include_htm=False, include_xml=False
+    )
+    if not law_text:
+        return LawDiffsResponse(parse_status="no_text", diffs=[])
+
     # Parse amendments (reuses existing logic)
     schemas = await parse_law_amendments(session, congress, law_number)
     if not schemas:
-        return []
+        return LawDiffsResponse(parse_status="no_amendments_found", diffs=[])
 
     # Get parent revision for "before" state
     revision_id = await _get_parent_revision_id(session, congress, law_number)
     if revision_id is None:
-        return []
+        return LawDiffsResponse(parse_status="no_amendments_found", diffs=[])
 
     # Group amendments by (title, section)
     groups: dict[tuple[int, str], list[ParsedAmendmentSchema]] = {}
@@ -1069,7 +1078,7 @@ async def compute_law_diffs(
                 )
             )
 
-    return diffs
+    return LawDiffsResponse(parse_status="success", diffs=diffs)
 
 
 def _build_note_hunks(

--- a/backend/app/schemas/law_viewer.py
+++ b/backend/app/schemas/law_viewer.py
@@ -4,6 +4,8 @@ These schemas support the /api/v1/laws endpoints used to browse
 and inspect parsed law text and amendments.
 """
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -114,6 +116,13 @@ class SectionDiffSchema(BaseModel):
         default_factory=list,
         description="Full section lines for frontend expansion",
     )
+
+
+class LawDiffsResponse(BaseModel):
+    """Response envelope for the diffs endpoint, including parse status."""
+
+    parse_status: Literal["success", "no_amendments_found", "no_text"]
+    diffs: list[SectionDiffSchema]
 
 
 class StandaloneProvisionSchema(BaseModel):

--- a/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
+++ b/frontend/src/app/laws/[congress]/[lawNumber]/page.tsx
@@ -79,7 +79,7 @@ export default function LawViewerPage() {
   );
 
   // Diffs fetched when the amendments tab is active (default)
-  const { data: diffs, isLoading: diffsLoading } = useLawDiffs(
+  const { data: diffsResponse, isLoading: diffsLoading } = useLawDiffs(
     congress,
     lawNumber,
     activeTab === 'diff'
@@ -158,7 +158,8 @@ export default function LawViewerPage() {
           <LawDiffViewer
             congress={congress}
             lawNumber={lawNumber}
-            diffs={diffs ?? []}
+            diffs={diffsResponse?.diffs ?? []}
+            parseStatus={diffsResponse?.parse_status}
             isLoading={diffsLoading}
           />
         )}

--- a/frontend/src/components/law-viewer/LawDiffViewer.tsx
+++ b/frontend/src/components/law-viewer/LawDiffViewer.tsx
@@ -6,6 +6,7 @@ import type {
   SectionDiff,
   SectionGroupTree,
   TitleStructure,
+  ParseStatus,
 } from '@/lib/types';
 import { useTitleStructure } from '@/hooks/useTitleStructure';
 import { useLawStandaloneProvisions } from '@/hooks/useLaw';
@@ -17,6 +18,7 @@ interface LawDiffViewerProps {
   congress: number;
   lawNumber: string;
   diffs: SectionDiff[];
+  parseStatus?: ParseStatus;
   isLoading: boolean;
 }
 
@@ -125,6 +127,7 @@ export default function LawDiffViewer({
   congress,
   lawNumber,
   diffs,
+  parseStatus,
   isLoading,
 }: LawDiffViewerProps) {
   const [activeSection, setActiveSection] = useState<string | null>(null);
@@ -176,6 +179,31 @@ export default function LawDiffViewer({
   }
 
   if (diffs.length === 0) {
+    if (parseStatus === 'no_text') {
+      return (
+        <div className="py-10 text-center">
+          <p className="text-sm font-medium text-amber-600">
+            Law text not yet available in the pipeline.
+          </p>
+          <p className="mt-1 text-xs text-gray-400">
+            The source text for this law has not been ingested. Check back
+            later.
+          </p>
+        </div>
+      );
+    }
+    if (parseStatus === 'no_amendments_found' || parseStatus === 'success') {
+      return (
+        <div className="py-10 text-center">
+          <p className="text-sm font-medium text-gray-600">
+            This law does not appear to make direct amendments to the US Code.
+          </p>
+          <p className="mt-1 text-xs text-gray-400">
+            It may be a standalone provision, appropriation, or temporary rule.
+          </p>
+        </div>
+      );
+    }
     return (
       <p className="py-8 text-center text-sm text-gray-500">
         No amendments parsed from this law.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,7 +6,7 @@ import type {
   LawText,
   LegislativeHistory,
   ParsedAmendment,
-  SectionDiff,
+  LawDiffsResponse,
   StandaloneProvision,
   HeadRevision,
 } from './types';
@@ -158,7 +158,7 @@ export async function fetchLawAmendments(
 export async function fetchLawDiffs(
   congress: number,
   lawNumber: string
-): Promise<SectionDiff[]> {
+): Promise<LawDiffsResponse> {
   const res = await fetch(
     `${API_BASE}/laws/${congress}/${encodeURIComponent(lawNumber)}/diffs`
   );

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -272,6 +272,13 @@ export interface SectionDiff {
   all_provisions: DiffLine[];
 }
 
+export type ParseStatus = 'success' | 'no_amendments_found' | 'no_text';
+
+export interface LawDiffsResponse {
+  parse_status: ParseStatus;
+  diffs: SectionDiff[];
+}
+
 // --- Legislative history types ---
 
 export type HistoryEventType =


### PR DESCRIPTION
## Summary

- `GET /laws/{congress}/{law_number}/diffs` now returns a `LawDiffsResponse` envelope: `{ parse_status, diffs }` instead of a bare array
- `compute_law_diffs` checks law text existence first so the two empty cases produce distinct statuses: `no_text` (law never ingested) vs `no_amendments_found` (text present, parser found no codified amendments)
- Frontend `LawDiffViewer` renders three distinct empty states based on `parse_status`:
  - `no_text` → amber "Law text not yet available in the pipeline."
  - `no_amendments_found` → grey "This law does not appear to make direct amendments to the US Code. It may be a standalone provision, appropriation, or temporary rule."
  - fallback → original message (only reachable if response hasn't loaded yet)

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)