### PR TITLE
feat: sticky section headers while scrolling diffs

### DIFF
--- a/frontend/src/components/law-viewer/LawDiffViewer.tsx
+++ b/frontend/src/components/law-viewer/LawDiffViewer.tsx
@@ -273,7 +273,7 @@ export default function LawDiffViewer({
                 if (el) sectionRefs.current.set(diff.section_key, el);
               }}
             >
-              <h3 className="mb-3">
+              <h3 className="sticky top-0 z-10 -mx-2 mb-3 bg-white px-2 pb-2 pt-1 shadow-sm">
                 <SectionBreadcrumb
                   titleNumber={diff.title_number}
                   sectionNumber={diff.section_number}


### PR DESCRIPTION
## Summary

Adds `sticky top-0` to each section breadcrumb header in the law diff viewer so the header (e.g. `16 U.S.C. § 797`) stays pinned at the top of the scrolling panel while the user reads through long diff hunks. When the next section begins, its header naturally pushes the previous one away.

## Implementation

One-line CSS change in `LawDiffViewer.tsx`: the `<h3>` wrapping each `SectionBreadcrumb` gains `sticky top-0 z-10 -mx-2 bg-white px-2 pb-2 pt-1 shadow-sm`.

- `sticky top-0` — pins to top of the `overflow-y-auto` scroll container (the parent div), not the viewport, so the site navbar height is irrelevant
- `bg-white` + `shadow-sm` — prevents diff content from bleeding through the header
- `-mx-2 px-2` — extends the white background full-width to match the card border

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)