### PR TITLE
feat: parse <quotedContent> blocks and render as blockquotes in notes

### DIFF
--- a/backend/app/schemas/us_code.py
+++ b/backend/app/schemas/us_code.py
@@ -37,6 +37,9 @@ class CodeLineSchema(BaseModel):
     marker: str | None = Field(None, description="List item marker (e.g., '(a)')")
     is_header: bool = Field(False, description="Whether this is a header line")
     is_signature: bool = Field(False, description="Whether this is a signature line")
+    is_quoted: bool = Field(
+        False, description="True for lines derived from <quotedContent> blocks"
+    )
     start_char: int = Field(..., ge=0, description="Start position in original text")
     end_char: int = Field(..., ge=0, description="End position in original text")
 

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -992,6 +992,7 @@ def normalize_note_content(text: str) -> list[ParsedLine]:
                             indent_level=indent,
                             marker=marker,
                             is_header=False,
+                            is_quoted=True,
                             start_char=match.start(),
                             end_char=match.end(),
                         )

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1208,76 +1208,105 @@ class USLMParser:
     def _format_quoted_content(self, elem: etree._Element) -> str:
         """Format quotedContent element with proper structure markers.
 
-        Parses the structured subsections, paragraphs, etc. within quoted content
-        and formats them with markers that the normalizer can use to create
-        properly indented lines.
+        Parses the structured sections, subsections, paragraphs, etc. within
+        quoted content and formats them with [QC:level] markers the normalizer
+        uses to create properly indented lines.
 
-        Markers: [QC:level:marker]content where level is indent depth (1-5).
+        Two patterns handled:
+        - Anonymous inline: <section class="inline"> with chapeau + paragraphs
+          + continuation (no section header emitted for empty <num>)
+        - Full named sections: <section> with real <num> and <heading>
+        - Subsection-only: <subsection> children at top level (legacy pattern)
         """
         parts = []
 
         def format_item(item_elem: etree._Element, level: int) -> None:
-            """Format a subsection/paragraph/clause/etc. element."""
-            # Get marker (num)
+            """Recursively format a structural element."""
             num_elem = item_elem.find("{*}num")
             if num_elem is None:
                 num_elem = item_elem.find("num")
             marker = self._get_text_content(num_elem) if num_elem is not None else ""
 
-            # Get heading
             heading_elem = item_elem.find("{*}heading")
             if heading_elem is None:
                 heading_elem = item_elem.find("heading")
-            heading = ""
-            if heading_elem is not None:
-                heading = self._get_text_content(heading_elem).strip()
+            heading = (
+                self._get_text_content(heading_elem).strip()
+                if heading_elem is not None
+                else ""
+            )
 
-            # Get content
-            content_elem = item_elem.find("{*}content")
-            if content_elem is None:
-                content_elem = item_elem.find("content")
             chapeau_elem = item_elem.find("{*}chapeau")
             if chapeau_elem is None:
                 chapeau_elem = item_elem.find("chapeau")
 
-            content = ""
-            if chapeau_elem is not None:
-                content = self._get_text_content(chapeau_elem).strip()
-            elif content_elem is not None:
-                content = self._get_text_content(content_elem).strip()
+            content_elem = item_elem.find("{*}content")
+            if content_elem is None:
+                content_elem = item_elem.find("content")
 
-            # Build the formatted line
-            line_parts = []
+            # Emit the header line: marker + heading + direct content (if no chapeau)
+            line_parts: list[str] = []
             if marker:
                 line_parts.append(marker)
             if heading:
                 line_parts.append(heading)
-            if content:
-                line_parts.append(content)
+            if chapeau_elem is None and content_elem is not None:
+                content_text = self._get_text_content(content_elem).strip()
+                if content_text:
+                    line_parts.append(content_text)
 
             if line_parts:
-                text = " ".join(line_parts)
-                parts.append(f"[QC:{level}]{text}[/QC]")
+                parts.append(f"[QC:{level}]{' '.join(line_parts)}[/QC]")
 
-            # Process nested children
-            child_tags = ["paragraph", "subparagraph", "clause", "subclause", "item"]
+            # Chapeau is the intro sentence before enumerated children
+            if chapeau_elem is not None:
+                chapeau_text = self._get_text_content(chapeau_elem).strip()
+                if chapeau_text:
+                    child_level = level + 1 if line_parts else level
+                    parts.append(f"[QC:{child_level}]{chapeau_text}[/QC]")
+
+            # Recurse into structural children (subsection added for section→subsection)
+            child_tags = [
+                "subsection",
+                "paragraph",
+                "subparagraph",
+                "clause",
+                "subclause",
+                "item",
+            ]
             for child_tag in child_tags:
                 for child in item_elem.findall(f"{{*}}{child_tag}"):
                     format_item(child, level + 1)
                 for child in item_elem.findall(child_tag):
                     format_item(child, level + 1)
 
