### PR TITLE
feat: wire notes hyperlink refs into NoteBlock renderer

### DIFF
--- a/frontend/src/components/viewer/NoteBlock.tsx
+++ b/frontend/src/components/viewer/NoteBlock.tsx
@@ -1,46 +1,68 @@
 import Link from 'next/link';
-import type { SectionNote, CodeLine } from '@/lib/types';
+import type { ReactNode } from 'react';
+import type { SectionNote, CodeLine, NoteReference } from '@/lib/types';
 import { findNoteLinks, type CrossRefLookup } from '@/lib/noteUtils';
+import { linkifyContent } from '@/lib/linkifyContent';
 
 interface NoteBlockProps {
   note: SectionNote;
   lineNumberOffset?: number;
   crossRefs?: CrossRefLookup;
   basePath?: string;
+  externalRefs?: NoteReference[];
 }
 
+const identity = (href: string) => href;
+
 /**
- * Render line content, hyperlinking any cross-references to other note files.
- * Returns a plain string when there are no cross-refs to avoid unnecessary JSX.
+ * Render line content, linking both cross-note refs and external law/section refs.
+ *
+ * Cross-note links (e.g. "Effective Date note below") take priority. External
+ * refs (Public Laws, USC sections) are applied to the text gaps between them.
  */
 function renderContent(
   content: string,
   note: SectionNote,
   crossRefs: CrossRefLookup | undefined,
-  basePath: string | undefined
-) {
-  if (!crossRefs || !basePath || crossRefs.size === 0) return content;
+  basePath: string | undefined,
+  externalRefs: NoteReference[]
+): ReactNode {
+  const noteSegs =
+    crossRefs && basePath && crossRefs.size > 0
+      ? findNoteLinks(content, crossRefs, note.category, basePath)
+      : [];
 
-  const segments = findNoteLinks(content, crossRefs, note.category, basePath);
-  if (segments.length === 0) return content;
+  const applyExternal = (text: string): ReactNode =>
+    externalRefs.length > 0
+      ? linkifyContent(text, externalRefs, identity)
+      : text;
 
-  const nodes: any[] = [];
-  let pos = 0;
-  for (const seg of segments) {
-    if (seg.start > pos) nodes.push(content.slice(pos, seg.start));
-    nodes.push(
-      <Link
-        key={seg.start}
-        href={seg.url}
-        className="text-blue-600 hover:underline"
-      >
+  if (noteSegs.length === 0) return applyExternal(content);
+
+  const linkClass = 'text-blue-600 hover:underline';
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  for (const seg of noteSegs) {
+    if (seg.start > cursor) {
+      parts.push(
+        <span key={`t-${cursor}`}>
+          {applyExternal(content.slice(cursor, seg.start))}
+        </span>
+      );
+    }
+    parts.push(
+      <Link key={`n-${seg.start}`} href={seg.url} className={linkClass}>
         {seg.text}
       </Link>
     );
-    pos = seg.end;
+    cursor = seg.end;
   }
-  if (pos < content.length) nodes.push(content.slice(pos));
-  return <>{nodes}</>;
+  if (cursor < content.length) {
+    parts.push(
+      <span key={`t-${cursor}`}>{applyExternal(content.slice(cursor))}</span>
+    );
+  }
+  return <>{parts}</>;
 }
 
 /** Renders a single line with line number and optional indent. */
@@ -50,12 +72,14 @@ function NoteLine({
   note,
   crossRefs,
   basePath,
+  externalRefs = [],
 }: {
   lineNumber: number;
   line: CodeLine;
   note: SectionNote;
   crossRefs?: CrossRefLookup;
   basePath?: string;
+  externalRefs?: NoteReference[];
 }) {
   const indent = line.indent_level > 0 ? '\t'.repeat(line.indent_level) : '';
   const isListItem = line.marker !== null;
@@ -73,10 +97,16 @@ function NoteLine({
       >
         {line.is_header ? (
           <span className="font-semibold">
-            {renderContent(line.content, note, crossRefs, basePath)}
+            {renderContent(
+              line.content,
+              note,
+              crossRefs,
+              basePath,
+              externalRefs
+            )}
           </span>
         ) : (
-          renderContent(line.content, note, crossRefs, basePath)
+          renderContent(line.content, note, crossRefs, basePath, externalRefs)
         )}
       </span>
     </div>
@@ -89,6 +119,7 @@ export default function NoteBlock({
   lineNumberOffset = 1,
   crossRefs,
   basePath,
+  externalRefs = [],
 }: NoteBlockProps) {
   if (note.lines.length > 0) {
     return (
@@ -101,6 +132,7 @@ export default function NoteBlock({
             note={note}
             crossRefs={crossRefs}
             basePath={basePath}
+            externalRefs={externalRefs}
           />
         ))}
       </div>
@@ -125,6 +157,7 @@ export default function NoteBlock({
           note={note}
           crossRefs={crossRefs}
           basePath={basePath}
+          externalRefs={externalRefs}
         />
       ))}
     </div>

--- a/frontend/src/components/viewer/NotesViewer.test.tsx
+++ b/frontend/src/components/viewer/NotesViewer.test.tsx
@@ -20,6 +20,7 @@ const sectionData: SectionView = {
     citations: [],
     amendments: [],
     short_titles: [],
+    references: [],
     notes: [
       {
         header: 'References in Text',
@@ -225,6 +226,61 @@ describe('NotesViewer', () => {
       'href',
       '/sections/50/541/STATUTORY_NOTES#effective-and-termination-date'
     );
+  });
+
+  it('linkifies external law references from notes.references', async () => {
+    const extRefData: SectionView = {
+      ...sectionData,
+      notes: {
+        ...sectionData.notes!,
+        references: [
+          {
+            ref_type: 'public_law',
+            href: '/us/pl/107/273',
+            display_text: 'Pub. L. 107–273',
+            congress: 107,
+            law_number: 273,
+            target_id: 'PL 107-273',
+            resolvable: true,
+          },
+        ],
+        notes: [
+          {
+            header: 'Amendments',
+            content: '',
+            lines: [
+              {
+                line_number: 1,
+                content: '2002—Subsec. (a). Pub. L. 107–273 amended heading.',
+                indent_level: 0,
+                marker: null,
+                is_header: false,
+              },
+            ],
+            category: 'historical',
+          },
+        ],
+      },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(extRefData), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    render(
+      <NotesViewer
+        titleNumber={17}
+        sectionNumber="106"
+        file="HISTORICAL_NOTES"
+      />,
+      { wrapper }
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Amendments')).toBeInTheDocument();
+    });
+    const link = screen.getByRole('link', { name: 'Pub. L. 107–273' });
+    expect(link).toHaveAttribute('href', '/laws/107/273');
   });
 
   it('shows error state on fetch failure', async () => {

--- a/frontend/src/components/viewer/NotesViewer.tsx
+++ b/frontend/src/components/viewer/NotesViewer.tsx
@@ -62,6 +62,8 @@ export default function NotesViewer({
 
   const basePath = `/sections/${titleNumber}/${encodeURIComponent(sectionNumber)}`;
 
+  const references = data.notes?.references ?? [];
+
   return (
     <SectionNotes
       notes={filtered}
@@ -70,6 +72,7 @@ export default function NotesViewer({
       categoryLabel={categoryLabel}
       allNotes={allNotes}
       basePath={basePath}
+      references={references}
     />
   );
 }

--- a/frontend/src/components/viewer/SectionNotes.tsx
+++ b/frontend/src/components/viewer/SectionNotes.tsx
@@ -1,4 +1,4 @@
-import type { SectionNote } from '@/lib/types';
+import type { SectionNote, NoteReference } from '@/lib/types';
 import {
   buildCrossRefLookup,
   slugify,
@@ -13,6 +13,7 @@ interface SectionNotesProps {
   categoryLabel: string;
   allNotes?: SectionNote[];
   basePath?: string;
+  references?: NoteReference[];
 }
 
 /** Count lines a note will render. */
@@ -29,6 +30,7 @@ export default function SectionNotes({
   categoryLabel,
   allNotes,
   basePath,
+  references = [],
 }: SectionNotesProps) {
   if (notes.length === 0) return null;
 
@@ -79,6 +81,7 @@ export default function SectionNotes({
               lineNumberOffset={contentOffset}
               crossRefs={crossRefs}
               basePath={basePath}
+              externalRefs={references}
             />
           </div>
         );

--- a/frontend/src/components/viewer/SectionViewer.test.tsx
+++ b/frontend/src/components/viewer/SectionViewer.test.tsx
@@ -71,6 +71,7 @@ const baseSectionData: SectionView = {
       },
     ],
     notes: [],
+    references: [],
     has_notes: false,
     has_citations: true,
     has_amendments: true,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -162,6 +162,7 @@ export interface SectionNotes {
     public_law: string | null;
   }[];
   notes: SectionNote[];
+  references: NoteReference[];
   has_notes: boolean;
   has_citations: boolean;
   has_amendments: boolean;


### PR DESCRIPTION
## Summary

- `SectionNotes` TypeScript interface gains `references: NoteReference[]` (mirrors existing backend `SectionNotesSchema.references` JSONB field, previously missing from the frontend type)
- `NoteBlock` renderer extended with `externalRefs?: NoteReference[]` prop; calls `linkifyContent()` to turn Public Law / USC section refs into clickable `<Link>` elements — cross-note links (e.g. "Effective Date note below") retain priority, external refs fill text gaps between them
- `NotesViewer` → `SectionNotes` → `NoteBlock` threading wires `data.notes.references` from the API response down to the renderer
- New `NotesViewer` test asserts that a `Pub. L. 107–273` ref in `notes.references` renders as an `<a href="/laws/107/273">` link; test fixtures updated to include `references: []`

Backend parsing infrastructure (`_extract_notes_refs`, `NoteRef`, `note_refs_to_schemas`, `SectionNotesSchema.references`) was already complete with tests — this PR is purely the frontend wiring.

Closes #298

## Test plan

- [ ] All 181 frontend unit tests pass
- [ ] TypeScript type-check passes (no errors)
- [ ] On a section with historical/editorial notes containing `<ref href="/us/pl/…">` citations (e.g. 17 USC 106), Public Law citations render as blue underline links pointing to `/laws/{congress}/{number}`
- [ ] Cross-note links (e.g. "Effective Date note below") still work — they are not broken by the new external-ref pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)