### PR TITLE
test: add regression test for 33 USC §2215 flat notes (Closes #222)

### DIFF
--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1957,6 +1957,59 @@ class TestNoteTopicAmendmentParsing:
         assert len(amendment_notes) == 1
         assert len(notes.amendments) >= 1
 
+    def test_multiple_flat_notes_mixed_categories_issue_222(self) -> None:
+        """33 USC §2215 pattern: multiple flat <note topic="..."><heading>...</heading> elements.
+
+        The section has 4 flat notes with no 'Editorial Notes'/'Statutory Notes' wrapper.
+        All notes must be parsed with correct categories. Closes #222.
+        """
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<note topic="referencesInText">'
+            "<heading>References in Text</heading>"
+            "<p>The Water Resources Development Act of 2000, referred to in subsec. (d)(2),"
+            " is Pub. L. 106–541, Dec. 11, 2000, 114 Stat. 2572."
+            " Title VI of the Act is not classified to the Code.</p>"
+            "</note>"
+            '<note topic="amendments">'
+            "<heading>Amendments</heading>"
+            "<p>2007—Subsec. (a)(3). Pub. L. 110–114, added par. (3).</p>"
+            "<p>1990—Subsec. (b). Pub. L. 101–640 inserted text at end.</p>"
+            "</note>"
+            '<note topic="effectiveDateOfAmendment">'
+            "<heading>Effective Date of 1996 Amendment</heading>"
+            "<p>Pub. L. 104–303, title II, § 203(b), Oct. 12, 1996,"
+            " 110 Stat. 3678, provided that the amendments shall apply"
+            " notwithstanding any prior feasibility cost-sharing agreement.</p>"
+            "</note>"
+            '<note topic="miscellaneous">'
+            "<heading>No Requirement of Reimbursement</heading>"
+            "<p>Pub. L. 104–303, title II, § 203(c), Oct. 12, 1996,"
+            " 110 Stat. 3678, provided that nothing in this section requires"
+            " reimbursement for funds previously contributed for a study.</p>"
+            "</note>"
+            "</notes>"
+        )
+        notes = self._parse_xml_notes(xml)
+
+        assert len(notes.notes) == 4
+
+        headers = [n.header for n in notes.notes]
+        assert "References In Text" in headers
+        assert "Amendments" in headers
+        assert "Effective Date Of 1996 Amendment" in headers
+        assert "No Requirement Of Reimbursement" in headers
+
+        editorial = [n for n in notes.notes if n.category.value == "editorial"]
+        statutory = [n for n in notes.notes if n.category.value == "statutory"]
+        assert len(editorial) == 2  # References in Text + Amendments
+        assert len(statutory) == 2  # Effective Date + No Requirement
+
+        assert len(notes.amendments) >= 2
+        years = [a.year for a in notes.amendments]
+        assert 1990 in years
+        assert 2007 in years
+
 
 class TestCleanHeading:
     """Tests for _clean_heading function."""


### PR DESCRIPTION
## Context

33 USC §2215 has `has_notes: true` but `notes.notes: []` in the API response. The root cause is a data-ingestion gap: the section's `raw_notes` was stored before the parser learned to emit `[NH]` markers for `<note topic="..."><heading>...</heading>` elements, so `_parse_notes_structure` finds nothing to structure.

The current parser already handles this correctly — fresh ingestion of title 33 release point 113-21 with `--force-parse` will fix the live data. See the re-ingestion note below.

## Changes

- **test**: `TestNoteTopicAmendmentParsing.test_multiple_flat_notes_mixed_categories_issue_222` — exercises the exact 33 USC §2215 XML structure (4 flat `<note topic="..."><heading>...</heading>` elements with no Editorial/Statutory category wrappers) through the full parse → normalize pipeline. Asserts all 4 notes are produced with correct categories (References in Text + Amendments → editorial; Effective Date + No Requirement of Reimbursement → statutory) and `notes.amendments` is populated.

## Before / After (parser output for 33 USC §2215)

**Before** (stale ingestion — raw_notes stored without `[NH]` markers):
```
notes.notes = []   (empty — no [NH] markers for _parse_flat_notes to find)
has_notes = true   (raw_notes non-empty, so flag is set)
```

**After** (fresh ingestion with current parser):
```
notes.notes = [
  { header: "References In Text",            category: "editorial"  },
  { header: "Amendments",                    category: "editorial"  },
  { header: "Effective Date Of 1996 Amendment", category: "statutory" },
  { header: "No Requirement Of Reimbursement",  category: "statutory" },
]
```

## Re-ingestion required

To fix the live database, run once after this PR merges:

```bash
cd backend
uv run python -m pipeline.cli ingest_title 33 --release-point 113-21 --force-parse
```

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)