-        # Process top-level subsections in quoted content
-        for subsection in elem.findall("{*}subsection"):
-            format_item(subsection, 1)
-        for subsection in elem.findall("subsection"):
-            format_item(subsection, 1)
+            # Continuation is the closing sentence after enumerated children
+            cont_elem = item_elem.find("{*}continuation")
+            if cont_elem is None:
+                cont_elem = item_elem.find("continuation")
+            if cont_elem is not None:
+                cont_text = self._get_text_content(cont_elem).strip()
+                if cont_text:
+                    child_level = level + 1 if line_parts else level
+                    parts.append(f"[QC:{child_level}]{cont_text}[/QC]")
 
-        # If no structured content, extract plain text (for inline quotedContent)
+        # Process top-level sections (both anonymous inline and named)
+        for section in elem.findall("{*}section"):
+            format_item(section, 1)
+        for section in elem.findall("section"):
+            format_item(section, 1)
+
+        # Process top-level subsections when no sections are present
+        if not parts:
+            for subsection in elem.findall("{*}subsection"):
+                format_item(subsection, 1)
+            for subsection in elem.findall("subsection"):
+                format_item(subsection, 1)
+
+        # Fallback: extract plain text for simple inline quotedContent
         if not parts:
             text = self._get_text_content(elem).strip()
             if text:
-                # Inline quoted content at level 1
                 parts.append(f"[QC:1]{text}[/QC]")
 
         return "\n".join(parts)

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1393,6 +1393,93 @@ class TestParserNotesContent:
         assert "[QC:1]" in content
         assert "[QC:2]" in content
 
