### PR TITLE
feat: implement Search API and search page

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from app.api.v1 import laws, revisions, sections, titles
+from app.api.v1 import laws, revisions, search, sections, titles
 
 api_router = APIRouter()
 
@@ -10,3 +10,4 @@ api_router.include_router(titles.router, prefix="/titles", tags=["titles"])
 api_router.include_router(sections.router, prefix="/sections", tags=["sections"])
 api_router.include_router(laws.router, prefix="/laws", tags=["laws"])
 api_router.include_router(revisions.router, prefix="/revisions", tags=["revisions"])
+api_router.include_router(search.router, prefix="/search", tags=["search"])

--- a/backend/app/api/v1/search.py
+++ b/backend/app/api/v1/search.py
@@ -1,0 +1,36 @@
+"""Search endpoints for sections and public laws."""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.search import search_laws, search_sections
+from app.models.base import get_async_session
+from app.schemas.search import LawSearchResponse, SectionSearchResponse
+
+router = APIRouter()
+
+_MAX_LIMIT = 100
+
+
+@router.get("/sections")
+async def search_sections_endpoint(
+    q: str = Query(..., min_length=2, description="Search query"),
+    title: int | None = Query(None, description="Filter by title number"),
+    limit: int = Query(20, ge=1, le=_MAX_LIMIT),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_async_session),
+) -> SectionSearchResponse:
+    """Search US Code sections by heading or text content."""
+    return await search_sections(session, q, title=title, limit=limit, offset=offset)
+
+
+@router.get("/laws")
+async def search_laws_endpoint(
+    q: str = Query(..., min_length=2, description="Search query"),
+    congress: int | None = Query(None, description="Filter by congress number"),
+    limit: int = Query(20, ge=1, le=_MAX_LIMIT),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_async_session),
+) -> LawSearchResponse:
+    """Search public laws by name, title, or number."""
+    return await search_laws(session, q, congress=congress, limit=limit, offset=offset)

