### PR TITLE
feat: paginate laws list endpoint and add page navigation UI

### DIFF
--- a/backend/app/api/v1/laws.py
+++ b/backend/app/api/v1/laws.py
@@ -18,8 +18,8 @@ from app.models.base import get_async_session
 from app.schemas.law_history import LegislativeHistorySchema
 from app.schemas.law_viewer import (
     LawDiffsResponse,
-    LawSummarySchema,
     LawTextSchema,
+    PaginatedLawsResponse,
     ParsedAmendmentSchema,
     StandaloneProvisionSchema,
 )
@@ -32,7 +32,7 @@ async def list_laws(
     limit: int = Query(50, ge=1, le=500, description="Max results to return"),
     offset: int = Query(0, ge=0, description="Number of results to skip"),
     session: AsyncSession = Depends(get_async_session),
-) -> list[LawSummarySchema]:
+) -> PaginatedLawsResponse:
     """List public laws in the database (paginated)."""
     return await get_laws_list(session, limit=limit, offset=offset)
 

--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import Integer, cast, select
+from sqlalchemy import Integer, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -33,6 +33,7 @@ from app.schemas.law_viewer import (
     LawDiffsResponse,
     LawSummarySchema,
     LawTextSchema,
+    PaginatedLawsResponse,
     ParsedAmendmentSchema,
     PositionQualifierSchema,
     SectionDiffSchema,
@@ -47,11 +48,14 @@ async def get_laws_list(
     session: AsyncSession,
     limit: int = 50,
     offset: int = 0,
-) -> list[LawSummarySchema]:
+) -> PaginatedLawsResponse:
     """Return public laws ordered by congress desc, law_number desc.
 
-    Paginated with limit/offset to avoid transferring the entire table.
+    Paginated with limit/offset. Includes a total count for building page controls.
     """
