### PR TITLE
fix: normalize leading tabs in HTM/XML law text viewer

### DIFF
--- a/frontend/src/components/law-viewer/LawTextViewer.test.ts
+++ b/frontend/src/components/law-viewer/LawTextViewer.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { stripHtml } from './LawTextViewer';
+
+describe('stripHtml', () => {
+  it('normalizes leading tabs to 4-space indentation', () => {
+    const raw = '\tSEC. 1.\n\t\t  This Act may be cited as the "Test Act".';
+    const result = stripHtml(raw);
+    expect(result).toBe(
+      '    SEC. 1.\n          This Act may be cited as the "Test Act".'
+    );
+  });
+
+  it('leaves non-leading tabs unchanged', () => {
+    const raw = 'word\tword';
+    const result = stripHtml(raw);
+    expect(result).toBe('word\tword');
+  });
+
+  it('strips HTML wrapper tags', () => {
+    const raw = '<html><body><pre>text</pre></body></html>';
+    expect(stripHtml(raw)).toBe('text');
+  });
+
+  it('removes GPO end-of-document marker', () => {
+    const raw = 'text\n<all>';
+    expect(stripHtml(raw)).toBe('text');
+  });
+
+  it('trims leading and trailing blank lines', () => {
+    const raw = '\n\ntext\n\n';
+    expect(stripHtml(raw)).toBe('text');
+  });
+});

--- a/frontend/src/components/law-viewer/LawTextViewer.tsx
+++ b/frontend/src/components/law-viewer/LawTextViewer.tsx
@@ -5,7 +5,7 @@ interface LawTextViewerProps {
 }
 
 /** Strip HTML wrapper tags and decode HTML entities to plain text. */
-function stripHtml(raw: string): string {
+export function stripHtml(raw: string): string {
   // Remove <html>, <body>, <pre> wrappers (and closing tags)
   let text = raw.replace(/<\/?(html|body|pre)[^>]*>/gi, '');
   // Decode HTML entities (&lt; &gt; &amp; &quot; &#NNN; &#xHH;)
@@ -17,6 +17,8 @@ function stripHtml(raw: string): string {
   }
   // Remove GPO end-of-document marker <all>
   text = text.replace(/<all>\s*/gi, '');
+  // Normalize leading tabs to 4 spaces so indentation matches the statute viewer
+  text = text.replace(/^(\t+)/gm, (tabs) => '    '.repeat(tabs.length));
   // Trim leading/trailing blank lines
   return text.replace(/^\n+/, '').replace(/\n+$/, '');
 }


### PR DESCRIPTION
## Problem

The HTM tab on law pages rendered raw congressional HTM with `whitespace-pre-wrap`, so literal `\t` characters expanded to browser-default tab stops (~8 spaces). This looked inconsistent compared to the statute viewer's 4-space indentation rhythm.

## Fix

Added one regex pass in `stripHtml()` that replaces each run of leading tabs with 4 spaces per tab:

```ts
text = text.replace(/^(\t+)/gm, (tabs) => '    '.repeat(tabs.length));
```

Also exported `stripHtml` as a named export so it can be unit-tested, and added 5 unit tests covering: tab normalization, non-leading tabs, HTML stripping, GPO marker removal, and blank-line trimming.

## Before / After

Before: a single `\t` indent renders as 8-character-wide browser default  
After: a single `\t` renders as exactly 4 spaces, matching the statute viewer

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)