--- a/backend/app/crud/search.py
+++ b/backend/app/crud/search.py
@@ -1,0 +1,137 @@
+"""CRUD operations for full-text search across sections and laws."""
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.public_law import PublicLaw
+from app.models.us_code import USCodeSection
+from app.schemas.search import (
+    LawSearchResponse,
+    LawSearchResult,
+    SectionSearchResponse,
+    SectionSearchResult,
+)
+
+_SNIPPET_MAX_LEN = 200
+
+
+def _make_snippet(text: str | None, query: str) -> str | None:
+    """Return a short excerpt around the first match of query in text."""
+    if not text:
+        return None
+    lower_text = text.lower()
+    lower_query = query.lower()
+    pos = lower_text.find(lower_query)
+    if pos == -1:
+        return text[:_SNIPPET_MAX_LEN].rstrip() + (
+            "…" if len(text) > _SNIPPET_MAX_LEN else ""
+        )
+    start = max(0, pos - 80)
+    end = min(len(text), pos + len(query) + 120)
+    snippet = (
+        ("…" if start > 0 else "")
+        + text[start:end].strip()
+        + ("…" if end < len(text) else "")
+    )
+    return snippet
+
+
+async def search_sections(
+    session: AsyncSession,
+    q: str,
+    title: int | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> SectionSearchResponse:
+    pattern = f"%{q}%"
+    conditions = [
+        or_(
+            USCodeSection.heading.ilike(pattern),
+            USCodeSection.text_content.ilike(pattern),
+        )
+    ]
+    if title is not None:
+        conditions.append(USCodeSection.title_number == title)
+
+    count_stmt = select(func.count()).select_from(USCodeSection).where(*conditions)
+    total = (await session.scalar(count_stmt)) or 0
+
+    stmt = (
+        select(
+            USCodeSection.title_number,
+            USCodeSection.section_number,
+            USCodeSection.heading,
+            USCodeSection.full_citation,
+            USCodeSection.text_content,
+            USCodeSection.is_repealed,
+            USCodeSection.last_modified_date,
+        )
+        .where(*conditions)
+        .order_by(USCodeSection.title_number, USCodeSection.sort_order)
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await session.execute(stmt)).all()
+    results = [
+        SectionSearchResult(
+            title_number=r.title_number,
+            section_number=r.section_number,
+            heading=r.heading,
+            full_citation=r.full_citation,
+            snippet=_make_snippet(r.text_content, q),
+            is_repealed=r.is_repealed,
+            last_modified_date=r.last_modified_date,
+        )
+        for r in rows
+    ]
+    return SectionSearchResponse(
+        results=results, total=total, limit=limit, offset=offset
+    )
+
+
+async def search_laws(
+    session: AsyncSession,
+    q: str,
+    congress: int | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> LawSearchResponse:
+    pattern = f"%{q}%"
+    conditions = [
+        or_(
+            PublicLaw.popular_name.ilike(pattern),
+            PublicLaw.short_title.ilike(pattern),
+            PublicLaw.law_number.ilike(pattern),
+        )
+    ]
+    if congress is not None:
+        conditions.append(PublicLaw.congress == congress)
+
+    count_stmt = select(func.count()).select_from(PublicLaw).where(*conditions)
+    total = (await session.scalar(count_stmt)) or 0
+
+    stmt = (
+        select(
+            PublicLaw.congress,
+            PublicLaw.law_number,
+            PublicLaw.short_title,
+            PublicLaw.popular_name,
+            PublicLaw.enacted_date,
+        )
+        .where(*conditions)
+        .order_by(PublicLaw.enacted_date.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await session.execute(stmt)).all()
+    results = [
+        LawSearchResult(
+            congress=r.congress,
+            law_number=r.law_number,
+            short_title=r.short_title,
+            popular_name=r.popular_name,
+            enacted_date=r.enacted_date,
+        )
+        for r in rows
+    ]
+    return LawSearchResponse(results=results, total=total, limit=limit, offset=offset)

--- a/backend/app/schemas/search.py
+++ b/backend/app/schemas/search.py
@@ -1,0 +1,37 @@
+"""Pydantic schemas for search API responses."""
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class SectionSearchResult(BaseModel):
+    title_number: int
+    section_number: str
+    heading: str
+    full_citation: str
+    snippet: str | None = None
+    is_repealed: bool = False
+    last_modified_date: date | None = None
+
+
+class LawSearchResult(BaseModel):
+    congress: int
+    law_number: str
+    short_title: str | None = None
+    popular_name: str | None = None
+    enacted_date: date | None = None
+
+
+class SectionSearchResponse(BaseModel):
+    results: list[SectionSearchResult]
+    total: int
+    limit: int
+    offset: int
+
+
+class LawSearchResponse(BaseModel):
+    results: list[LawSearchResult]
+    total: int
+    limit: int
+    offset: int

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -49,6 +49,12 @@ describe('Home', () => {
   it('marks placeholder cards as coming soon', () => {
     render(<Home />);
     const badges = screen.getAllByText('Coming soon');
-    expect(badges).toHaveLength(2);
+    expect(badges).toHaveLength(1);
+  });
+
+  it('links Search card to /search', () => {
+    render(<Home />);
+    const link = screen.getByText('Search').closest('a');
+    expect(link).toHaveAttribute('href', '/search');
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,15 +21,15 @@ export default function Home() {
             </p>
           </Link>
 
-          <div className="block rounded-lg border border-gray-200 bg-white p-6 opacity-50">
+          <Link
+            href="/search"
+            className="block rounded-lg border border-gray-200 bg-white p-6 transition-colors hover:border-primary-500"
+          >
             <h2 className="mb-2 text-xl font-semibold">Search</h2>
             <p className="text-gray-600">
               Find specific sections, laws, or text across the entire US Code.
             </p>
-            <span className="mt-2 inline-block text-xs text-gray-400">
-              Coming soon
-            </span>
-          </div>
+          </Link>
 
           <Link
             href="/laws"

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState, useTransition, useRef } from 'react';
+import Link from 'next/link';
+import { searchSections, searchLaws } from '@/lib/api';
+import type { SectionSearchResult, LawSearchResult } from '@/lib/types';
+
+type Tab = 'sections' | 'laws';
+
+export default function SearchPage() {
+  const [query, setQuery] = useState('');
+  const [activeTab, setActiveTab] = useState<Tab>('sections');
+  const [sectionResults, setSectionResults] = useState<SectionSearchResult[]>(
+    []
+  );
+  const [lawResults, setLawResults] = useState<LawSearchResult[]>([]);
+  const [sectionTotal, setSectionTotal] = useState(0);
+  const [lawTotal, setLawTotal] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    const q = query.trim();
+    if (q.length < 2) return;
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        const [sec, law] = await Promise.all([
+          searchSections(q, { limit: 20 }),
+          searchLaws(q, { limit: 20 }),
+        ]);
+        setSectionResults(sec.results);
+        setSectionTotal(sec.total);
+        setLawResults(law.results);
+        setLawTotal(law.total);
+      } catch {
+        setError('Search failed. Please try again.');
+      }
+    });
+  }
+
+  const hasResults = sectionResults.length > 0 || lawResults.length > 0;
+  const searched =
+    sectionTotal > 0 ||
+    lawTotal > 0 ||
+    (!isPending && query.trim().length >= 2);
+
+  return (
+    <main className="min-h-screen p-8">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-2 text-3xl font-bold">Search</h1>
+        <p className="mb-6 text-gray-600">
+          Find sections of the US Code or Public Laws by keyword.
+        </p>
+
+        <form onSubmit={handleSearch} className="mb-8 flex gap-2">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="e.g. privacy, copyright, annual report…"
+            className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            minLength={2}
+          />
+          <button
+            type="submit"
+            disabled={isPending || query.trim().length < 2}
+            className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          >
+            {isPending ? 'Searching…' : 'Search'}
+          </button>
+        </form>
+
+        {error && <p className="mb-4 text-sm text-red-600">{error}</p>}
+
+        {hasResults && (
+          <>
+            <div className="mb-4 flex gap-4 border-b border-gray-200">
+              <button
+                onClick={() => setActiveTab('sections')}
+                className={`pb-2 text-sm font-medium transition-colors ${
+                  activeTab === 'sections'
+                    ? 'border-b-2 border-blue-600 text-blue-600'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                Sections ({sectionTotal})
+              </button>
+              <button
+                onClick={() => setActiveTab('laws')}
+                className={`pb-2 text-sm font-medium transition-colors ${
+                  activeTab === 'laws'
+                    ? 'border-b-2 border-blue-600 text-blue-600'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                Laws ({lawTotal})
+              </button>
+            </div>
+
+            {activeTab === 'sections' && (
+              <SectionResults results={sectionResults} total={sectionTotal} />
+            )}
+            {activeTab === 'laws' && (
+              <LawResults results={lawResults} total={lawTotal} />
+            )}
+          </>
+        )}
+
+        {!hasResults && searched && !isPending && (
+          <p className="text-sm text-gray-500">
+            No results found for &ldquo;{query}&rdquo;.
+          </p>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function SectionResults({
+  results,
+  total,
+}: {
+  results: SectionSearchResult[];
+  total: number;
+}) {
+  return (
+    <div className="space-y-4">
+      {total > results.length && (
+        <p className="text-xs text-gray-500">
+          Showing {results.length} of {total} results
+        </p>
+      )}
+      {results.map((r) => (
+        <div
+          key={`${r.title_number}-${r.section_number}`}
+          className="rounded-lg border border-gray-200 bg-white p-4"
+        >
+          <Link
+            href={`/sections/${r.title_number}/${encodeURIComponent(r.section_number)}`}
+            className="font-medium text-blue-700 hover:underline"
+          >
+            {r.full_citation}
+          </Link>
+          <p className="mt-0.5 text-sm text-gray-700">{r.heading}</p>
+          {r.snippet && (
+            <p className="mt-1 line-clamp-3 text-xs text-gray-500">
+              {r.snippet}
+            </p>
+          )}
+          {r.is_repealed && (
+            <span className="mt-1 inline-block rounded bg-red-100 px-1.5 py-0.5 text-xs text-red-700">
+              Repealed
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function LawResults({
+  results,
+  total,
+}: {
+  results: LawSearchResult[];
+  total: number;
+}) {
+  return (
+    <div className="space-y-4">
+      {total > results.length && (
+        <p className="text-xs text-gray-500">
+          Showing {results.length} of {total} results
+        </p>
+      )}
+      {results.map((r) => (
+        <div
+          key={`${r.congress}-${r.law_number}`}
+          className="rounded-lg border border-gray-200 bg-white p-4"
+        >
+          <Link
+            href={`/laws/${r.congress}/${encodeURIComponent(r.law_number)}`}
+            className="font-medium text-blue-700 hover:underline"
+          >
+            PL {r.congress}-{r.law_number}
+          </Link>
+          {(r.short_title || r.popular_name) && (
+            <p className="mt-0.5 text-sm text-gray-700">
+              {r.short_title ?? r.popular_name}
+            </p>
+          )}
+          {r.enacted_date && (
+            <p className="mt-1 text-xs text-gray-500">
+              Enacted {r.enacted_date}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   LawDiffsResponse,
   StandaloneProvision,
   HeadRevision,
+  SectionSearchResponse,
+  LawSearchResponse,
 } from './types';
 
 const API_BASE = '/api/v1';
@@ -199,5 +201,37 @@ export async function fetchLawStandaloneProvisions(
       `Failed to fetch standalone provisions for PL ${congress}-${lawNumber}: ${res.status}`
     );
   }
+  return res.json();
+}
+
+/** Search US Code sections by heading or text content. */
+export async function searchSections(
+  q: string,
+  opts: { title?: number; limit?: number; offset?: number } = {}
+): Promise<SectionSearchResponse> {
+  const params: Record<string, string> = { q };
+  if (opts.title !== undefined) params.title = String(opts.title);
+  if (opts.limit !== undefined) params.limit = String(opts.limit);
+  if (opts.offset !== undefined) params.offset = String(opts.offset);
+  const res = await fetch(
+    `${API_BASE}/search/sections?${new URLSearchParams(params)}`
+  );
+  if (!res.ok) throw new Error(`Search sections failed: ${res.status}`);
+  return res.json();
+}
+
+/** Search public laws by name, title, or number. */
+export async function searchLaws(
+  q: string,
+  opts: { congress?: number; limit?: number; offset?: number } = {}
+): Promise<LawSearchResponse> {
+  const params: Record<string, string> = { q };
+  if (opts.congress !== undefined) params.congress = String(opts.congress);
+  if (opts.limit !== undefined) params.limit = String(opts.limit);
+  if (opts.offset !== undefined) params.offset = String(opts.offset);
+  const res = await fetch(
+    `${API_BASE}/search/laws?${new URLSearchParams(params)}`
+  );
+  if (!res.ok) throw new Error(`Search laws failed: ${res.status}`);
   return res.json();
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -405,3 +405,35 @@ export interface SectionView {
   last_revision?: HeadRevision | null;
   group_ancestors?: GroupAncestor[];
 }
+
+export interface SectionSearchResult {
+  title_number: number;
+  section_number: string;
+  heading: string;
+  full_citation: string;
+  snippet: string | null;
+  is_repealed: boolean;
+  last_modified_date: string | null;
+}
+
+export interface LawSearchResult {
+  congress: number;
+  law_number: string;
+  short_title: string | null;
+  popular_name: string | null;
+  enacted_date: string | null;
+}
+
+export interface SectionSearchResponse {
+  results: SectionSearchResult[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface LawSearchResponse {
+  results: LawSearchResult[];
+  total: number;
+  limit: number;
+  offset: number;
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/search/sections?q=...` — searches `heading` and `text_content` via ILIKE, with optional `title` filter; returns results with citation, heading, and a snippet around the match
- Add `GET /api/v1/search/laws?q=...` — searches `popular_name`, `short_title`, and `law_number` via ILIKE, with optional `congress` filter
- Register a new `search` router at `/api/v1/search`
- Add `/search` frontend page with a search bar, tabbed Sections / Laws results, and snippet display
- Enable the Search card on the homepage (was "Coming soon")

Both endpoints support `limit` (max 100) and `offset` for pagination.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)