### PR TITLE
fix: parse flat notes that follow Historical and Revision Notes section

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1345,7 +1345,16 @@ def _parse_notes_structure(
     # Fallback: some older sections use flat <note> elements without category
     # wrapper headings ("Editorial Notes" / "Statutory Notes"), so none of the
     # three parsers above match.  Parse all [NH]...[/NH] blocks directly.
-    if not notes.notes:
+    #
+    # Also triggered when _parse_historical_notes greedily consumed the full
+    # text (because there was no "Editorial Notes" terminator), leaving sibling
+    # flat notes—like "Amendments"—unprocessed.  See issue #283 (13 USC § 141).
+    already_processed = {n.header.lower() for n in notes.notes}
+    has_unprocessed_nh = any(
+        m.group(1).strip().lower() not in already_processed
+        for m in re.finditer(r"\[NH\](.*?)\[/NH\]", raw_notes, re.DOTALL)
+    )
+    if has_unprocessed_nh:
         _parse_flat_notes(raw_notes, notes)
 
 
@@ -1382,8 +1391,10 @@ def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
         header_positions.append((match.start(), match.end(), header))
 
     seen_headers: set[str] = set()
+    # Skip headers already emitted by _parse_historical/editorial/statutory_notes
+    existing_lower = {n.header.lower() for n in notes.notes}
     for i, (_start, end, header) in enumerate(header_positions):
-        if header in seen_headers:
+        if header in seen_headers or header.lower() in existing_lower:
             continue
         seen_headers.add(header)
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1721,6 +1721,70 @@ class TestFlatNotesParser:
 
         assert len(notes.notes) == 0
 
+    def test_flat_notes_after_historical_note_issue_283(self) -> None:
+        """Regression: flat notes after 'Historical and Revision Notes' must not be swallowed.
+
+        13 U.S.C. § 141 has 11 flat notes. The first is 'Historical and Revision
+        Notes'; prior to the fix _parse_historical_notes greedily consumed all
+        content (since there was no 'Editorial Notes' terminator), leaving notes
+        2–11 unprocessed.  Closes #283.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        raw_notes = (
+            "[NH]Historical And Revision Notes[/NH] "
+            "Based on title 13, U.S.C., 1952 ed., § 201 (part). "
+            "[NH]Amendments[/NH] "
+            "1957—Pub. L. 85–207, § 9, substituted heading; added housing census. "
+            "1975—Pub. L. 94–171, §§ 1, 2(a), inserted apportionment tabulation. "
+            "1976—Pub. L. 94–521, § 7(a), updated heading and subsections. "
+            "[NH]Effective Date Of 1976 Amendment[/NH] "
+            "Amendment by Pub. L. 94–521 effective Oct. 1, 1976. "
+            "[NH]Statistical Sampling Or Adjustment In Decennial Enumeration[/NH] "
+            "Pub. L. 105–119, title II, § 209(a), Nov. 26, 1997, 111 Stat. 2482, provided."
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        headers = [n.header for n in notes.notes]
+        # _parse_historical_notes hardcodes "Historical and Revision Notes" (lowercase "and")
+        assert "Historical and Revision Notes" in headers
+        assert "Amendments" in headers
+        assert "Effective Date Of 1976 Amendment" in headers
+        assert "Statistical Sampling Or Adjustment In Decennial Enumeration" in headers
+        assert len(notes.notes) >= 4
+
+    def test_amendments_populated_from_flat_notes_issue_284(self) -> None:
+        """Regression: notes.amendments must be populated when 'Amendments' is a flat note.
+
+        For 13 U.S.C. § 141 the 'Amendments' note is flat (no 'Editorial Notes'
+        wrapper). Prior to the fix _parse_flat_notes was not called because
+        _parse_historical_notes had already added a note.  Closes #284.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        raw_notes = (
+            "[NH]Historical And Revision Notes[/NH] "
+            "Based on title 13, U.S.C., 1952 ed., § 201 (part). "
+            "[NH]Amendments[/NH] "
+            "1957—Pub. L. 85–207, § 9, substituted the heading for prior heading. "
+            "1975—Pub. L. 94–171, §§ 1, 2(a), inserted apportionment language. "
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        # amendments array must be populated from the flat Amendments note
+        assert len(notes.amendments) > 0
+        years = [a.year for a in notes.amendments]
+        assert 1957 in years
+        assert 1975 in years
+
 
 class TestNoteTopicAmendmentParsing:
     """Regression tests for issue #216: <note topic="amendments"> not parsed.


### PR DESCRIPTION
## Summary

- `_parse_historical_notes` used `$` as one of its regex terminal anchors, so when a section has no "Editorial Notes"/"Statutory Notes" wrapper it greedily consumed everything to end-of-string — swallowing all sibling flat notes into the first note's content
- After the three structured parsers run, `_parse_notes_structure` now checks whether any `[NH]` markers remain unaccounted-for in `notes.notes`; if so, `_parse_flat_notes` is called to handle them
- `_parse_flat_notes` gains an `existing_lower` guard so headers already emitted by the structured parsers are not duplicated
- Two regression tests added for 13 U.S.C. § 141: one verifying all 4 modeled notes appear, one verifying `notes.amendments` is populated

## Test plan

- [ ] `uv run python -m pytest tests/pipeline/test_normalized_section.py -q --override-ini="addopts="` — all 7 flat-notes tests pass (including 2 new regression tests)
- [ ] Full suite: `uv run python -m pytest tests/ -q --override-ini="addopts="` — 753 passed
- [ ] `uv run mypy app --ignore-missing-imports` — clean

Note: the fix is a parser/normalization change. Existing ingested data in production will not be updated until a re-ingestion pass runs for affected sections (13 USC § 141 and any other sections with flat notes following a Historical section). The fix ensures correct output for any future ingestion.

Closes #283
Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)