### PR TITLE
fix: wire linkifyContent into NoteBlock so note references render as links

### DIFF
--- a/frontend/src/components/viewer/NoteBlock.tsx
+++ b/frontend/src/components/viewer/NoteBlock.tsx
@@ -1,33 +1,52 @@
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import type { SectionNote, CodeLine } from '@/lib/types';
 import { findNoteLinks, type CrossRefLookup } from '@/lib/noteUtils';
+import { linkifyContent } from '@/lib/linkifyContent';
 
 interface NoteBlockProps {
   note: SectionNote;
   lineNumberOffset?: number;
   crossRefs?: CrossRefLookup;
   basePath?: string;
+  withRev?: (href: string) => string;
 }
 
 /**
- * Render line content, hyperlinking any cross-references to other note files.
- * Returns a plain string when there are no cross-refs to avoid unnecessary JSX.
+ * Render line content with two layers of hyperlinking:
+ * 1. USC/law references from note.references (via linkifyContent)
+ * 2. Cross-references to other note categories (via findNoteLinks)
  */
 function renderContent(
   content: string,
   note: SectionNote,
   crossRefs: CrossRefLookup | undefined,
-  basePath: string | undefined
-) {
-  if (!crossRefs || !basePath || crossRefs.size === 0) return content;
+  basePath: string | undefined,
+  withRev: (href: string) => string = (h) => h
+): ReactNode {
+  const refs = note.references ?? [];
+  const hasCrossRefs = crossRefs && basePath && crossRefs.size > 0;
+
+  if (!hasCrossRefs && refs.length === 0) return content;
+
+  if (!hasCrossRefs) {
+    return linkifyContent(content, refs, withRev);
+  }
 
   const segments = findNoteLinks(content, crossRefs, note.category, basePath);
-  if (segments.length === 0) return content;
+  if (segments.length === 0) {
+    return refs.length > 0 ? linkifyContent(content, refs, withRev) : content;
+  }
 
-  const nodes: any[] = [];
+  const nodes: ReactNode[] = [];
   let pos = 0;
   for (const seg of segments) {
-    if (seg.start > pos) nodes.push(content.slice(pos, seg.start));
+    if (seg.start > pos) {
+      const plain = content.slice(pos, seg.start);
+      nodes.push(
+        refs.length > 0 ? linkifyContent(plain, refs, withRev) : plain
+      );
+    }
     nodes.push(
       <Link
         key={seg.start}
@@ -39,7 +58,10 @@ function renderContent(
     );
     pos = seg.end;
   }
-  if (pos < content.length) nodes.push(content.slice(pos));
+  if (pos < content.length) {
+    const plain = content.slice(pos);
+    nodes.push(refs.length > 0 ? linkifyContent(plain, refs, withRev) : plain);
+  }
   return <>{nodes}</>;
 }
 
@@ -50,12 +72,14 @@ function NoteLine({
   note,
   crossRefs,
   basePath,
+  withRev,
 }: {
   lineNumber: number;
   line: CodeLine;
   note: SectionNote;
   crossRefs?: CrossRefLookup;
   basePath?: string;
+  withRev?: (href: string) => string;
 }) {
   const indent = line.indent_level > 0 ? '\t'.repeat(line.indent_level) : '';
   const isListItem = line.marker !== null;
@@ -73,10 +97,10 @@ function NoteLine({
       >
         {line.is_header ? (
           <span className="font-semibold">
-            {renderContent(line.content, note, crossRefs, basePath)}
+            {renderContent(line.content, note, crossRefs, basePath, withRev)}
           </span>
         ) : (
-          renderContent(line.content, note, crossRefs, basePath)
+          renderContent(line.content, note, crossRefs, basePath, withRev)
         )}
       </span>
     </div>
@@ -89,6 +113,7 @@ export default function NoteBlock({
   lineNumberOffset = 1,
   crossRefs,
   basePath,
+  withRev,
 }: NoteBlockProps) {
   if (note.lines.length > 0) {
     return (
@@ -101,6 +126,7 @@ export default function NoteBlock({
             note={note}
             crossRefs={crossRefs}
             basePath={basePath}
+            withRev={withRev}
           />
         ))}
       </div>
@@ -125,6 +151,7 @@ export default function NoteBlock({
           note={note}
           crossRefs={crossRefs}
           basePath={basePath}
+          withRev={withRev}
         />
       ))}
     </div>

--- a/frontend/src/components/viewer/NotesViewer.test.tsx
+++ b/frontend/src/components/viewer/NotesViewer.test.tsx
@@ -4,6 +4,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import NotesViewer from './NotesViewer';
 import type { SectionView } from '@/lib/types';
 
+vi.mock('@/hooks/useRevision', () => ({
+  useRevision: () => ({ revision: undefined, withRev: (h: string) => h }),
+}));
+
 const sectionData: SectionView = {
   title_number: 17,
   section_number: '106',

--- a/frontend/src/components/viewer/NotesViewer.tsx
+++ b/frontend/src/components/viewer/NotesViewer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSection } from '@/hooks/useSection';
+import { useRevision } from '@/hooks/useRevision';
 import type { SectionNote } from '@/lib/types';
 import SectionNotes from './SectionNotes';
 
@@ -30,6 +31,7 @@ export default function NotesViewer({
   file,
   revision,
 }: NotesViewerProps) {
+  const { withRev } = useRevision();
   const { data, isLoading, error } = useSection(
     titleNumber,
     sectionNumber,
@@ -70,6 +72,7 @@ export default function NotesViewer({
       categoryLabel={categoryLabel}
       allNotes={allNotes}
       basePath={basePath}
+      withRev={withRev}
     />
   );
 }

--- a/frontend/src/components/viewer/SectionNotes.test.tsx
+++ b/frontend/src/components/viewer/SectionNotes.test.tsx
@@ -1,7 +1,17 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import SectionNotes from './SectionNotes';
-import type { SectionNote } from '@/lib/types';
+import type { SectionNote, NoteReference } from '@/lib/types';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
 
 const notes: SectionNote[] = [
   {
@@ -103,6 +113,47 @@ describe('SectionNotes', () => {
   it('renders in a code-style block', () => {
     const { container } = render(<SectionNotes {...defaultProps} />);
     expect(container.querySelector('.bg-gray-100')).toBeInTheDocument();
+  });
+
+  it('renders note.references as clickable links', () => {
+    const ref: NoteReference = {
+      ref_type: 'usc_section',
+      href: '',
+      display_text: 'section 106 of title 17',
+      congress: null,
+      law_number: null,
+      usc_title: 17,
+      usc_section: '106',
+      target_id: '17 USC 106',
+      resolvable: true,
+    };
+    const noteWithRefs: SectionNote[] = [
+      {
+        header: 'References in Text',
+        content: '',
+        lines: [
+          {
+            line_number: 1,
+            content: 'See section 106 of title 17 for details.',
+            indent_level: 0,
+            marker: null,
+            is_header: false,
+          },
+        ],
+        category: 'editorial',
+        references: [ref],
+      },
+    ];
+    render(
+      <SectionNotes
+        notes={noteWithRefs}
+        fullCitation="17 U.S.C. § 602"
+        heading="Infringing importation or exportation"
+        categoryLabel="Editorial Notes"
+      />
+    );
+    const link = screen.getByRole('link', { name: 'section 106 of title 17' });
+    expect(link).toHaveAttribute('href', '/sections/17/106');
   });
 
   it('does not use dropdown details/summary elements', () => {

--- a/frontend/src/components/viewer/SectionNotes.tsx
+++ b/frontend/src/components/viewer/SectionNotes.tsx
@@ -13,6 +13,7 @@ interface SectionNotesProps {
   categoryLabel: string;
   allNotes?: SectionNote[];
   basePath?: string;
+  withRev?: (href: string) => string;
 }
 
 /** Count lines a note will render. */
@@ -29,6 +30,7 @@ export default function SectionNotes({
   categoryLabel,
   allNotes,
   basePath,
+  withRev,
 }: SectionNotesProps) {
   if (notes.length === 0) return null;
 
@@ -79,6 +81,7 @@ export default function SectionNotes({
               lineNumberOffset={contentOffset}
               crossRefs={crossRefs}
               basePath={basePath}
+              withRev={withRev}
             />
           </div>
         );


### PR DESCRIPTION
## Summary

- `NoteBlock.renderContent` now calls `linkifyContent` for `note.references` (USC/PL citations) alongside the existing `findNoteLinks` note-to-note cross-reference pass
- `withRev` is threaded from `NotesViewer` (via `useRevision()`) → `SectionNotes` → `NoteBlock` so `?rev=` context is preserved on generated hrefs
- `NotesViewer.test.tsx` mocks `useRevision` to avoid `useSearchParams` context requirement in tests
- `SectionNotes.test.tsx` adds a new test verifying that a note with `references` renders a clickable link

## Test plan

- [ ] All 181 frontend tests pass (`npx vitest run`)
- [ ] TypeScript type-check is clean (`npm run type-check`)
- [ ] Navigate to a section with notes (e.g. `/sections/17/106/HISTORICAL_NOTES`) — any `NoteReference` objects returned in `SectionNote.references` from the API should appear as clickable links rather than plain text

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)