+    count_result = await session.execute(select(func.count()).select_from(PublicLaw))
+    total = count_result.scalar_one()
+
     stmt = (
         select(PublicLaw)
         .order_by(
@@ -64,7 +68,7 @@ async def get_laws_list(
     result = await session.execute(stmt)
     laws = result.scalars().all()
 
-    return [
+    items = [
         LawSummarySchema(
             congress=law.congress,
             law_number=law.law_number,
@@ -75,6 +79,7 @@ async def get_laws_list(
         )
         for law in laws
     ]
+    return PaginatedLawsResponse(total=total, items=items, limit=limit, offset=offset)
 
 
 def _date_str(d: Any) -> str | None:

--- a/backend/app/schemas/law_viewer.py
+++ b/backend/app/schemas/law_viewer.py
@@ -20,6 +20,15 @@ class LawSummarySchema(BaseModel):
     sections_affected: int = Field(0, description="Number of USC sections affected")
 
 
+class PaginatedLawsResponse(BaseModel):
+    """Paginated response for the public laws list."""
+
+    total: int = Field(..., description="Total number of laws in the database")
+    items: list[LawSummarySchema]
+    limit: int
+    offset: int
+
+
 class LawTextSchema(BaseModel):
     """Raw text content of a Public Law (HTM and/or XML)."""
 

--- a/backend/tests/api/test_laws.py
+++ b/backend/tests/api/test_laws.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
-from app.schemas.law_viewer import LawSummarySchema
+from app.schemas.law_viewer import LawSummarySchema, PaginatedLawsResponse
 
 
 def _make_law(congress: int, law_number: str) -> LawSummarySchema:
@@ -18,16 +18,37 @@ def _make_law(congress: int, law_number: str) -> LawSummarySchema:
     )
 
 
+def _make_paginated(
+    laws: list[LawSummarySchema],
+    total: int | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> PaginatedLawsResponse:
+    return PaginatedLawsResponse(
+        total=total if total is not None else len(laws),
+        items=laws,
+        limit=limit,
+        offset=offset,
+    )
+
+
 @patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
-def test_list_laws_returns_laws(mock_list: AsyncMock, client: TestClient) -> None:
-    """Laws list endpoint returns laws from the CRUD layer."""
-    mock_list.return_value = [_make_law(113, "9"), _make_law(113, "8")]
+def test_list_laws_returns_paginated_response(
+    mock_list: AsyncMock, client: TestClient
+) -> None:
+    """Laws list endpoint returns a paginated wrapper with total and items."""
+    mock_list.return_value = _make_paginated(
+        [_make_law(113, "9"), _make_law(113, "8")], total=42
+    )
 
     response = client.get("/api/v1/laws/")
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 2
-    assert data[0]["law_number"] == "9"
+    assert data["total"] == 42
+    assert len(data["items"]) == 2
+    assert data["items"][0]["law_number"] == "9"
+    assert data["limit"] == 50
+    assert data["offset"] == 0
 
 
 @patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
@@ -35,7 +56,7 @@ def test_list_laws_passes_limit_to_crud(
     mock_list: AsyncMock, client: TestClient
 ) -> None:
     """The limit query param is forwarded to the CRUD layer."""
-    mock_list.return_value = []
+    mock_list.return_value = _make_paginated([], limit=500)
 
     client.get("/api/v1/laws/?limit=500")
     mock_list.assert_called_once()
@@ -44,11 +65,24 @@ def test_list_laws_passes_limit_to_crud(
 
 
 @patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
+def test_list_laws_passes_offset_to_crud(
+    mock_list: AsyncMock, client: TestClient
+) -> None:
+    """The offset query param is forwarded to the CRUD layer."""
+    mock_list.return_value = _make_paginated([], offset=50)
+
+    client.get("/api/v1/laws/?offset=50")
+    mock_list.assert_called_once()
+    _, kwargs = mock_list.call_args
+    assert kwargs["offset"] == 50
+
+
+@patch("app.api.v1.laws.get_laws_list", new_callable=AsyncMock)
 def test_list_laws_limit_exceeds_old_cap(
     mock_list: AsyncMock, client: TestClient
 ) -> None:
     """Limit of 500 is accepted (previously capped at 200, causing truncation)."""
-    mock_list.return_value = []
+    mock_list.return_value = _make_paginated([], limit=500)
 
     response = client.get("/api/v1/laws/?limit=500")
     assert response.status_code == 200

--- a/frontend/src/app/laws/LawsTable.tsx
+++ b/frontend/src/app/laws/LawsTable.tsx
@@ -47,11 +47,116 @@ const columns: { key: SortKey; label: string; align: string }[] = [
   { key: 'sections_affected', label: 'Sections Affected', align: 'text-right' },
 ];
 
-/** Sortable laws table. Receives initial data from the parent Server Component. */
-export default function LawsTable({ laws }: { laws: LawSummary[] }) {
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  total: number;
+  limit: number;
+}
+
+function Pagination({ page, totalPages, total, limit }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const start = (page - 1) * limit + 1;
+  const end = Math.min(page * limit, total);
+
+  // Show at most 5 page numbers centered around the current page
+  const pageNumbers: number[] = [];
+  const half = 2;
+  let lo = Math.max(1, page - half);
+  const hi = Math.min(totalPages, lo + 4);
+  lo = Math.max(1, hi - 4);
+  for (let i = lo; i <= hi; i++) pageNumbers.push(i);
+
+  return (
+    <div className="mt-4 flex items-center justify-between">
+      <p className="text-sm text-gray-500">
+        Showing {start}–{end} of {total} laws
+      </p>
+      <nav className="flex items-center gap-1" aria-label="Pagination">
+        <Link
+          href={`/laws?page=${page - 1}`}
+          aria-disabled={page === 1}
+          className={`rounded px-2 py-1 text-sm ${
+            page === 1
+              ? 'pointer-events-none text-gray-300'
+              : 'text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          ← Prev
+        </Link>
+        {lo > 1 && (
+          <>
+            <Link
+              href="/laws?page=1"
+              className="rounded px-2 py-1 text-sm text-gray-600 hover:bg-gray-100"
+            >
+              1
+            </Link>
+            {lo > 2 && <span className="px-1 text-sm text-gray-400">…</span>}
+          </>
+        )}
+        {pageNumbers.map((n) => (
+          <Link
+            key={n}
+            href={`/laws?page=${n}`}
+            className={`rounded px-2 py-1 text-sm ${
+              n === page
+                ? 'bg-primary-600 font-medium text-white'
+                : 'text-gray-600 hover:bg-gray-100'
+            }`}
+          >
+            {n}
+          </Link>
+        ))}
+        {hi < totalPages && (
+          <>
+            {hi < totalPages - 1 && (
+              <span className="px-1 text-sm text-gray-400">…</span>
+            )}
+            <Link
+              href={`/laws?page=${totalPages}`}
+              className="rounded px-2 py-1 text-sm text-gray-600 hover:bg-gray-100"
+            >
+              {totalPages}
+            </Link>
+          </>
+        )}
+        <Link
+          href={`/laws?page=${page + 1}`}
+          aria-disabled={page === totalPages}
+          className={`rounded px-2 py-1 text-sm ${
+            page === totalPages
+              ? 'pointer-events-none text-gray-300'
+              : 'text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          Next →
+        </Link>
+      </nav>
+    </div>
+  );
+}
+
+interface LawsTableProps {
+  laws: LawSummary[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+/** Sortable laws table. Receives a single page of data from the parent Server Component. */
+export default function LawsTable({
+  laws,
+  total,
+  page,
+  limit,
+}: LawsTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>('enacted_date');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const queryClient = useQueryClient();
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
 
   const sorted = useMemo(() => {
     const copy = [...laws];
@@ -143,6 +248,13 @@ export default function LawsTable({ laws }: { laws: LawSummary[] }) {
           </p>
         )}
       </div>
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        limit={limit}
+      />
     </div>
   );
 }

--- a/frontend/src/app/laws/page.tsx
+++ b/frontend/src/app/laws/page.tsx
@@ -5,8 +5,24 @@ import LawsTable from './LawsTable';
 // Data is still fetched server-side on every request (no client waterfall).
 export const dynamic = 'force-dynamic';
 
-/** Public laws list page (SSR). Sorting stays client-side in LawsTable. */
-export default async function LawsPage() {
-  const laws = await fetchLawsServer();
-  return <LawsTable laws={laws} />;
+const PAGE_SIZE = 50;
+
+/** Public laws list page (SSR). Sorting stays client-side per page in LawsTable. */
+export default async function LawsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const params = await searchParams;
+  const page = Math.max(1, Number(params.page ?? 1));
+  const offset = (page - 1) * PAGE_SIZE;
+  const data = await fetchLawsServer(PAGE_SIZE, offset);
+  return (
+    <LawsTable
+      laws={data.items}
+      total={data.total}
+      page={page}
+      limit={PAGE_SIZE}
+    />
+  );
 }

--- a/frontend/src/lib/api.server.ts
+++ b/frontend/src/lib/api.server.ts
@@ -5,7 +5,7 @@
  * to client-originated requests). Never import this file in client components.
  */
 
-import type { TitleSummary, LawSummary } from './types';
+import type { TitleSummary, PaginatedLaws } from './types';
 
 function serverApiBase(): string {
   return `${process.env.BACKEND_URL ?? 'http://localhost:8000'}/api/v1`;
@@ -17,8 +17,13 @@ export async function fetchTitlesServer(): Promise<TitleSummary[]> {
   return res.json() as Promise<TitleSummary[]>;
 }
 
-export async function fetchLawsServer(): Promise<LawSummary[]> {
-  const res = await fetch(`${serverApiBase()}/laws/?limit=500`);
+export async function fetchLawsServer(
+  limit = 50,
+  offset = 0
+): Promise<PaginatedLaws> {
+  const res = await fetch(
+    `${serverApiBase()}/laws/?limit=${limit}&offset=${offset}`
+  );
   if (!res.ok) throw new Error(`Failed to fetch laws: ${res.status}`);
-  return res.json() as Promise<LawSummary[]>;
+  return res.json() as Promise<PaginatedLaws>;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   LegislativeHistory,
   ParsedAmendment,
   LawDiffsResponse,
+  PaginatedLaws,
   StandaloneProvision,
   HeadRevision,
 } from './types';
@@ -65,9 +66,12 @@ export async function fetchSection(
   return res.json();
 }
 
-/** Fetch all public law summaries. */
-export async function fetchLaws(): Promise<LawSummary[]> {
-  const res = await fetch(`${API_BASE}/laws/?limit=500`);
+/** Fetch a page of public law summaries. */
+export async function fetchLaws(
+  limit = 50,
+  offset = 0
+): Promise<PaginatedLaws> {
+  const res = await fetch(`${API_BASE}/laws/?limit=${limit}&offset=${offset}`);
   if (!res.ok) {
     throw new Error(`Failed to fetch laws: ${res.status}`);
   }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -194,6 +194,14 @@ export interface LawSummary {
   sections_affected: number;
 }
 
+/** Paginated response from GET /api/v1/laws. */
+export interface PaginatedLaws {
+  total: number;
+  items: LawSummary[];
+  limit: number;
+  offset: number;
+}
+
 /** Raw text content of a Public Law. */
 export interface LawText {
   congress: number;


### PR DESCRIPTION
## Summary

- **Backend**: Wraps `GET /api/v1/laws` response in `PaginatedLawsResponse { total, items, limit, offset }` so the frontend knows the full count without a separate query. Adds a `SELECT COUNT(*)` alongside the paginated fetch.
- **Frontend**: `LawsPage` reads `?page` from `searchParams`, fetches only the current 50-law page via SSR. `LawsTable` renders `Showing X–Y of Z laws` and prev/next + numbered page controls.
- **Types**: New `PaginatedLaws` interface mirrors the backend schema.

Sorting remains client-side within each page (per the issue's stated trade-off).

## Test plan

- [ ] `uv run pytest tests/api/test_laws.py` — 4 tests, all pass
- [ ] `npm run type-check` — no errors
- [ ] Full backend suite: 776 tests pass
- [ ] Full frontend suite: 181 tests pass
- [ ] Visit `/laws` — shows first 50 laws with pagination controls (hidden when ≤ 50 total)
- [ ] Navigate to `/laws?page=2` — second page loads correctly
- [ ] Column sort headers still sort within the current page

Closes #273

🤖 Generated with [Claude Code](https://claude.ai/claude-code)