### PR TITLE
fix: amendments tab always showing 'no text' due to get_law_text(include_htm=False, include_xml=False)

### DIFF
--- a/backend/app/crud/public_law.py
+++ b/backend/app/crud/public_law.py
@@ -959,12 +959,10 @@ async def compute_law_diffs(
     """
     from pipeline.olrc.snapshot_service import SnapshotService
 
-    # Check law text existence first so we can distinguish "no text" from
-    # "text present but no codified amendments found".
-    law_text = await get_law_text(
-        session, congress, law_number, include_htm=False, include_xml=False
-    )
-    if not law_text:
+    # Check law existence first so we can distinguish "not ingested" from
+    # "ingested but no codified amendments found".
+    law_meta = await get_law_metadata(session, congress, law_number)
+    if not law_meta:
         return LawDiffsResponse(parse_status="no_text", diffs=[])
 
     # Parse amendments (reuses existing logic)


### PR DESCRIPTION
## Context

Every law's Amendments tab was showing "Law text not yet available" — including laws that are fully ingested (e.g. `/laws/113/39?tab=diff`).

## Root Cause

`compute_law_diffs` used `get_law_text(include_htm=False, include_xml=False)` as a cheap existence check. But `get_law_text` returns `None` when both `htm_content` and `xml_content` are `None`, which is **always** the case when both flags are `False` (nothing is fetched). The function then short-circuited with `parse_status="no_text"` for every law, never reaching the amendment parser.

## Fix

Replace the broken call with `get_law_metadata`, which does a direct DB query to check whether the law row exists — the right tool for a pure existence check.

**Before/after diff** (`backend/app/crud/public_law.py`):
```python
# Before (always returns no_text)
law_text = await get_law_text(
    session, congress, law_number, include_htm=False, include_xml=False
)
if not law_text:
    return LawDiffsResponse(parse_status="no_text", diffs=[])

# After (correct DB-only existence check)
law_meta = await get_law_metadata(session, congress, law_number)
if not law_meta:
    return LawDiffsResponse(parse_status="no_text", diffs=[])
```

Closes #433