### PR TITLE
feat: post screenshots and parsing proof to PRs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **GitHub issue labels**: When creating GitHub issues, apply the `bug` label for bugfix issues and the `enhancement` label for feature issues (e.g., `gh issue create --label bug ...` or `gh issue create --label enhancement ...`).
 - **PR-to-issue linking**: Every PR body must include `Closes #N` or `Fixes #N` so the motivating issue auto-closes on merge.
 - **PR screenshots**: After creating a PR that includes frontend/UI changes, post screenshots of the affected pages. Run `bash scripts/post_pr_screenshots.sh <PR_NUMBER> /path1 /path2 ...` with the dev server running on port 3000. Pass every page path that shows the new or changed UI.
+- **PR parsing proof**: After creating a PR that includes parsing or rendering changes, include a before/after block in the PR body or a follow-up comment showing the parsed output for the representative example that triggered the fix. Use plain text or a code block — no special tooling required, just run the parser on the example in both states.
 
 ## Project Overview
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Before pushing**: Always run `uv run mypy app --ignore-missing-imports && uv run pytest` in the backend directory. After pushing, check CI status with `gh run list --branch <branch> --limit 1` and `gh run view <run-id> --log-failed`.
 - **GitHub issue labels**: When creating GitHub issues, apply the `bug` label for bugfix issues and the `enhancement` label for feature issues (e.g., `gh issue create --label bug ...` or `gh issue create --label enhancement ...`).
 - **PR-to-issue linking**: Every PR body must include `Closes #N` or `Fixes #N` so the motivating issue auto-closes on merge.
+- **PR screenshots**: After creating a PR that includes frontend/UI changes, post screenshots of the affected pages. Run `bash scripts/post_pr_screenshots.sh <PR_NUMBER> /path1 /path2 ...` with the dev server running on port 3000. Pass every page path that shows the new or changed UI.
 
 ## Project Overview
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,5 +9,18 @@
       "WebFetch(domain:www.law.cornell.edu)",
       "WebFetch(domain:codeweliveby.org)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"import sys,json; d=json.load(sys.stdin); cmd=d.get('tool_input',{}).get('command',''); print('Reminder: This PR includes frontend changes — post screenshots with: bash scripts/post_pr_screenshots.sh <PR_NUMBER> /path/to/feature') if 'gh pr create' in cmd else None\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/post_pr_screenshots.sh
+++ b/scripts/post_pr_screenshots.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Posts screenshots of frontend pages to a GitHub PR.
+# Usage: bash scripts/post_pr_screenshots.sh <PR_NUMBER> [/path1] [/path2] ...
+# Requires: dev server running on localhost:3000, gh CLI authenticated, npx
+
+set -euo pipefail
+
+PR_NUMBER="${1:?Usage: $0 <PR_NUMBER> [/path1] [/path2] ...}"
+shift
+PATHS=("${@:- /}")
+
+# Verify gh is authenticated
+if ! gh auth status &>/dev/null; then
+    echo "Error: gh CLI not authenticated. Run: gh auth login" >&2
+    exit 1
+fi
+
+# Verify dev server is reachable
+if ! curl -sf http://localhost:3000 -o /dev/null; then
+    echo "Error: Dev server not responding on http://localhost:3000" >&2
+    echo "Run: cd frontend && npm run dev" >&2
+    exit 1
+fi
+
+# Install Playwright browser if not already present
+npx --yes playwright install chromium --with-deps &>/dev/null
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Taking screenshots..."
+FILES=()
+ENTRIES=()
+for path in "${PATHS[@]}"; do
+    slug=$(echo "$path" | sed 's|^/||; s|/|-|g')
+    slug="${slug:-home}"
+    output="${TMPDIR}/${slug}.png"
+
+    if npx playwright screenshot "http://localhost:3000${path}" "$output" --full-page 2>/dev/null; then
+        echo "  OK  http://localhost:3000${path}"
+        FILES+=("$output")
+        ENTRIES+=("${path}:${slug}")
+    else
+        echo "  SKIP  http://localhost:3000${path} (page not reachable)" >&2
+    fi
+done
+
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo "No screenshots captured." >&2
+    exit 1
+fi
+
+# Upload all screenshots to a single public gist
+echo "Uploading to GitHub Gist..."
+GIST_URL=$(gh gist create --public "${FILES[@]}" --desc "Screenshots for PR #${PR_NUMBER}")
+GIST_ID="${GIST_URL##*/}"
+GH_USER=$(gh api user -q .login)
+
+# Build PR comment body
+BODY="## Screenshots\n\n"
+for entry in "${ENTRIES[@]}"; do
+    path="${entry%%:*}"
+    slug="${entry##*:}"
+    raw_url="https://gist.githubusercontent.com/${GH_USER}/${GIST_ID}/raw/${slug}.png"
+    BODY+="**\`${path:-/}\`**\n![Screenshot of ${path:-/}](${raw_url})\n\n"
+done
+
+gh pr comment "$PR_NUMBER" --body "$(printf "%b" "$BODY")"
+echo "Posted screenshots to PR #${PR_NUMBER} — gist: ${GIST_URL}"


### PR DESCRIPTION
## Summary

- Adds `scripts/post_pr_screenshots.sh` — takes full-page Playwright screenshots of specified pages, uploads them to a public GitHub Gist, and posts a formatted comment with embedded images to the PR
- Adds a `PostToolUse` hook in `.claude/settings.json` that fires after `gh pr create` to remind Claude to run the screenshot script for frontend PRs
- Adds two new CLAUDE.md conventions:
  - **PR screenshots**: run the helper script after any frontend/UI PR
  - **PR parsing proof**: include a before/after text block in the PR body or comment for any parsing/rendering change

## Test plan

- [ ] Create a frontend PR, verify the hook fires with the reminder after `gh pr create`
- [ ] Run `bash scripts/post_pr_screenshots.sh <PR_NUMBER> /` with the dev server running and confirm a screenshot comment appears on the PR
- [ ] Verify Playwright auto-installs via `npx` on first run

Closes #298