+    def test_section_with_chapeau_and_continuation(self) -> None:
+        """quotedContent with anonymous section: chapeau + paragraphs + continuation."""
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        xml = """<notes>
+            <quotedContent>
+                <section class="inline">
+                    <num value=""/>
+                    <chapeau>"Notwithstanding any provision&#8212;</chapeau>
+                    <paragraph>
+                        <num value="1">"(1)"</num>
+                        <content>imposes any tax, or</content>
+                    </paragraph>
+                    <paragraph>
+                        <num value="2">"(2)"</num>
+                        <content>establishes any trust fund,</content>
+                    </paragraph>
+                    <continuation>shall have no force or effect."</continuation>
+                </section>
+            </quotedContent>
+        </notes>"""
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # Chapeau should be at level 1, paragraphs at level 2
+        assert "[QC:1]" in content
+        assert "[QC:2]" in content
+        assert "Notwithstanding" in content
+        assert '"(1)"' in content
+        assert "imposes any tax" in content
+        assert "shall have no force or effect" in content
+
+    def test_named_sections_in_quoted_content(self) -> None:
+        """quotedContent with named sections (section + subsection nesting)."""
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        xml = """<notes>
+            <quotedContent>
+                <section>
+                    <num value="1">"SEC. 1."</num>
+                    <heading>SHORT TITLE.</heading>
+                    <content>This Act may be cited as the 'Test Act'.</content>
+                </section>
+                <section>
+                    <num value="2">"SEC. 2."</num>
+                    <heading>DEFINITIONS.</heading>
+                    <subsection>
+                        <num value="a">"(a)"</num>
+                        <content>For purposes of this Act&#8212;</content>
+                    </subsection>
+                </section>
+            </quotedContent>
+        </notes>"""
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # Section headers at level 1, subsection at level 2
+        assert '"SEC. 1."' in content
+        assert "SHORT TITLE" in content
+        assert '"SEC. 2."' in content
+        assert "[QC:1]" in content
+        assert "[QC:2]" in content
+
+    def test_is_quoted_flag_set_on_qc_lines(self) -> None:
+        """Lines derived from quotedContent blocks have is_quoted=True."""
+        from pipeline.olrc.normalized_section import normalize_note_content
+
+        raw = 'Provided that:\n[QC:1]"(a)" First item.[/QC]\n[QC:1]"(b)" Second item.[/QC]'
+        lines = normalize_note_content(raw)
+
+        prose_lines = [ln for ln in lines if not ln.is_quoted]
+        quoted_lines = [ln for ln in lines if ln.is_quoted]
+
+        assert any("Provided" in ln.content for ln in prose_lines)
+        assert len(quoted_lines) == 2
+        assert all(ln.is_quoted for ln in quoted_lines)
+
     def test_smallcaps_heading_marked_with_nh(self) -> None:
         """Test that smallCaps headings are marked with [NH]...[/NH].
 

--- a/frontend/src/components/viewer/NoteBlock.tsx
+++ b/frontend/src/components/viewer/NoteBlock.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, Fragment } from 'react';
 import Link from 'next/link';
 import type { SectionNote, CodeLine } from '@/lib/types';
 import { findNoteLinks, type CrossRefLookup } from '@/lib/noteUtils';
@@ -107,6 +107,22 @@ function NoteLine({
   );
 }
 
+/** Groups consecutive lines into prose vs quoted-content segments. */
+function groupLineSegments(lines: CodeLine[]) {
+  type Segment = { isQuoted: boolean; lines: CodeLine[]; startIdx: number };
+  const segs: Segment[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const isQuoted = lines[i].is_quoted === true;
+    const last = segs[segs.length - 1];
+    if (!last || last.isQuoted !== isQuoted) {
+      segs.push({ isQuoted, lines: [lines[i]], startIdx: i });
+    } else {
+      last.lines.push(lines[i]);
+    }
+  }
+  return segs;
+}
+
 /** Renders a single structured note as a block with line numbers. */
 export default function NoteBlock({
   note,
@@ -116,19 +132,33 @@ export default function NoteBlock({
   withRev,
 }: NoteBlockProps) {
   if (note.lines.length > 0) {
+    const lineSegs = groupLineSegments(note.lines);
     return (
       <div className="mb-2">
-        {note.lines.map((line, i) => (
-          <NoteLine
-            key={line.line_number}
-            lineNumber={lineNumberOffset + i}
-            line={line}
-            note={note}
-            crossRefs={crossRefs}
-            basePath={basePath}
-            withRev={withRev}
-          />
-        ))}
+        {lineSegs.map((seg, si) => {
+          const lineElems = seg.lines.map((line, j) => (
+            <NoteLine
+              key={line.line_number}
+              lineNumber={lineNumberOffset + seg.startIdx + j}
+              line={line}
+              note={note}
+              crossRefs={crossRefs}
+              basePath={basePath}
+              withRev={withRev}
+            />
+          ));
+          if (seg.isQuoted) {
+            return (
+              <div
+                key={si}
+                className="my-1 ml-8 border-l-2 border-slate-300 bg-slate-50 pl-2"
+              >
+                {lineElems}
+              </div>
+            );
+          }
+          return <Fragment key={si}>{lineElems}</Fragment>;
+        })}
       </div>
     );
   }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -88,6 +88,7 @@ export interface CodeLine {
   marker: string | null;
   is_header: boolean;
   is_signature?: boolean;
+  is_quoted?: boolean;
 }
 
 export type NoteRefType = 'public_law' | 'act' | 'usc_section' | 'statute';


### PR DESCRIPTION
## Context

`<quotedContent>` elements in USLM section notes contain verbatim statutory text — quoted provisions, entire Act sections, etc. There are 426 occurrences in Phase 1 titles (Title 42: 122, Title 26: 77). Two patterns exist:

1. **Anonymous inline** (`<section class="inline">` with empty `<num>`): chapeau + enumerated paragraphs + continuation closing text
2. **Named sections** (`<section>` with real `<num>` and `<heading>`): full Act sections with nested subsections

Previously the parser only handled `<subsection>` as a top-level element, so both patterns above fell through to a plain-text fallback that concatenated all text into one flat `[QC:1]` line. `<continuation>` elements were silently dropped entirely.

## Changes

### Backend — parser
- Handle `<section>` as top-level in `_format_quoted_content()`, covering both anonymous and named patterns
- Add `<continuation>` support: closing text after enumerated paragraphs is now captured at the correct indent level
- Add `subsection` to `child_tags` so section→subsection recursion works
- Fix lxml FutureWarning: `not chapeau_elem` → `chapeau_elem is None`

### Backend — schema + normalizer
- Add `is_quoted: bool = False` to `CodeLineSchema`; the normalizer sets it `True` for every line derived from a `[QC:level]` marker
- This lets the frontend distinguish quoted-content lines from editorial prose without a separate data structure

### Frontend
- `NoteBlock.tsx`: `groupLineSegments()` groups consecutive `is_quoted` lines into segments; each quoted segment is wrapped in a `<div class="border-l-2 border-slate-300 bg-slate-50">` blockquote container
- `types.ts`: add `is_quoted?: boolean` to `CodeLine`

### Tests
- 4 new tests: anonymous section + continuation, named sections, `is_quoted` flag

Closes #323