### PR TITLE
fix: section API always returns is_positive_law: false

### DIFF
--- a/backend/app/crud/us_code.py
+++ b/backend/app/crud/us_code.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import attributes
 from app.core.revision_cache import revision_cache
 from app.crud.revision import get_last_changed_revision_for_section
 from app.models.public_law import PublicLaw
-from app.models.us_code import SectionGroup, USCodeSection
+from app.models.us_code import SectionGroup
 from app.schemas.us_code import (
     CodeLineSchema,
     GroupAncestorSchema,
@@ -463,10 +463,11 @@ async def get_section(
             CodeLineSchema.model_validate(line) for line in state.normalized_provisions
         ]
 
-    # Read is_positive_law from the persisted USCodeSection record
-    is_positive_law_stmt = select(USCodeSection.is_positive_law).where(
-        USCodeSection.title_number == title_number,
-        USCodeSection.section_number == section_number,
+    # Read is_positive_law from the title-level SectionGroup (USCodeSection.is_positive_law
+    # is never populated by the pipeline; the flag lives on the title SectionGroup).
+    is_positive_law_stmt = select(SectionGroup.is_positive_law).where(
+        SectionGroup.group_type == "title",
+        SectionGroup.number == str(title_number),
     )
     is_positive_law = await session.scalar(is_positive_law_stmt) or False
 


### PR DESCRIPTION
## Problem

`GET /api/v1/sections/{title}/{section}` always returned `is_positive_law: false` for every section, even those in titles that are positive law (e.g. Title 17 — Copyrights).

## Root Cause

`get_section()` in `app/crud/us_code.py` was querying `USCodeSection.is_positive_law`, but the pipeline never populates that column. The `is_positive_law` flag is only stored on the title-level `SectionGroup` record.

## Fix

Changed the query to look up the title's `SectionGroup` row (where `group_type = 'title'` and `number = str(title_number)`), which is correctly populated by the ingestion pipeline.

## Before / After

Before: `GET /api/v1/sections/17/106` → `"is_positive_law": false`  
After: `GET /api/v1/sections/17/106` → `"is_positive_law": true`

(Title 17 is a positive law title; `GET /api/v1/titles` already correctly reports `is_positive_law: true` for it.)

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)