### PR TITLE
research: congressional committee jurisdiction mapping for CODEOWNERS metaphor

### DIFF
--- a/backend/alembic/versions/19521111cd88_add_codeowners_tables.py
+++ b/backend/alembic/versions/19521111cd88_add_codeowners_tables.py
@@ -1,0 +1,131 @@
+"""add_codeowners_tables
+
+Revision ID: 19521111cd88
+Revises: ce275a30c5ec
+Create Date: 2026-05-19 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "19521111cd88"
+down_revision: str | None = "ce275a30c5ec"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add CODEOWNERS tables and widen committee_code to support readable slugs."""
+    # Widen committee.committee_code from VARCHAR(20) to VARCHAR(100).
+    # The Committee table is currently empty (no pipeline populates it yet),
+    # so this is safe. Required for slugs like "house-education-and-workforce".
+    op.alter_column(
+        "committee",
+        "committee_code",
+        type_=sa.String(length=100),
+        existing_nullable=False,
+    )
+
+    op.create_table(
+        "committee_congress_instance",
+        sa.Column("instance_id", sa.Integer(), nullable=False),
+        sa.Column("committee_id", sa.Integer(), nullable=False),
+        sa.Column("congress", sa.Integer(), nullable=False),
+        sa.Column("official_name", sa.String(length=300), nullable=False),
+        sa.Column("rule_citation", sa.String(length=100), nullable=True),
+        sa.Column("jurisdiction_text", sa.Text(), nullable=True),
+        sa.Column("source_url", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["committee_id"],
+            ["committee.committee_id"],
+            name=op.f("fk_committee_congress_instance_committee_id_committee"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "instance_id", name=op.f("pk_committee_congress_instance")
+        ),
+        sa.UniqueConstraint(
+            "committee_id",
+            "congress",
+            name="uq_cci_committee_congress",
+        ),
+    )
+    op.create_index("idx_cci_congress", "committee_congress_instance", ["congress"])
+    op.create_index(
+        "idx_cci_committee_id", "committee_congress_instance", ["committee_id"]
+    )
+
+    op.create_table(
+        "committee_usc_mapping",
+        sa.Column("mapping_id", sa.Integer(), nullable=False),
+        sa.Column("committee_id", sa.Integer(), nullable=False),
+        sa.Column("congress_start", sa.Integer(), nullable=False),
+        sa.Column("congress_end", sa.Integer(), nullable=True),
+        sa.Column("title_number", sa.Integer(), nullable=False),
+        sa.Column("chapter_number", sa.String(length=20), nullable=True),
+        sa.Column("jurisdiction_type", sa.String(length=20), nullable=False),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint(
+            "jurisdiction_type IN ('primary', 'secondary', 'oversight')",
+            name=op.f("ck_committee_usc_mapping_cum_jurisdiction_type"),
+        ),
+        sa.CheckConstraint(
+            "congress_end IS NULL OR congress_end >= congress_start",
+            name=op.f("ck_committee_usc_mapping_cum_congress_range"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["committee_id"],
+            ["committee.committee_id"],
+            name=op.f("fk_committee_usc_mapping_committee_id_committee"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("mapping_id", name=op.f("pk_committee_usc_mapping")),
+        sa.UniqueConstraint(
+            "committee_id",
+            "congress_start",
+            "title_number",
+            "chapter_number",
+            "jurisdiction_type",
+            name="uq_cum_committee_congress_path_type",
+        ),
+    )
+    op.create_index("idx_cum_title", "committee_usc_mapping", ["title_number"])
+    op.create_index(
+        "idx_cum_title_chapter",
+        "committee_usc_mapping",
+        ["title_number", "chapter_number"],
+    )
+    op.create_index("idx_cum_committee_id", "committee_usc_mapping", ["committee_id"])
+    op.create_index(
+        "idx_cum_congress_range",
+        "committee_usc_mapping",
+        ["congress_start", "congress_end"],
+    )
+
+
+def downgrade() -> None:
+    """Remove CODEOWNERS tables and restore committee_code width."""
+    op.drop_index("idx_cum_congress_range", table_name="committee_usc_mapping")
+    op.drop_index("idx_cum_committee_id", table_name="committee_usc_mapping")
+    op.drop_index("idx_cum_title_chapter", table_name="committee_usc_mapping")
+    op.drop_index("idx_cum_title", table_name="committee_usc_mapping")
+    op.drop_table("committee_usc_mapping")
+
+    op.drop_index("idx_cci_committee_id", table_name="committee_congress_instance")
+    op.drop_index("idx_cci_congress", table_name="committee_congress_instance")
+    op.drop_table("committee_congress_instance")
+
+    op.alter_column(
+        "committee",
+        "committee_code",
+        type_=sa.String(length=20),
+        existing_nullable=False,
+    )

--- a/backend/app/api/v1/committees.py
+++ b/backend/app/api/v1/committees.py
@@ -1,0 +1,76 @@
+"""CODEOWNERS API: committee jurisdiction for US Code titles and chapters."""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.committees import (
+    CURRENT_CONGRESS,
+    get_all_mappings,
+    get_congress_instances,
+    get_owners_for_chapter,
+    get_owners_for_title,
+)
+from app.models.base import get_async_session
+from app.schemas.committees import (
+    CodeOwnersForPathSchema,
+    CommitteeCongressInstanceSchema,
+    CommitteeOwnershipSchema,
+)
+
+router = APIRouter()
+
+
+@router.get("/owners/title/{title_number}")
+async def owners_for_title(
+    title_number: int,
+    congress: int = Query(CURRENT_CONGRESS, description="Congress number"),
+    session: AsyncSession = Depends(get_async_session),
+) -> CodeOwnersForPathSchema:
+    """Return committees that own the given US Code title."""
+    owners = await get_owners_for_title(session, title_number, congress)
+    return CodeOwnersForPathSchema(
+        title_number=title_number,
+        chapter_number=None,
+        congress=congress,
+        owners=owners,
+    )
+
+
+@router.get("/owners/title/{title_number}/chapter/{chapter_number}")
+async def owners_for_chapter(
+    title_number: int,
+    chapter_number: str,
+    congress: int = Query(CURRENT_CONGRESS, description="Congress number"),
+    session: AsyncSession = Depends(get_async_session),
+) -> CodeOwnersForPathSchema:
+    """Return committees that own the given chapter, with title-level fallback."""
+    owners = await get_owners_for_chapter(
+        session, title_number, chapter_number, congress
+    )
+    return CodeOwnersForPathSchema(
+        title_number=title_number,
+        chapter_number=chapter_number,
+        congress=congress,
+        owners=owners,
+    )
+
+
+@router.get("/congress/{congress}/owners")
+async def all_owners_for_congress(
+    congress: int,
+    session: AsyncSession = Depends(get_async_session),
+) -> list[CommitteeOwnershipSchema]:
+    """Return all CODEOWNERS mappings valid for the given Congress."""
+    return await get_all_mappings(session, congress)
+
+
+@router.get("/congress/{congress}/instances")
+async def committee_instances(
+    congress: int,
+    chamber: str | None = Query(
+        None, description="Filter by chamber: 'House' or 'Senate'"
+    ),
+    session: AsyncSession = Depends(get_async_session),
+) -> list[CommitteeCongressInstanceSchema]:
+    """Return committee congress instances (Rule X data) for the given Congress."""
+    return await get_congress_instances(session, congress, chamber)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from app.api.v1 import laws, revisions, search, sections, titles
+from app.api.v1 import committees, laws, revisions, search, sections, titles
 
 api_router = APIRouter()
 
@@ -11,3 +11,4 @@ api_router.include_router(sections.router, prefix="/sections", tags=["sections"]
 api_router.include_router(laws.router, prefix="/laws", tags=["laws"])
 api_router.include_router(revisions.router, prefix="/revisions", tags=["revisions"])
 api_router.include_router(search.router, prefix="/search", tags=["search"])
+api_router.include_router(committees.router, prefix="/committees", tags=["committees"])

--- a/backend/app/crud/committees.py
+++ b/backend/app/crud/committees.py
@@ -1,0 +1,157 @@
+"""CRUD operations for CODEOWNERS committee queries."""
+
+from __future__ import annotations
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.codeowners import CommitteeUSCodeMapping
+from app.models.supporting import Committee
+from app.schemas.committees import (
+    CommitteeBaseSchema,
+    CommitteeCongressInstanceSchema,
+    CommitteeOwnershipSchema,
+)
+
+# Update this constant at the start of each new Congress.
+CURRENT_CONGRESS = 119
+
+
+def _congress_filter(congress: int):  # type: ignore[return]
+    """SQLAlchemy WHERE clause for mappings valid at the given Congress."""
+    return and_(
+        CommitteeUSCodeMapping.congress_start <= congress,
+        or_(
+            CommitteeUSCodeMapping.congress_end.is_(None),
+            CommitteeUSCodeMapping.congress_end >= congress,
+        ),
+    )
+
+
+def _build_ownership(
+    mapping: CommitteeUSCodeMapping,
+    committee: Committee,
+) -> CommitteeOwnershipSchema:
+    return CommitteeOwnershipSchema(
+        committee=CommitteeBaseSchema(
+            committee_code=committee.committee_code,
+            chamber=committee.chamber.value,
+            name=committee.name,
+            url=committee.url,
+        ),
+        jurisdiction_type=mapping.jurisdiction_type,
+        display_order=mapping.display_order,
+        title_number=mapping.title_number,
+        chapter_number=mapping.chapter_number,
+        notes=mapping.notes,
+        congress_start=mapping.congress_start,
+        congress_end=mapping.congress_end,
+    )
+
+
+async def get_owners_for_title(
+    session: AsyncSession,
+    title_number: int,
+    congress: int = CURRENT_CONGRESS,
+) -> list[CommitteeOwnershipSchema]:
+    """Return committees that own the given US Code title (title-level only).
+
+    Returns only title-level mappings (chapter_number IS NULL), ordered by display_order.
+    """
+    result = await session.execute(
+        select(CommitteeUSCodeMapping, Committee)
+        .join(Committee, CommitteeUSCodeMapping.committee_id == Committee.committee_id)
+        .where(
+            CommitteeUSCodeMapping.title_number == title_number,
+            CommitteeUSCodeMapping.chapter_number.is_(None),
+            _congress_filter(congress),
+        )
+        .order_by(CommitteeUSCodeMapping.display_order)
+    )
+    return [_build_ownership(m, c) for m, c in result]
+
+
+async def get_owners_for_chapter(
+    session: AsyncSession,
+    title_number: int,
+    chapter_number: str,
+    congress: int = CURRENT_CONGRESS,
+) -> list[CommitteeOwnershipSchema]:
+    """Return committees that own the given chapter, falling back to title-level.
+
+    Implements the CODEOWNERS specificity rule: chapter-level overrides take
+    precedence; if none exist, title-level mappings are returned instead.
+    """
+    chapter_result = await session.execute(
+        select(CommitteeUSCodeMapping, Committee)
+        .join(Committee, CommitteeUSCodeMapping.committee_id == Committee.committee_id)
+        .where(
+            CommitteeUSCodeMapping.title_number == title_number,
+            CommitteeUSCodeMapping.chapter_number == chapter_number,
+            _congress_filter(congress),
+        )
+        .order_by(CommitteeUSCodeMapping.display_order)
+    )
+    rows = chapter_result.all()
+    if rows:
+        return [_build_ownership(m, c) for m, c in rows]
+
+    # Fall back to title-level
+    return await get_owners_for_title(session, title_number, congress)
+
+
+async def get_all_mappings(
+    session: AsyncSession,
+    congress: int = CURRENT_CONGRESS,
+) -> list[CommitteeOwnershipSchema]:
+    """Return all committee→code mappings valid for the given Congress."""
+    result = await session.execute(
+        select(CommitteeUSCodeMapping, Committee)
+        .join(Committee, CommitteeUSCodeMapping.committee_id == Committee.committee_id)
+        .where(_congress_filter(congress))
+        .order_by(
+            CommitteeUSCodeMapping.title_number,
+            CommitteeUSCodeMapping.chapter_number.nulls_first(),
+            CommitteeUSCodeMapping.display_order,
+        )
+    )
+    return [_build_ownership(m, c) for m, c in result]
+
+
+async def get_congress_instances(
+    session: AsyncSession,
+    congress: int,
+    chamber: str | None = None,
+) -> list[CommitteeCongressInstanceSchema]:
+    """Return CommitteeCongressInstance records for the given Congress.
+
+    Args:
+        session: Async DB session.
+        congress: Congress number.
+        chamber: Optional "House" or "Senate" filter.
+    """
+    from app.models.codeowners import CommitteeCongressInstance
+
+    stmt = (
+        select(CommitteeCongressInstance, Committee)
+        .join(
+            Committee,
+            CommitteeCongressInstance.committee_id == Committee.committee_id,
+        )
+        .where(CommitteeCongressInstance.congress == congress)
+        .order_by(Committee.chamber, Committee.name)
+    )
+    if chamber is not None:
+        stmt = stmt.where(Committee.chamber == chamber)
+
+    result = await session.execute(stmt)
+    return [
+        CommitteeCongressInstanceSchema(
+            committee_code=committee.committee_code,
+            chamber=committee.chamber.value,
+            official_name=instance.official_name,
+            congress=instance.congress,
+            rule_citation=instance.rule_citation,
+        )
+        for instance, committee in result
+    ]

--- a/backend/app/crud/committees.py
+++ b/backend/app/crud/committees.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import ColumnElement, and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.codeowners import CommitteeUSCodeMapping
@@ -17,7 +17,7 @@ from app.schemas.committees import (
 CURRENT_CONGRESS = 119
 
 
-def _congress_filter(congress: int):  # type: ignore[return]
+def _congress_filter(congress: int) -> ColumnElement[bool]:
     """SQLAlchemy WHERE clause for mappings valid at the given Congress."""
     return and_(
         CommitteeUSCodeMapping.congress_start <= congress,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 """SQLAlchemy models for The Code We Live By."""
 
 from app.models.base import Base, TimestampMixin, async_session_maker, get_async_session
+from app.models.codeowners import CommitteeCongressInstance, CommitteeUSCodeMapping
 from app.models.enums import (
     AmendmentReviewStatus,
     BillStatus,
@@ -110,6 +111,9 @@ __all__ = [
     "SectionSnapshot",
     "RevisionType",
     "RevisionStatus",
+    # CODEOWNERS
+    "CommitteeCongressInstance",
+    "CommitteeUSCodeMapping",
     # Supporting
     "SectionReference",
     "Committee",

--- a/backend/app/models/codeowners.py
+++ b/backend/app/models/codeowners.py
@@ -1,0 +1,110 @@
+"""CODEOWNERS models: CommitteeCongressInstance, CommitteeUSCodeMapping."""
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.supporting import Committee
+
+
+class CommitteeCongressInstance(Base, TimestampMixin):
+    """Per-Congress metadata for a committee, including raw Rule X jurisdiction text.
+
+    Keyed to (committee_id, congress) so that committee renames and restructuring
+    across Congresses are captured without modifying the stable Committee record.
+    """
+
+    __tablename__ = "committee_congress_instance"
+
+    instance_id: Mapped[int] = mapped_column(primary_key=True)
+    committee_id: Mapped[int] = mapped_column(
+        ForeignKey("committee.committee_id", ondelete="CASCADE"), nullable=False
+    )
+    congress: Mapped[int] = mapped_column(Integer, nullable=False)
+    official_name: Mapped[str] = mapped_column(String(300), nullable=False)
+    rule_citation: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    jurisdiction_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    committee: Mapped["Committee"] = relationship()
+
+    __table_args__ = (
+        UniqueConstraint("committee_id", "congress", name="uq_cci_committee_congress"),
+        Index("idx_cci_congress", "congress"),
+        Index("idx_cci_committee_id", "committee_id"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<CommitteeCongressInstance({self.committee_id}, congress={self.congress})>"
+
+
+class CommitteeUSCodeMapping(Base, TimestampMixin):
+    """Human-curated mapping from a committee to a US Code title/chapter path.
+
+    This is the authoritative CODEOWNERS layer — it bridges the prose jurisdiction
+    language in Rule X (which never references the US Code directly) to actual
+    US Code title/chapter paths. Maintained as a YAML fixture and loaded via CLI.
+
+    congress_start/congress_end define the range of Congresses this mapping applies to.
+    congress_end = NULL means the mapping is still current.
+    chapter_number = NULL means the mapping applies at the Title level.
+    """
+
+    __tablename__ = "committee_usc_mapping"
+
+    mapping_id: Mapped[int] = mapped_column(primary_key=True)
+    committee_id: Mapped[int] = mapped_column(
+        ForeignKey("committee.committee_id", ondelete="CASCADE"), nullable=False
+    )
+    congress_start: Mapped[int] = mapped_column(Integer, nullable=False)
+    congress_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    title_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    chapter_number: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    jurisdiction_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    display_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    committee: Mapped["Committee"] = relationship()
+
+    __table_args__ = (
+        UniqueConstraint(
+            "committee_id",
+            "congress_start",
+            "title_number",
+            "chapter_number",
+            "jurisdiction_type",
+            name="uq_cum_committee_congress_path_type",
+        ),
+        CheckConstraint(
+            "jurisdiction_type IN ('primary', 'secondary', 'oversight')",
+            name="cum_jurisdiction_type",
+        ),
+        CheckConstraint(
+            "congress_end IS NULL OR congress_end >= congress_start",
+            name="cum_congress_range",
+        ),
+        Index("idx_cum_title", "title_number"),
+        Index("idx_cum_title_chapter", "title_number", "chapter_number"),
+        Index("idx_cum_committee_id", "committee_id"),
+        Index("idx_cum_congress_range", "congress_start", "congress_end"),
+    )
+
+    def __repr__(self) -> str:
+        path = (
+            f"title {self.title_number}"
+            if self.chapter_number is None
+            else f"title {self.title_number} ch. {self.chapter_number}"
+        )
+        return f"<CommitteeUSCodeMapping({self.committee_id} → {path}, {self.jurisdiction_type})>"

--- a/backend/app/schemas/committees.py
+++ b/backend/app/schemas/committees.py
@@ -1,0 +1,38 @@
+"""Pydantic schemas for CODEOWNERS committee endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class CommitteeBaseSchema(BaseModel):
+    committee_code: str
+    chamber: str
+    name: str
+    url: str | None
+
+
+class CommitteeOwnershipSchema(BaseModel):
+    committee: CommitteeBaseSchema
+    jurisdiction_type: str
+    display_order: int
+    title_number: int
+    chapter_number: str | None
+    notes: str | None
+    congress_start: int
+    congress_end: int | None
+
+
+class CodeOwnersForPathSchema(BaseModel):
+    title_number: int
+    chapter_number: str | None
+    congress: int
+    owners: list[CommitteeOwnershipSchema]
+
+
+class CommitteeCongressInstanceSchema(BaseModel):
+    committee_code: str
+    chamber: str
+    official_name: str
+    congress: int
+    rule_citation: str | None

--- a/backend/pipeline/cli.py
+++ b/backend/pipeline/cli.py
@@ -2775,6 +2775,81 @@ Examples:
         help="Delete existing rows and re-fetch from Congress.gov",
     )
 
+    # seed-committees command
+    seed_committees_parser = subparsers.add_parser(
+        "seed-committees",
+        help="Upsert Committee rows from committee_seed.yaml",
+    )
+    seed_committees_parser.add_argument(
+        "--yaml",
+        type=Path,
+        default=None,
+        help="Path to committee YAML fixture (default: bundled committee_seed.yaml)",
+    )
+    seed_committees_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Update existing rows even if unchanged",
+    )
+
+    # seed-codeowners command
+    seed_codeowners_parser = subparsers.add_parser(
+        "seed-codeowners",
+        help="Upsert CommitteeUSCodeMapping rows from committee_usc_mappings.yaml",
+    )
+    seed_codeowners_parser.add_argument(
+        "--yaml",
+        type=Path,
+        default=None,
+        help="Path to mapping YAML fixture (default: bundled committee_usc_mappings.yaml)",
+    )
+    seed_codeowners_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Update existing rows even if unchanged",
+    )
+
+    # house-rules-ingest command
+    house_rules_ingest_parser = subparsers.add_parser(
+        "house-rules-ingest",
+        help="Fetch House Rule X from GovInfo HMAN and store CommitteeCongressInstance rows",
+    )
+    house_rules_ingest_parser.add_argument(
+        "congress",
+        type=int,
+        help="Congress number to ingest (e.g. 119)",
+    )
+    house_rules_ingest_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Re-fetch even if cached",
+    )
+
+    # house-rules-ingest-range command
+    house_rules_ingest_range_parser = subparsers.add_parser(
+        "house-rules-ingest-range",
+        help="Ingest House Rule X for a range of Congresses (useful for backfilling 106–119)",
+    )
+    house_rules_ingest_range_parser.add_argument(
+        "start",
+        type=int,
+        help="First Congress number (inclusive)",
+    )
+    house_rules_ingest_range_parser.add_argument(
+        "end",
+        type=int,
+        help="Last Congress number (inclusive)",
+    )
+    house_rules_ingest_range_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Re-fetch even if cached",
+    )
+
     args = parser.parse_args()
 
     # Initialize shared pipeline cache (local-only unless GCS_CACHE_BUCKET is set)
@@ -3176,6 +3251,39 @@ Examples:
         return asyncio.run(
             seed_congress_law_history_command(
                 congress=args.congress,
+                force=args.force,
+            )
+        )
+
+    elif args.command == "seed-committees":
+        return asyncio.run(
+            seed_committees_command(
+                yaml_path=args.yaml,
+                force=args.force,
+            )
+        )
+
+    elif args.command == "seed-codeowners":
+        return asyncio.run(
+            seed_codeowners_command(
+                yaml_path=args.yaml,
+                force=args.force,
+            )
+        )
+
+    elif args.command == "house-rules-ingest":
+        return asyncio.run(
+            house_rules_ingest_command(
+                congress=args.congress,
+                force=args.force,
+            )
+        )
+
+    elif args.command == "house-rules-ingest-range":
+        return asyncio.run(
+            house_rules_ingest_range_command(
+                start=args.start,
+                end=args.end,
                 force=args.force,
             )
         )
@@ -3965,6 +4073,157 @@ def _print_checkpoint_result(checkpoint) -> None:  # type: ignore[type-arg]
             )
         if len(checkpoint.mismatches) > 30:
             print(f"      ... and {len(checkpoint.mismatches) - 30} more")
+
+
+async def seed_committees_command(
+    yaml_path: Path | None = None,
+    force: bool = False,
+) -> int:
+    """Upsert Committee rows from the YAML fixture.
+
+    Args:
+        yaml_path: Path to YAML fixture; defaults to bundled committee_seed.yaml.
+        force: If True, update existing rows even if unchanged.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    from pathlib import Path as _Path
+
+    from app.models.base import async_session_maker
+    from pipeline.house_rules.seed import (
+        _DEFAULT_COMMITTEE_YAML,
+        seed_committees,
+    )
+
+    resolved = yaml_path if yaml_path is not None else _DEFAULT_COMMITTEE_YAML
+    logger.info("Seeding committees from %s", resolved)
+
+    try:
+        async with async_session_maker() as session:
+            count = await seed_committees(
+                session, yaml_path=_Path(resolved), force=force
+            )
+        print(f"Seeded {count} committee rows.")
+        return 0
+    except Exception as exc:
+        logger.error("seed-committees failed: %s", exc)
+        return 1
+
+
+async def seed_codeowners_command(
+    yaml_path: Path | None = None,
+    force: bool = False,
+) -> int:
+    """Upsert CommitteeUSCodeMapping rows from the YAML fixture.
+
+    Requires Committee rows to already exist (run seed-committees first).
+
+    Args:
+        yaml_path: Path to YAML fixture; defaults to bundled committee_usc_mappings.yaml.
+        force: If True, update existing rows even if unchanged.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    from pathlib import Path as _Path
+
+    from app.models.base import async_session_maker
+    from pipeline.house_rules.seed import (
+        _DEFAULT_MAPPING_YAML,
+        seed_codeowners_mappings,
+    )
+
+    resolved = yaml_path if yaml_path is not None else _DEFAULT_MAPPING_YAML
+    logger.info("Seeding CODEOWNERS mappings from %s", resolved)
+
+    try:
+        async with async_session_maker() as session:
+            count = await seed_codeowners_mappings(
+                session, yaml_path=_Path(resolved), force=force
+            )
+        print(f"Seeded {count} CommitteeUSCodeMapping rows.")
+        return 0
+    except Exception as exc:
+        logger.error("seed-codeowners failed: %s", exc)
+        return 1
+
+
+async def house_rules_ingest_command(
+    congress: int,
+    force: bool = False,
+) -> int:
+    """Fetch House Rule X from GovInfo HMAN and upsert CommitteeCongressInstance rows.
+
+    Args:
+        congress: Congress number to ingest (e.g. 119).
+        force: If True, re-fetch even if the HTML is already cached.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    from app.models.base import async_session_maker
+    from pipeline.house_rules.ingestion import HouseRulesIngestionService
+
+    logger.info("Ingesting House Rule X for %dth Congress", congress)
+
+    try:
+        async with async_session_maker() as session:
+            service = HouseRulesIngestionService(session, cache=_cli_cache)
+            log = await service.ingest_congress(congress, force=force)
+        print(
+            f"house-rules-ingest {congress}: status={log.status} "
+            f"created={log.records_created} updated={log.records_updated} "
+            f"failed={log.records_failed}"
+        )
+        return 0 if log.status == "completed" else 1
+    except Exception as exc:
+        logger.error("house-rules-ingest failed: %s", exc)
+        return 1
+
+
+async def house_rules_ingest_range_command(
+    start: int,
+    end: int,
+    force: bool = False,
+) -> int:
+    """Ingest House Rule X for a range of Congresses.
+
+    Args:
+        start: First Congress number (inclusive).
+        end: Last Congress number (inclusive).
+        force: If True, re-fetch even if cached.
+
+    Returns:
+        0 on success, 1 if any Congress failed.
+    """
+    from app.models.base import async_session_maker
+    from pipeline.house_rules.ingestion import HouseRulesIngestionService
+
+    logger.info("Ingesting House Rule X for Congresses %d–%d", start, end)
+
+    failed = 0
+    for congress in range(start, end + 1):
+        try:
+            async with async_session_maker() as session:
+                service = HouseRulesIngestionService(session, cache=_cli_cache)
+                log = await service.ingest_congress(congress, force=force)
+            status = log.status
+            print(
+                f"  Congress {congress}: {status} "
+                f"(created={log.records_created} updated={log.records_updated})"
+            )
+            if status != "completed":
+                failed += 1
+        except Exception as exc:
+            logger.error("  Congress %d failed: %s", congress, exc)
+            failed += 1
+
+    if failed:
+        print(f"\n{failed} Congress(es) failed.")
+    else:
+        print(f"\nAll {end - start + 1} Congress(es) ingested successfully.")
+    return 0 if failed == 0 else 1
 
 
 if __name__ == "__main__":

--- a/backend/pipeline/house_rules/__init__.py
+++ b/backend/pipeline/house_rules/__init__.py
@@ -1,0 +1,1 @@
+"""House Rules pipeline: Rule X ingestion and CODEOWNERS seed utilities."""

--- a/backend/pipeline/house_rules/committee_seed.yaml
+++ b/backend/pipeline/house_rules/committee_seed.yaml
@@ -1,0 +1,204 @@
+# Committee seed data — stable identity records for all House and Senate committees.
+# These are loaded by `seed-committees` CLI command and must exist before
+# CommitteeCongressInstance or CommitteeUSCodeMapping rows can be inserted.
+#
+# committee_code slug convention: {chamber}-{short-name}
+# chamber values: "House" or "Senate"
+
+committees:
+  # ── House Committees ─────────────────────────────────────────────────────
+  - code: house-agriculture
+    chamber: House
+    name: "Committee on Agriculture"
+    url: "https://agriculture.house.gov/"
+
+  - code: house-appropriations
+    chamber: House
+    name: "Committee on Appropriations"
+    url: "https://appropriations.house.gov/"
+
+  - code: house-armed-services
+    chamber: House
+    name: "Committee on Armed Services"
+    url: "https://armedservices.house.gov/"
+
+  - code: house-budget
+    chamber: House
+    name: "Committee on the Budget"
+    url: "https://budget.house.gov/"
+
+  - code: house-education-and-workforce
+    chamber: House
+    name: "Committee on Education and the Workforce"
+    url: "https://edworkforce.house.gov/"
+
+  - code: house-energy-and-commerce
+    chamber: House
+    name: "Committee on Energy and Commerce"
+    url: "https://energycommerce.house.gov/"
+
+  - code: house-ethics
+    chamber: House
+    name: "Committee on Ethics"
+    url: "https://ethics.house.gov/"
+
+  - code: house-financial-services
+    chamber: House
+    name: "Committee on Financial Services"
+    url: "https://financialservices.house.gov/"
+
+  - code: house-foreign-affairs
+    chamber: House
+    name: "Committee on Foreign Affairs"
+    url: "https://foreignaffairs.house.gov/"
+
+  - code: house-homeland-security
+    chamber: House
+    name: "Committee on Homeland Security"
+    url: "https://homeland.house.gov/"
+
+  - code: house-administration
+    chamber: House
+    name: "Committee on House Administration"
+    url: "https://cha.house.gov/"
+
+  - code: house-intelligence
+    chamber: House
+    name: "Permanent Select Committee on Intelligence"
+    url: "https://intelligence.house.gov/"
+
+  - code: house-judiciary
+    chamber: House
+    name: "Committee on the Judiciary"
+    url: "https://judiciary.house.gov/"
+
+  - code: house-natural-resources
+    chamber: House
+    name: "Committee on Natural Resources"
+    url: "https://naturalresources.house.gov/"
+
+  - code: house-oversight-and-accountability
+    chamber: House
+    name: "Committee on Oversight and Accountability"
+    url: "https://oversight.house.gov/"
+
+  - code: house-rules
+    chamber: House
+    name: "Committee on Rules"
+    url: "https://rules.house.gov/"
+
+  - code: house-science-space-technology
+    chamber: House
+    name: "Committee on Science, Space, and Technology"
+    url: "https://science.house.gov/"
+
+  - code: house-small-business
+    chamber: House
+    name: "Committee on Small Business"
+    url: "https://smallbusiness.house.gov/"
+
+  - code: house-transportation-and-infrastructure
+    chamber: House
+    name: "Committee on Transportation and Infrastructure"
+    url: "https://transportation.house.gov/"
+
+  - code: house-veterans-affairs
+    chamber: House
+    name: "Committee on Veterans' Affairs"
+    url: "https://veterans.house.gov/"
+
+  - code: house-ways-and-means
+    chamber: House
+    name: "Committee on Ways and Means"
+    url: "https://waysandmeans.house.gov/"
+
+  # ── Senate Committees ────────────────────────────────────────────────────
+  - code: senate-agriculture-nutrition-forestry
+    chamber: Senate
+    name: "Committee on Agriculture, Nutrition, and Forestry"
+    url: "https://www.agriculture.senate.gov/"
+
+  - code: senate-appropriations
+    chamber: Senate
+    name: "Committee on Appropriations"
+    url: "https://www.appropriations.senate.gov/"
+
+  - code: senate-armed-services
+    chamber: Senate
+    name: "Committee on Armed Services"
+    url: "https://www.armed-services.senate.gov/"
+
+  - code: senate-banking-housing-urban-affairs
+    chamber: Senate
+    name: "Committee on Banking, Housing, and Urban Affairs"
+    url: "https://www.banking.senate.gov/"
+
+  - code: senate-budget
+    chamber: Senate
+    name: "Committee on the Budget"
+    url: "https://www.budget.senate.gov/"
+
+  - code: senate-commerce-science-transportation
+    chamber: Senate
+    name: "Committee on Commerce, Science, and Transportation"
+    url: "https://www.commerce.senate.gov/"
+
+  - code: senate-energy-and-natural-resources
+    chamber: Senate
+    name: "Committee on Energy and Natural Resources"
+    url: "https://www.energy.senate.gov/"
+
+  - code: senate-environment-and-public-works
+    chamber: Senate
+    name: "Committee on Environment and Public Works"
+    url: "https://www.epw.senate.gov/"
+
+  - code: senate-finance
+    chamber: Senate
+    name: "Committee on Finance"
+    url: "https://www.finance.senate.gov/"
+
+  - code: senate-foreign-relations
+    chamber: Senate
+    name: "Committee on Foreign Relations"
+    url: "https://www.foreign.senate.gov/"
+
+  - code: senate-help
+    chamber: Senate
+    name: "Committee on Health, Education, Labor, and Pensions"
+    url: "https://www.help.senate.gov/"
+
+  - code: senate-homeland-security-governmental-affairs
+    chamber: Senate
+    name: "Committee on Homeland Security and Governmental Affairs"
+    url: "https://www.hsgac.senate.gov/"
+
+  - code: senate-indian-affairs
+    chamber: Senate
+    name: "Committee on Indian Affairs"
+    url: "https://www.indian.senate.gov/"
+
+  - code: senate-intelligence
+    chamber: Senate
+    name: "Select Committee on Intelligence"
+    url: "https://www.intelligence.senate.gov/"
+
+  - code: senate-judiciary
+    chamber: Senate
+    name: "Committee on the Judiciary"
+    url: "https://www.judiciary.senate.gov/"
+
+  - code: senate-rules-and-administration
+    chamber: Senate
+    name: "Committee on Rules and Administration"
+    url: "https://www.rules.senate.gov/"
+
+  - code: senate-small-business
+    chamber: Senate
+    name: "Committee on Small Business and Entrepreneurship"
+    url: "https://www.sbc.senate.gov/"
+
+  - code: senate-veterans-affairs
+    chamber: Senate
+    name: "Committee on Veterans' Affairs"
+    url: "https://www.veterans.senate.gov/"

--- a/backend/pipeline/house_rules/committee_usc_mappings.yaml
+++ b/backend/pipeline/house_rules/committee_usc_mappings.yaml
@@ -1,0 +1,1258 @@
+# Curated CODEOWNERS mapping: congressional committee → US Code title/chapter path.
+#
+# This is the authoritative human-authored layer that bridges Rule X jurisdiction
+# prose (which never references the US Code directly) to actual US Code paths.
+# See research/TASK-0.15-Committee-Jurisdiction-Mapping.md for the full analysis.
+#
+# Fields:
+#   committee_code  — matches Committee.committee_code slug
+#   congress_start  — first Congress this mapping applies (106 = first with parseable HMAN HTM)
+#   congress_end    — last Congress (null = still current)
+#   title_number    — US Code title number (integer)
+#   chapter_number  — US Code chapter (string, null = title-level mapping)
+#   jurisdiction_type — "primary" | "secondary" | "oversight"
+#   display_order   — sort order within same title/chapter (primary first)
+#   notes           — optional curator note
+#
+# Chapter-level splits documented below for Titles 21, 31, 42, and 50.
+# All other titles use title-level (chapter_number: null) mappings.
+
+mappings:
+  # ── Title 1: General Provisions ─────────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 1
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 1
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 2: The Congress ────────────────────────────────────────────────
+  - committee_code: house-administration
+    congress_start: 106
+    congress_end: null
+    title_number: 2
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-rules-and-administration
+    congress_start: 106
+    congress_end: null
+    title_number: 2
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 3: The President ───────────────────────────────────────────────
+  - committee_code: house-oversight-and-accountability
+    congress_start: 106
+    congress_end: null
+    title_number: 3
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-homeland-security-governmental-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 3
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 4: Flag and Seal ───────────────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 4
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 4
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 5: Government Organization and Employees ───────────────────────
+  - committee_code: house-oversight-and-accountability
+    congress_start: 106
+    congress_end: null
+    title_number: 5
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-homeland-security-governmental-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 5
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 6: Domestic Security ───────────────────────────────────────────
+  - committee_code: house-homeland-security
+    congress_start: 109
+    congress_end: null
+    title_number: 6
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Homeland Security Committee established 109th Congress (H.Res.5, Jan 4, 2005)"
+
+  - committee_code: senate-homeland-security-governmental-affairs
+    congress_start: 109
+    congress_end: null
+    title_number: 6
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 7: Agriculture ─────────────────────────────────────────────────
+  - committee_code: house-agriculture
+    congress_start: 106
+    congress_end: null
+    title_number: 7
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-agriculture-nutrition-forestry
+    congress_start: 106
+    congress_end: null
+    title_number: 7
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 8: Aliens and Nationality ─────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 8
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 8
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 9: Arbitration ─────────────────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 9
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 9
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 10: Armed Forces ───────────────────────────────────────────────
+  - committee_code: house-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 10
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 10
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 11: Bankruptcy ─────────────────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 11
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 11
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 12: Banks and Banking ──────────────────────────────────────────
+  - committee_code: house-financial-services
+    congress_start: 106
+    congress_end: null
+    title_number: 12
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-banking-housing-urban-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 12
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 13: Census ─────────────────────────────────────────────────────
+  - committee_code: house-oversight-and-accountability
+    congress_start: 106
+    congress_end: null
+    title_number: 13
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-homeland-security-governmental-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 13
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 14: Coast Guard ────────────────────────────────────────────────
+  - committee_code: house-transportation-and-infrastructure
+    congress_start: 106
+    congress_end: null
+    title_number: 14
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 14
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 15: Commerce and Trade ─────────────────────────────────────────
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 15
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 15
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 16: Conservation ───────────────────────────────────────────────
+  - committee_code: house-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 16
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-energy-and-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 16
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 17: Copyrights ─────────────────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 17
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 17
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 18: Crimes and Criminal Procedure ──────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 18
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 18
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 19: Customs Duties ─────────────────────────────────────────────
+  - committee_code: house-ways-and-means
+    congress_start: 106
+    congress_end: null
+    title_number: 19
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-finance
+    congress_start: 106
+    congress_end: null
+    title_number: 19
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 20: Education ──────────────────────────────────────────────────
+  - committee_code: house-education-and-workforce
+    congress_start: 106
+    congress_end: null
+    title_number: 20
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 20
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 21: Food and Drugs — Chapter-level split ───────────────────────
+  # Default (title-level): FDA and drug regulation → Energy and Commerce / HELP
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Default title-level: FDA drug/device authority (FDCA, Ch. 9)"
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 1 (original Food and Drugs Act, USDA commodity standards)
+  - committee_code: house-agriculture
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "1"
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "USDA food safety authorities (meat, poultry inspection)"
+
+  - committee_code: senate-agriculture-nutrition-forestry
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "1"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 9 (Federal Food, Drug, and Cosmetic Act — FDA primary)
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "9"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "9"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 13 (Controlled Substances Act) — Judiciary + Energy and Commerce
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "13"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "13"
+    jurisdiction_type: secondary
+    display_order: 1
+    notes: "Judiciary has shared jurisdiction over criminal enforcement of CSA"
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "13"
+    jurisdiction_type: primary
+    display_order: 2
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 21
+    chapter_number: "13"
+    jurisdiction_type: secondary
+    display_order: 3
+
+  # ── Title 22: Foreign Relations and Intercourse ──────────────────────────
+  - committee_code: house-foreign-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 22
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-foreign-relations
+    congress_start: 106
+    congress_end: null
+    title_number: 22
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 23: Highways ───────────────────────────────────────────────────
+  - committee_code: house-transportation-and-infrastructure
+    congress_start: 106
+    congress_end: null
+    title_number: 23
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-environment-and-public-works
+    congress_start: 106
+    congress_end: null
+    title_number: 23
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 24: Hospitals and Asylums ─────────────────────────────────────
+  - committee_code: house-veterans-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 24
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Primarily VA hospital facilities; Energy and Commerce has secondary jurisdiction for non-VA public hospitals"
+
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 24
+    chapter_number: null
+    jurisdiction_type: secondary
+    display_order: 1
+
+  - committee_code: senate-veterans-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 24
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 2
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 24
+    chapter_number: null
+    jurisdiction_type: secondary
+    display_order: 3
+
+  # ── Title 25: Indians ────────────────────────────────────────────────────
+  - committee_code: house-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 25
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-indian-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 25
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+    notes: "Senate has a dedicated standing Committee on Indian Affairs"
+
+  # ── Title 26: Internal Revenue Code ─────────────────────────────────────
+  - committee_code: house-ways-and-means
+    congress_start: 106
+    congress_end: null
+    title_number: 26
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Art. I §7 constitutional origination authority — all revenue bills must originate in the House"
+
+  - committee_code: senate-finance
+    congress_start: 106
+    congress_end: null
+    title_number: 26
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 27: Intoxicating Liquors ───────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 27
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 27
+    chapter_number: null
+    jurisdiction_type: secondary
+    display_order: 1
+    notes: "Energy and Commerce has secondary jurisdiction over TTB (Alcohol and Tobacco Tax and Trade Bureau) regulation"
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 27
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 2
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 27
+    chapter_number: null
+    jurisdiction_type: secondary
+    display_order: 3
+
+  # ── Title 28: Judiciary and Judicial Procedure ───────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 28
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 28
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 29: Labor ──────────────────────────────────────────────────────
+  - committee_code: house-education-and-workforce
+    congress_start: 106
+    congress_end: null
+    title_number: 29
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 29
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 30: Mineral Lands and Mining ───────────────────────────────────
+  - committee_code: house-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 30
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-energy-and-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 30
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 31: Money and Finance — Chapter-level split ────────────────────
+  # Default (title-level): fiscal policy → Ways and Means / Finance
+  - committee_code: house-ways-and-means
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Default title-level: fiscal and appropriations authority"
+
+  - committee_code: senate-finance
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 3 (Department of the Treasury organization)
+  - committee_code: house-ways-and-means
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "3"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-finance
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "3"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 5 (Office of Management and Budget)
+  - committee_code: house-oversight-and-accountability
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "5"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-homeland-security-governmental-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "5"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 31 (Public Debt — debt ceiling)
+  - committee_code: house-ways-and-means
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "31"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-finance
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "31"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapters 51, 53 (Coins/currency, Bank Secrecy Act/AML)
+  - committee_code: house-financial-services
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "51"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-banking-housing-urban-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "51"
+    jurisdiction_type: primary
+    display_order: 1
+
+  - committee_code: house-financial-services
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "53"
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Bank Secrecy Act and Anti-Money Laundering authorities"
+
+  - committee_code: senate-banking-housing-urban-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 31
+    chapter_number: "53"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 32: National Guard ─────────────────────────────────────────────
+  - committee_code: house-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 32
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 32
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 33: Navigation and Navigable Waters ────────────────────────────
+  - committee_code: house-transportation-and-infrastructure
+    congress_start: 106
+    congress_end: null
+    title_number: 33
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-environment-and-public-works
+    congress_start: 106
+    congress_end: null
+    title_number: 33
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 34: Crime Control and Law Enforcement ──────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 34
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 34
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 35: Patents ────────────────────────────────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 35
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 35
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 36: Patriotic and National Observances ─────────────────────────
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 36
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 36
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 37: Pay and Allowances of the Uniformed Services ───────────────
+  - committee_code: house-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 37
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 37
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 38: Veterans' Benefits ─────────────────────────────────────────
+  - committee_code: house-veterans-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 38
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-veterans-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 38
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 39: Postal Service ─────────────────────────────────────────────
+  - committee_code: house-oversight-and-accountability
+    congress_start: 106
+    congress_end: null
+    title_number: 39
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-homeland-security-governmental-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 39
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 40: Public Buildings, Property, and Works ─────────────────────
+  - committee_code: house-transportation-and-infrastructure
+    congress_start: 106
+    congress_end: null
+    title_number: 40
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-environment-and-public-works
+    congress_start: 106
+    congress_end: null
+    title_number: 40
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 41: Public Contracts ───────────────────────────────────────────
+  - committee_code: house-oversight-and-accountability
+    congress_start: 106
+    congress_end: null
+    title_number: 41
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-homeland-security-governmental-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 41
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 42: Public Health and Welfare — Chapter-level split ────────────
+  # Default (title-level): public health agencies → Energy and Commerce / HELP
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Default title-level: public health agencies (CDC, NIH, FDA authorities under PHS Act)"
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 6A (Public Health Service Act — CDC, NIH, HRSA, SAMHSA)
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "6a"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-help
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "6a"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 7 (Social Security Act — Medicare, Medicaid, CHIP, TANF)
+  - committee_code: house-ways-and-means
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "7"
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "Ways and Means has jurisdiction over Social Security Act programs financed by trust funds"
+
+  - committee_code: senate-finance
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "7"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 8 (Low-Income Housing programs)
+  - committee_code: house-financial-services
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "8"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-banking-housing-urban-affairs
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "8"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 21 (Civil Rights Act provisions — §§1981–2000h-6)
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "21"
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 42
+    chapter_number: "21"
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 43: Public Lands ───────────────────────────────────────────────
+  - committee_code: house-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 43
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-energy-and-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 43
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 44: Public Printing and Documents ──────────────────────────────
+  - committee_code: house-administration
+    congress_start: 106
+    congress_end: null
+    title_number: 44
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-rules-and-administration
+    congress_start: 106
+    congress_end: null
+    title_number: 44
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 45: Railroads ──────────────────────────────────────────────────
+  - committee_code: house-transportation-and-infrastructure
+    congress_start: 106
+    congress_end: null
+    title_number: 45
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 45
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 46: Shipping ───────────────────────────────────────────────────
+  - committee_code: house-transportation-and-infrastructure
+    congress_start: 106
+    congress_end: null
+    title_number: 46
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 46
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 47: Telecommunications ─────────────────────────────────────────
+  - committee_code: house-energy-and-commerce
+    congress_start: 106
+    congress_end: null
+    title_number: 47
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 47
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 48: Territories and Insular Possessions ────────────────────────
+  - committee_code: house-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 48
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-energy-and-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 48
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 49: Transportation ─────────────────────────────────────────────
+  - committee_code: house-transportation-and-infrastructure
+    congress_start: 106
+    congress_end: null
+    title_number: 49
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 49
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 50: War and National Defense — chapter overrides ───────────────
+  # Default (title-level): Armed Services primary
+  - committee_code: house-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-armed-services
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # Chapter 36 (FISA — Foreign Intelligence Surveillance Act)
+  - committee_code: house-intelligence
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: "36"
+    jurisdiction_type: oversight
+    display_order: 0
+    notes: "Permanent Select Committee on Intelligence oversight of FISA surveillance authorities"
+
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: "36"
+    jurisdiction_type: oversight
+    display_order: 1
+    notes: "Judiciary has shared oversight of FISA due to civil liberties and Fourth Amendment implications"
+
+  - committee_code: senate-intelligence
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: "36"
+    jurisdiction_type: oversight
+    display_order: 2
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: "36"
+    jurisdiction_type: oversight
+    display_order: 3
+
+  # Chapter 44 (National Security Act — intelligence community organization)
+  - committee_code: house-intelligence
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: "44"
+    jurisdiction_type: oversight
+    display_order: 0
+    notes: "Intelligence community organization and budgets — exclusive Intelligence Committee oversight"
+
+  - committee_code: senate-intelligence
+    congress_start: 106
+    congress_end: null
+    title_number: 50
+    chapter_number: "44"
+    jurisdiction_type: oversight
+    display_order: 1
+
+  # ── Title 51: National and Commercial Space Program ──────────────────────
+  - committee_code: house-science-space-technology
+    congress_start: 106
+    congress_end: null
+    title_number: 51
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-commerce-science-transportation
+    congress_start: 106
+    congress_end: null
+    title_number: 51
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1
+
+  # ── Title 52: Voting and Elections ───────────────────────────────────────
+  - committee_code: house-administration
+    congress_start: 106
+    congress_end: null
+    title_number: 52
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+    notes: "House Administration has primary jurisdiction over election administration"
+
+  - committee_code: house-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 52
+    chapter_number: null
+    jurisdiction_type: secondary
+    display_order: 1
+    notes: "Judiciary has secondary jurisdiction for voting rights enforcement"
+
+  - committee_code: senate-rules-and-administration
+    congress_start: 106
+    congress_end: null
+    title_number: 52
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 2
+
+  - committee_code: senate-judiciary
+    congress_start: 106
+    congress_end: null
+    title_number: 52
+    chapter_number: null
+    jurisdiction_type: secondary
+    display_order: 3
+
+  # ── Title 54: National Park Service and Related Programs ─────────────────
+  - committee_code: house-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 54
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 0
+
+  - committee_code: senate-energy-and-natural-resources
+    congress_start: 106
+    congress_end: null
+    title_number: 54
+    chapter_number: null
+    jurisdiction_type: primary
+    display_order: 1

--- a/backend/pipeline/house_rules/ingestion.py
+++ b/backend/pipeline/house_rules/ingestion.py
@@ -1,0 +1,230 @@
+"""House Rules ingestion service: fetches HMAN HTM and populates CommitteeCongressInstance."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.codeowners import CommitteeCongressInstance
+from app.models.supporting import Committee, DataIngestionLog
+from pipeline.house_rules.parser import CommitteeJurisdictionData, parse_rule_x
+
+if TYPE_CHECKING:
+    from pipeline.cache import PipelineCache
+
+logger = logging.getLogger(__name__)
+
+_HMAN_URL_TEMPLATE = "https://www.govinfo.gov/content/pkg/HMAN-{congress}/html/HMAN-{congress}-houserules.htm"
+_HTTP_TIMEOUT = 60.0
+
+
+class HouseRulesIngestionService:
+    """Fetches HMAN HTM from GovInfo and upserts CommitteeCongressInstance rows.
+
+    The HMAN static content URL does not require a GovInfo API key.
+    Responses are cached via PipelineCache to avoid repeated downloads.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        cache: PipelineCache | None = None,
+    ) -> None:
+        self._session = session
+        self._cache = cache
+
+    def _hman_url(self, congress: int) -> str:
+        return _HMAN_URL_TEMPLATE.format(congress=congress)
+
+    def _cache_key(self, congress: int) -> str:
+        return f"govinfo/hman/HMAN-{congress}-houserules.htm"
+
+    async def _fetch_html(self, congress: int, force: bool = False) -> str | None:
+        """Fetch and optionally cache the HMAN HTM for a Congress."""
+        cache_key = self._cache_key(congress)
+        url = self._hman_url(congress)
+
+        if self._cache and not force:
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                logger.debug("Cache hit: %s", cache_key)
+                return cached if isinstance(cached, str) else cached.decode()
+
+        logger.info("Fetching %s", url)
+        try:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                response = await client.get(url, follow_redirects=True)
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.error("HTTP %d fetching %s: %s", exc.response.status_code, url, exc)
+            return None
+        except httpx.RequestError as exc:
+            logger.error("Request error fetching %s: %s", url, exc)
+            return None
+
+        html = response.text
+        if self._cache:
+            self._cache.set(cache_key, html)
+        return html
+
+    async def _get_committee_id_map(self) -> dict[str, int]:
+        """Return a mapping of committee_code → committee_id from the DB."""
+        result = await self._session.execute(
+            select(Committee.committee_code, Committee.committee_id)
+        )
+        return {row[0]: row[1] for row in result}
+
+    async def ingest_congress(
+        self,
+        congress: int,
+        force: bool = False,
+    ) -> DataIngestionLog:
+        """Fetch Rule X for a Congress and upsert CommitteeCongressInstance rows.
+
+        Args:
+            congress: Congress number (e.g. 119).
+            force: If True, re-fetch even if the HTML is cached.
+
+        Returns:
+            DataIngestionLog summarising the operation.
+        """
+        log = DataIngestionLog(
+            source="govinfo/hman",
+            operation=f"ingest_house_rules/{congress}",
+            started_at=datetime.utcnow(),
+            status="running",
+            records_processed=0,
+            records_created=0,
+            records_updated=0,
+            records_failed=0,
+        )
+        self._session.add(log)
+        await self._session.flush()
+
+        try:
+            html = await self._fetch_html(congress, force=force)
+            if html is None:
+                log.status = "failed"
+                log.error_message = f"Could not fetch HMAN-{congress}"
+                log.completed_at = datetime.utcnow()
+                await self._session.commit()
+                return log
+
+            committees: list[CommitteeJurisdictionData] = parse_rule_x(html)
+            log.records_processed = len(committees)
+
+            if not committees:
+                logger.warning("No committee data parsed from HMAN-%d", congress)
+
+            code_to_id = await self._get_committee_id_map()
+            source_url = self._hman_url(congress)
+
+            for entry in committees:
+                if entry.committee_code is None:
+                    logger.warning(
+                        "Unknown committee name %r in HMAN-%d — skipping",
+                        entry.committee_name,
+                        congress,
+                    )
+                    log.records_failed += 1
+                    continue
+
+                committee_id = code_to_id.get(entry.committee_code)
+                if committee_id is None:
+                    logger.warning(
+                        "committee_code %r not found in Committee table for HMAN-%d — "
+                        "run seed-committees first",
+                        entry.committee_code,
+                        congress,
+                    )
+                    log.records_failed += 1
+                    continue
+
+                stmt = (
+                    insert(CommitteeCongressInstance)
+                    .values(
+                        committee_id=committee_id,
+                        congress=congress,
+                        official_name=entry.committee_name,
+                        rule_citation=entry.rule_citation,
+                        jurisdiction_text=entry.jurisdiction_text or None,
+                        source_url=source_url,
+                    )
+                    .on_conflict_do_update(
+                        constraint="uq_cci_committee_congress",
+                        set_={
+                            "official_name": entry.committee_name,
+                            "rule_citation": entry.rule_citation,
+                            "jurisdiction_text": entry.jurisdiction_text or None,
+                            "source_url": source_url,
+                        },
+                    )
+                )
+                result = await self._session.execute(stmt)
+                # rowcount == 1 for both INSERT and UPDATE
+                if result.rowcount:
+                    log.records_created += 1
+
+            log.status = "completed"
+            log.completed_at = datetime.utcnow()
+            await self._session.commit()
+
+        except Exception as exc:
+            log.status = "failed"
+            log.error_message = str(exc)
+            log.completed_at = datetime.utcnow()
+            await self._session.commit()
+            logger.error("house-rules-ingest/%d failed: %s", congress, exc)
+
+        return log
+
+    async def ingest_range(
+        self,
+        start: int,
+        end: int,
+        force: bool = False,
+    ) -> DataIngestionLog:
+        """Ingest Rule X for a range of Congresses.
+
+        Creates a single summary DataIngestionLog aggregating all congresses.
+
+        Args:
+            start: First Congress number (inclusive).
+            end: Last Congress number (inclusive).
+            force: If True, re-fetch even if cached.
+
+        Returns:
+            Aggregated DataIngestionLog for the range.
+        """
+        summary = DataIngestionLog(
+            source="govinfo/hman",
+            operation=f"ingest_house_rules_range/{start}-{end}",
+            started_at=datetime.utcnow(),
+            status="running",
+            records_processed=0,
+            records_created=0,
+            records_updated=0,
+            records_failed=0,
+        )
+        self._session.add(summary)
+        await self._session.flush()
+
+        for congress in range(start, end + 1):
+            log = await self.ingest_congress(congress, force=force)
+            summary.records_processed += log.records_processed
+            summary.records_created += log.records_created
+            summary.records_updated += log.records_updated
+            summary.records_failed += log.records_failed
+
+        summary.status = (
+            "completed" if summary.records_failed == 0 else "completed_with_errors"
+        )
+        summary.completed_at = datetime.utcnow()
+        await self._session.commit()
+        return summary

--- a/backend/pipeline/house_rules/parser.py
+++ b/backend/pipeline/house_rules/parser.py
@@ -1,0 +1,174 @@
+"""HTML parser for House Rules and Manual (HMAN) Rule X jurisdiction text."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from bs4 import BeautifulSoup, Tag
+
+# Maps the lowercased committee name as it appears in Rule X to the stable
+# committee_code slug used in the Committee table. Includes historical name
+# variants so the parser works across Congresses 106–119.
+HOUSE_COMMITTEE_NAME_TO_CODE: dict[str, str] = {
+    "agriculture": "house-agriculture",
+    "appropriations": "house-appropriations",
+    "armed services": "house-armed-services",
+    "budget": "house-budget",
+    "education and the workforce": "house-education-and-workforce",
+    "education and labor": "house-education-and-workforce",
+    "education and economic opportunities": "house-education-and-workforce",
+    "energy and commerce": "house-energy-and-commerce",
+    "ethics": "house-ethics",
+    "standards of official conduct": "house-ethics",
+    "financial services": "house-financial-services",
+    "banking and financial services": "house-financial-services",
+    "foreign affairs": "house-foreign-affairs",
+    "international relations": "house-foreign-affairs",
+    "homeland security": "house-homeland-security",
+    "house administration": "house-administration",
+    "intelligence (permanent select)": "house-intelligence",
+    "permanent select committee on intelligence": "house-intelligence",
+    "judiciary": "house-judiciary",
+    "natural resources": "house-natural-resources",
+    "resources": "house-natural-resources",
+    "oversight and accountability": "house-oversight-and-accountability",
+    "oversight and government reform": "house-oversight-and-accountability",
+    "government reform": "house-oversight-and-accountability",
+    "rules": "house-rules",
+    "science, space, and technology": "house-science-space-technology",
+    "science and technology": "house-science-space-technology",
+    "science": "house-science-space-technology",
+    "small business": "house-small-business",
+    "transportation and infrastructure": "house-transportation-and-infrastructure",
+    "public works and transportation": "house-transportation-and-infrastructure",
+    "veterans' affairs": "house-veterans-affairs",
+    "ways and means": "house-ways-and-means",
+}
+
+
+@dataclass
+class CommitteeJurisdictionData:
+    """Parsed jurisdiction data for a single committee from Rule X."""
+
+    committee_name: str
+    committee_code: str | None
+    clause_letter: str
+    rule_citation: str
+    jurisdiction_items: list[str] = field(default_factory=list)
+
+    @property
+    def jurisdiction_text(self) -> str:
+        """Numbered jurisdiction items joined as a single text block."""
+        return "\n".join(
+            f"({i + 1}) {item}" for i, item in enumerate(self.jurisdiction_items)
+        )
+
+
+def _normalize_committee_name(raw_name: str) -> str:
+    """Normalize a committee name for lookup against HOUSE_COMMITTEE_NAME_TO_CODE."""
+    # Strip "Committee on the", "Committee on", "Select Committee on", etc.
+    name = raw_name.lower().strip()
+    # Remove leading articles and qualifiers
+    for prefix in (
+        "permanent select committee on intelligence",
+        "committee on the ",
+        "committee on ",
+        "select committee on ",
+    ):
+        if (
+            name.startswith(prefix)
+            and prefix != "permanent select committee on intelligence"
+        ):
+            name = name[len(prefix) :]
+            break
+    return name.strip().rstrip(".")
+
+
+def _lookup_committee_code(raw_name: str) -> str | None:
+    """Return the committee_code slug for a raw Rule X committee name, or None."""
+    normalized = _normalize_committee_name(raw_name)
+    # Try direct lookup first
+    if normalized in HOUSE_COMMITTEE_NAME_TO_CODE:
+        return HOUSE_COMMITTEE_NAME_TO_CODE[normalized]
+    # Try full raw name lowercased (catches "Permanent Select Committee on Intelligence")
+    raw_lower = raw_name.lower().strip().rstrip(".")
+    if raw_lower in HOUSE_COMMITTEE_NAME_TO_CODE:
+        return HOUSE_COMMITTEE_NAME_TO_CODE[raw_lower]
+    return None
+
+
+def parse_rule_x(html: str) -> list[CommitteeJurisdictionData]:
+    """Parse Rule X committee jurisdiction text from a GovInfo HMAN HTM document.
+
+    Args:
+        html: Full HTML content of an HMAN-{congress}-houserules.htm page.
+
+    Returns:
+        List of CommitteeJurisdictionData, one per committee found in Rule X clause 1.
+    """
+    soup = BeautifulSoup(html, "lxml")
+
+    # Locate the Rule X section. The HMAN HTM uses a <p> or <h2> element with
+    # text like "RULE X" or "Rule X". We find it and then walk forward.
+    rule_x_start: Tag | None = None
+    for tag in soup.find_all(string=re.compile(r"^\s*RULE\s+X\.?\s*$", re.IGNORECASE)):
+        parent = tag.parent
+        if parent:
+            rule_x_start = parent
+            break
+
+    if rule_x_start is None:
+        return []
+
+    results: list[CommitteeJurisdictionData] = []
+    current: CommitteeJurisdictionData | None = None
+
+    # Walk siblings after Rule X header until we hit Rule XI
+    # Matches "(a) Committee on Agriculture." or "(a) Permanent Select Committee..."
+    committee_header_pattern = re.compile(
+        r"^\s*\(([a-z])\)\s+((?:Permanent\s+Select\s+)?(?:Committee\s+on\s+(?:the\s+)?)?.*?)\.?\s*$",
+        re.IGNORECASE,
+    )
+    item_pattern = re.compile(r"^\s*\((\d+)\)\s+(.+)$", re.DOTALL)
+    rule_xi_pattern = re.compile(r"^\s*RULE\s+XI\.?\s*$", re.IGNORECASE)
+
+    for sibling in rule_x_start.next_siblings:
+        if not isinstance(sibling, Tag):
+            continue
+
+        text = sibling.get_text(separator=" ", strip=True)
+
+        # Stop at Rule XI
+        if rule_xi_pattern.match(text):
+            break
+
+        # Check for a new committee clause like "(a) Committee on Agriculture."
+        header_match = committee_header_pattern.match(text)
+        if header_match and re.search(r"\bcommittee\b", text, re.IGNORECASE):
+            if current is not None:
+                results.append(current)
+
+            letter = header_match.group(1)
+            raw_name = header_match.group(2).strip().rstrip(".")
+            code = _lookup_committee_code(raw_name)
+            citation = f"House Rule X, Clause 1({letter})"
+            current = CommitteeJurisdictionData(
+                committee_name=raw_name,
+                committee_code=code,
+                clause_letter=letter,
+                rule_citation=citation,
+            )
+            continue
+
+        # Check for a numbered jurisdiction item "(1) Agriculture generally."
+        if current is not None:
+            item_match = item_pattern.match(text)
+            if item_match:
+                current.jurisdiction_items.append(item_match.group(2).strip())
+
+    # Don't forget the last committee
+    if current is not None:
+        results.append(current)
+
+    return results

--- a/backend/pipeline/house_rules/seed.py
+++ b/backend/pipeline/house_rules/seed.py
@@ -1,0 +1,137 @@
+"""Seed helpers for CODEOWNERS data: Committee rows and CommitteeUSCodeMapping rows."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.codeowners import CommitteeUSCodeMapping
+from app.models.enums import Chamber
+from app.models.supporting import Committee
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COMMITTEE_YAML = Path(__file__).parent / "committee_seed.yaml"
+_DEFAULT_MAPPING_YAML = Path(__file__).parent / "committee_usc_mappings.yaml"
+
+
+async def seed_committees(
+    session: AsyncSession,
+    yaml_path: Path = _DEFAULT_COMMITTEE_YAML,
+    force: bool = False,  # noqa: ARG001 — reserved for future selective update logic
+) -> int:
+    """Upsert Committee rows from a YAML fixture file.
+
+    Returns the number of rows inserted or updated.
+    Idempotent: safe to run multiple times.
+    """
+    data = yaml.safe_load(yaml_path.read_text())
+    entries = data.get("committees", [])
+
+    upserted = 0
+    for entry in entries:
+        code = entry["code"]
+        chamber = Chamber(entry["chamber"])
+
+        stmt = (
+            insert(Committee)
+            .values(
+                committee_code=code,
+                chamber=chamber,
+                name=entry["name"],
+                url=entry.get("url"),
+                is_active=True,
+            )
+            .on_conflict_do_update(
+                index_elements=["committee_code"],
+                set_={
+                    "name": entry["name"],
+                    "url": entry.get("url"),
+                    "is_active": True,
+                },
+            )
+        )
+        await session.execute(stmt)
+        upserted += 1
+
+    await session.commit()
+    logger.info("Seeded %d committee rows from %s", upserted, yaml_path)
+    return upserted
+
+
+async def seed_codeowners_mappings(
+    session: AsyncSession,
+    yaml_path: Path = _DEFAULT_MAPPING_YAML,
+    force: bool = False,  # noqa: ARG001 — reserved for future selective update logic
+) -> int:
+    """Upsert CommitteeUSCodeMapping rows from a YAML fixture file.
+
+    Resolves committee_code → committee_id via the Committee table.
+    Idempotent: safe to run multiple times. The Committee rows must
+    exist before this is called (run seed_committees first).
+
+    Returns the number of rows inserted or updated.
+    """
+    data = yaml.safe_load(yaml_path.read_text())
+    entries = data.get("mappings", [])
+
+    # Build a code → id lookup to avoid N+1 queries
+    result = await session.execute(
+        select(Committee.committee_code, Committee.committee_id)
+    )
+    code_to_id: dict[str, int] = {row[0]: row[1] for row in result}
+
+    upserted = 0
+    skipped = 0
+    for entry in entries:
+        code = entry["committee_code"]
+        committee_id = code_to_id.get(code)
+        if committee_id is None:
+            logger.warning(
+                "committee_code %r not found in Committee table — skipping mapping "
+                "(title %s, ch. %s). Run seed-committees first.",
+                code,
+                entry["title_number"],
+                entry.get("chapter_number"),
+            )
+            skipped += 1
+            continue
+
+        stmt = (
+            insert(CommitteeUSCodeMapping)
+            .values(
+                committee_id=committee_id,
+                congress_start=entry["congress_start"],
+                congress_end=entry.get("congress_end"),
+                title_number=entry["title_number"],
+                chapter_number=entry.get("chapter_number"),
+                jurisdiction_type=entry["jurisdiction_type"],
+                display_order=entry.get("display_order", 0),
+                notes=entry.get("notes"),
+            )
+            .on_conflict_do_update(
+                constraint="uq_cum_committee_congress_path_type",
+                set_={
+                    "congress_end": entry.get("congress_end"),
+                    "jurisdiction_type": entry["jurisdiction_type"],
+                    "display_order": entry.get("display_order", 0),
+                    "notes": entry.get("notes"),
+                },
+            )
+        )
+        await session.execute(stmt)
+        upserted += 1
+
+    await session.commit()
+    logger.info(
+        "Seeded %d CommitteeUSCodeMapping rows from %s (%d skipped)",
+        upserted,
+        yaml_path,
+        skipped,
+    )
+    return upserted

--- a/backend/tests/api/test_committees.py
+++ b/backend/tests/api/test_committees.py
@@ -1,0 +1,192 @@
+"""Tests for the CODEOWNERS /committees API endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.schemas.committees import (
+    CommitteeBaseSchema,
+    CommitteeCongressInstanceSchema,
+    CommitteeOwnershipSchema,
+)
+
+_HOUSE_JUDICIARY = CommitteeBaseSchema(
+    committee_code="house-judiciary",
+    chamber="House",
+    name="Committee on the Judiciary",
+    url="https://judiciary.house.gov/",
+)
+_SENATE_JUDICIARY = CommitteeBaseSchema(
+    committee_code="senate-judiciary",
+    chamber="Senate",
+    name="Committee on the Judiciary",
+    url="https://www.judiciary.senate.gov/",
+)
+_HOUSE_WAYS_MEANS = CommitteeBaseSchema(
+    committee_code="house-ways-and-means",
+    chamber="House",
+    name="Committee on Ways and Means",
+    url="https://waysandmeans.house.gov/",
+)
+_SENATE_FINANCE = CommitteeBaseSchema(
+    committee_code="senate-finance",
+    chamber="Senate",
+    name="Committee on Finance",
+    url="https://www.finance.senate.gov/",
+)
+_HOUSE_ENERGY = CommitteeBaseSchema(
+    committee_code="house-energy-and-commerce",
+    chamber="House",
+    name="Committee on Energy and Commerce",
+    url="https://energycommerce.house.gov/",
+)
+_SENATE_HELP = CommitteeBaseSchema(
+    committee_code="senate-help",
+    chamber="Senate",
+    name="Committee on Health, Education, Labor, and Pensions",
+    url="https://www.help.senate.gov/",
+)
+
+
+def _ownership(
+    committee: CommitteeBaseSchema,
+    title: int,
+    chapter: str | None = None,
+    jtype: str = "primary",
+    order: int = 0,
+) -> CommitteeOwnershipSchema:
+    return CommitteeOwnershipSchema(
+        committee=committee,
+        jurisdiction_type=jtype,
+        display_order=order,
+        title_number=title,
+        chapter_number=chapter,
+        notes=None,
+        congress_start=106,
+        congress_end=None,
+    )
+
+
+# ── GET /committees/owners/title/{title_number} ──────────────────────────────
+
+
+@patch("app.api.v1.committees.get_owners_for_title", new_callable=AsyncMock)
+def test_owners_for_title_17_returns_judiciary(
+    mock_get: AsyncMock, client: TestClient
+) -> None:
+    """Title 17 ownership returns Judiciary committees."""
+    mock_get.return_value = [
+        _ownership(_HOUSE_JUDICIARY, 17, order=0),
+        _ownership(_SENATE_JUDICIARY, 17, order=1),
+    ]
+    resp = client.get("/api/v1/committees/owners/title/17")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title_number"] == 17
+    assert data["chapter_number"] is None
+    assert len(data["owners"]) == 2
+    codes = [o["committee"]["committee_code"] for o in data["owners"]]
+    assert "house-judiciary" in codes
+    assert "senate-judiciary" in codes
+
+
+@patch("app.api.v1.committees.get_owners_for_title", new_callable=AsyncMock)
+def test_owners_for_title_congress_param_forwarded(
+    mock_get: AsyncMock, client: TestClient
+) -> None:
+    """congress query param is forwarded to the CRUD function."""
+    mock_get.return_value = []
+    client.get("/api/v1/committees/owners/title/17?congress=110")
+    mock_get.assert_awaited_once()
+    _, kwargs = mock_get.call_args
+    assert kwargs.get("congress") == 110 or mock_get.call_args.args[2] == 110
+
+
+# ── GET /committees/owners/title/{title}/chapter/{chapter} ───────────────────
+
+
+@patch("app.api.v1.committees.get_owners_for_chapter", new_callable=AsyncMock)
+def test_chapter_7_of_title_42_returns_finance(
+    mock_get: AsyncMock, client: TestClient
+) -> None:
+    """Title 42 chapter 7 returns Finance/Ways and Means, not HELP/E&C."""
+    mock_get.return_value = [
+        _ownership(_HOUSE_WAYS_MEANS, 42, chapter="7", order=0),
+        _ownership(_SENATE_FINANCE, 42, chapter="7", order=1),
+    ]
+    resp = client.get("/api/v1/committees/owners/title/42/chapter/7")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title_number"] == 42
+    assert data["chapter_number"] == "7"
+    codes = [o["committee"]["committee_code"] for o in data["owners"]]
+    assert "house-ways-and-means" in codes
+    assert "senate-finance" in codes
+    assert "house-energy-and-commerce" not in codes
+    assert "senate-help" not in codes
+
+
+@patch("app.api.v1.committees.get_owners_for_chapter", new_callable=AsyncMock)
+def test_title_level_fallback_for_unknown_chapter(
+    mock_get: AsyncMock, client: TestClient
+) -> None:
+    """When no chapter-level override exists, falls back to title-level ownership."""
+    mock_get.return_value = [
+        _ownership(_HOUSE_ENERGY, 42, order=0),
+        _ownership(_SENATE_HELP, 42, order=1),
+    ]
+    resp = client.get("/api/v1/committees/owners/title/42/chapter/999")
+    assert resp.status_code == 200
+    data = resp.json()
+    codes = [o["committee"]["committee_code"] for o in data["owners"]]
+    assert "house-energy-and-commerce" in codes
+
+
+# ── GET /committees/congress/{congress}/owners ────────────────────────────────
+
+
+@patch("app.api.v1.committees.get_all_mappings", new_callable=AsyncMock)
+def test_all_owners_for_congress(mock_get: AsyncMock, client: TestClient) -> None:
+    """Returns all mappings for the given Congress."""
+    mock_get.return_value = [
+        _ownership(_HOUSE_JUDICIARY, 17),
+        _ownership(_SENATE_JUDICIARY, 17, order=1),
+    ]
+    resp = client.get("/api/v1/committees/congress/119/owners")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+
+
+# ── GET /committees/congress/{congress}/instances ─────────────────────────────
+
+
+@patch("app.api.v1.committees.get_congress_instances", new_callable=AsyncMock)
+def test_congress_instances(mock_get: AsyncMock, client: TestClient) -> None:
+    """Returns committee congress instances for the given Congress."""
+    mock_get.return_value = [
+        CommitteeCongressInstanceSchema(
+            committee_code="house-judiciary",
+            chamber="House",
+            official_name="Committee on the Judiciary",
+            congress=119,
+            rule_citation="House Rule X, Clause 1(l)",
+        )
+    ]
+    resp = client.get("/api/v1/committees/congress/119/instances")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["committee_code"] == "house-judiciary"
+    assert data[0]["rule_citation"] == "House Rule X, Clause 1(l)"
+
+
+@patch("app.api.v1.committees.get_congress_instances", new_callable=AsyncMock)
+def test_congress_instances_chamber_filter(
+    mock_get: AsyncMock, client: TestClient
+) -> None:
+    """chamber query param is forwarded to the CRUD function."""
+    mock_get.return_value = []
+    client.get("/api/v1/committees/congress/119/instances?chamber=Senate")
+    mock_get.assert_awaited_once()

--- a/backend/tests/pipeline/test_house_rules_parser.py
+++ b/backend/tests/pipeline/test_house_rules_parser.py
@@ -1,0 +1,164 @@
+"""Tests for the House Rules HMAN Rule X parser."""
+
+from pipeline.house_rules.parser import (
+    _lookup_committee_code,
+    _normalize_committee_name,
+    parse_rule_x,
+)
+
+# Minimal HMAN-style HTML fixture with two committees under Rule X.
+_RULE_X_FIXTURE = """
+<!DOCTYPE html>
+<html>
+<body>
+<p>RULE IX</p>
+<p>Some rule IX content.</p>
+<p>RULE X</p>
+<p>Committees and their legislative jurisdictions</p>
+<p>(a) Committee on Agriculture.</p>
+<p>(1) Adulteration of seeds, insect pests, and protection of birds and animals in forest reserves.</p>
+<p>(2) Agriculture generally.</p>
+<p>(3) Agricultural and industrial chemistry.</p>
+<p>(b) Committee on the Judiciary.</p>
+<p>(1) Bankruptcy, mutiny, espionage, and counterfeiting.</p>
+<p>(2) Civil and criminal judicial proceedings in general.</p>
+<p>(3) Federal courts and judges.</p>
+<p>(4) Immigration policy and non-border enforcement.</p>
+<p>(5) Patents, the Patent and Trademark Office, copyrights, and trademarks.</p>
+<p>RULE XI</p>
+<p>Some rule XI content — should not be parsed.</p>
+<p>(c) Committee on Appropriations.</p>
+</body>
+</html>
+"""
+
+_PERMANENT_SELECT_FIXTURE = """
+<!DOCTYPE html>
+<html>
+<body>
+<p>RULE X</p>
+<p>(a) Committee on Agriculture.</p>
+<p>(1) Agriculture generally.</p>
+<p>(k) Permanent Select Committee on Intelligence.</p>
+<p>(1) Intelligence and intelligence-related activities of all departments and agencies of the Government.</p>
+<p>(2) The Central Intelligence Agency, the Director of National Intelligence, and the National Intelligence Program.</p>
+<p>RULE XI</p>
+</body>
+</html>
+"""
+
+
+class TestNormalizeCommitteeName:
+    def test_strips_committee_on(self) -> None:
+        assert _normalize_committee_name("Committee on Agriculture") == "agriculture"
+
+    def test_strips_committee_on_the(self) -> None:
+        assert _normalize_committee_name("Committee on the Judiciary") == "judiciary"
+
+    def test_lowercase(self) -> None:
+        assert (
+            _normalize_committee_name("Committee on Ways and Means") == "ways and means"
+        )
+
+    def test_strips_trailing_period(self) -> None:
+        assert _normalize_committee_name("Committee on Rules.") == "rules"
+
+
+class TestLookupCommitteeCode:
+    def test_agriculture(self) -> None:
+        assert _lookup_committee_code("Agriculture") == "house-agriculture"
+
+    def test_judiciary(self) -> None:
+        assert _lookup_committee_code("the Judiciary") == "house-judiciary"
+
+    def test_ways_and_means(self) -> None:
+        assert _lookup_committee_code("Ways and Means") == "house-ways-and-means"
+
+    def test_historical_name_oversight(self) -> None:
+        assert (
+            _lookup_committee_code("Oversight and Government Reform")
+            == "house-oversight-and-accountability"
+        )
+
+    def test_historical_name_resources(self) -> None:
+        assert _lookup_committee_code("Resources") == "house-natural-resources"
+
+    def test_unknown_returns_none(self) -> None:
+        assert _lookup_committee_code("Completely Unknown Committee Name") is None
+
+    def test_permanent_select_intelligence(self) -> None:
+        assert (
+            _lookup_committee_code("Permanent Select Committee on Intelligence")
+            == "house-intelligence"
+        )
+
+
+class TestParseRuleX:
+    def test_returns_committees(self) -> None:
+        results = parse_rule_x(_RULE_X_FIXTURE)
+        assert (
+            len(results) == 2
+        )  # Agriculture and Judiciary (Appropriations is after Rule XI)
+
+    def test_agriculture_committee(self) -> None:
+        results = parse_rule_x(_RULE_X_FIXTURE)
+        ag = results[0]
+        assert "agriculture" in ag.committee_name.lower()
+        assert ag.committee_code == "house-agriculture"
+        assert ag.clause_letter == "a"
+        assert ag.rule_citation == "House Rule X, Clause 1(a)"
+
+    def test_agriculture_jurisdiction_items(self) -> None:
+        results = parse_rule_x(_RULE_X_FIXTURE)
+        ag = results[0]
+        assert len(ag.jurisdiction_items) == 3
+        assert "Agriculture generally" in ag.jurisdiction_items[1]
+
+    def test_judiciary_committee(self) -> None:
+        results = parse_rule_x(_RULE_X_FIXTURE)
+        jud = results[1]
+        assert jud.committee_code == "house-judiciary"
+        assert jud.clause_letter == "b"
+
+    def test_judiciary_has_five_items(self) -> None:
+        results = parse_rule_x(_RULE_X_FIXTURE)
+        jud = results[1]
+        assert len(jud.jurisdiction_items) == 5
+
+    def test_stops_at_rule_xi(self) -> None:
+        results = parse_rule_x(_RULE_X_FIXTURE)
+        codes = [r.committee_code for r in results]
+        assert "house-appropriations" not in codes
+
+    def test_no_rule_x_returns_empty(self) -> None:
+        results = parse_rule_x("<html><body><p>No rules here.</p></body></html>")
+        assert results == []
+
+    def test_jurisdiction_text_property(self) -> None:
+        results = parse_rule_x(_RULE_X_FIXTURE)
+        ag = results[0]
+        text = ag.jurisdiction_text
+        assert "(1)" in text
+        assert "Agriculture generally" in text
+
+    def test_permanent_select_intelligence(self) -> None:
+        results = parse_rule_x(_PERMANENT_SELECT_FIXTURE)
+        intel = next(
+            (r for r in results if r.committee_code == "house-intelligence"), None
+        )
+        assert intel is not None
+        assert len(intel.jurisdiction_items) == 2
+
+    def test_unknown_committee_name_code_is_none(self) -> None:
+        html = """
+        <html><body>
+        <p>RULE X</p>
+        <p>(z) Committee on Completely Unknown.</p>
+        <p>(1) Some jurisdiction.</p>
+        <p>RULE XI</p>
+        </body></html>
+        """
+        results = parse_rule_x(html)
+        assert len(results) == 1
+        assert results[0].committee_code is None
+        assert results[0].clause_letter == "z"

--- a/backend/tests/pipeline/test_house_rules_parser.py
+++ b/backend/tests/pipeline/test_house_rules_parser.py
@@ -69,7 +69,7 @@ class TestLookupCommitteeCode:
         assert _lookup_committee_code("Agriculture") == "house-agriculture"
 
     def test_judiciary(self) -> None:
-        assert _lookup_committee_code("the Judiciary") == "house-judiciary"
+        assert _lookup_committee_code("Committee on the Judiciary") == "house-judiciary"
 
     def test_ways_and_means(self) -> None:
         assert _lookup_committee_code("Ways and Means") == "house-ways-and-means"

--- a/research/TASK-0.15-Committee-Jurisdiction-Mapping.md
+++ b/research/TASK-0.15-Committee-Jurisdiction-Mapping.md
@@ -1,0 +1,293 @@
+# Task 0.15: Congressional Committee Jurisdiction Mapping
+
+**Task**: Map House/Senate committees to US Code titles/chapters for the "CODEOWNERS" metaphor
+**Status**: Complete
+**Date**: 2026.05.19
+**GitHub Issue**: #302
+
+---
+
+## Executive Summary
+
+Congressional committees have jurisdiction over specific areas of federal law, making them the natural analogue for CODEOWNERS in the CWLB version-control metaphor. This document maps House and Senate committees to the 8 Phase 1 US Code titles, answers key design questions about granularity and overlap, and proposes a CODEOWNERS file format for the platform.
+
+**Key findings:**
+- 7 of 8 Phase 1 titles have clear **Title-level** jurisdiction assigned to a single primary committee pair
+- **Title 42 (Public Health and Welfare)** is the significant exception — jurisdiction splits at the **Chapter level** across three committees per chamber
+- **Title 50** has an additional **Intelligence committee** layer for chapters covering surveillance and intelligence authorities
+- Overlapping jurisdiction is handled by convention (primary/secondary designations) and formal referral procedures
+
+---
+
+## Recommended CODEOWNERS Format
+
+Using a path structure that mirrors the US Code hierarchy (`/title-NN/chapter-NN/section-NNNN`), the OWNERS mapping for Phase 1 titles would look like:
+
+```
+# CODEOWNERS — Congressional Committee Jurisdiction
+# Format: <path pattern>  <house-committee>  <senate-committee>
+# Overlapping jurisdiction listed left-to-right: primary first
+
+/title-10/    @house/armed-services          @senate/armed-services
+/title-17/    @house/judiciary               @senate/judiciary
+/title-18/    @house/judiciary               @senate/judiciary
+/title-20/    @house/education-and-workforce  @senate/help
+/title-22/    @house/foreign-affairs          @senate/foreign-relations
+/title-26/    @house/ways-and-means           @senate/finance
+
+# Title 42 splits at chapter level — overrides follow general rule
+/title-42/                      @house/energy-and-commerce        @senate/help
+/title-42/chapter-6a/           @house/energy-and-commerce        @senate/help
+/title-42/chapter-7/            @house/ways-and-means             @senate/finance
+/title-42/chapter-8/            @house/ways-and-means             @senate/finance
+
+# Title 50 — Armed Services primary; Intel committees have oversight authority
+/title-50/                      @house/armed-services             @senate/armed-services
+/title-50/chapter-44/           @house/intelligence               @senate/intelligence
+/title-50/chapter-36/           @house/intelligence @house/judiciary  @senate/intelligence @senate/judiciary
+```
+
+---
+
+## Design Questions Answered
+
+### Q1: Is jurisdiction at Title level or Chapter level?
+
+**Mostly Title level, with one major exception.**
+
+For 7 of 8 Phase 1 titles, a single committee pair holds comprehensive jurisdiction and no meaningful Chapter-level splits exist:
+
+| Title | Granularity | Notes |
+|-------|-------------|-------|
+| 10 — Armed Forces | Title | Armed Services has complete authority |
+| 17 — Copyrights | Title | Judiciary handles all IP law |
+| 18 — Crimes | Title | Judiciary handles all criminal law |
+| 20 — Education | Title | Education & Workforce / HELP |
+| 22 — Foreign Relations | Title | Foreign Affairs / Foreign Relations |
+| 26 — Internal Revenue Code | Title | Ways and Means / Finance (with House origination authority under Constitution Art. I §7) |
+| 50 — War and National Defense | Title (with chapter carve-outs) | Armed Services primary; Intelligence committees for Chapters 36 and 44 |
+
+**Title 42 requires Chapter-level mapping** because it contains fundamentally different program types with separate funding mechanisms, which Congress has historically assigned to different committees:
+
+| Title 42 Chapter | Subject | House | Senate |
+|-----------------|---------|-------|--------|
+| Chapter 6A | Public Health Service Act (CDC, NIH, FDA) | Energy and Commerce | HELP |
+| Chapter 7 | Social Security Act (Medicare, Medicaid, CHIP, TANF) | Ways and Means | Finance |
+| Chapter 8 | Housing programs | Financial Services | Banking |
+| Chapter 21 (Civil Rights) | Civil rights enforcement | Judiciary | Judiciary |
+| Chapters 67–136 (misc.) | Welfare, community, environment programs | Energy and Commerce / Oversight | HELP / Finance (split) |
+
+### Q2: How to handle overlapping jurisdiction?
+
+Three patterns appear in practice:
+
+**Pattern A — Primary/Secondary designation** (most common for Phase 1 titles)
+One committee is clearly primary; a second committee may claim secondary authority. Display the primary committee as the OWNER, list the secondary committee as a reviewer. Example: Title 18 criminal justice reform may also be referred to Homeland Security committee, but Judiciary is the clear primary.
+
+**Pattern B — Sequential referral** (Title 42 / complex legislation)
+When a bill amends multiple chapters under different committee jurisdictions, Congress refers it sequentially (or simultaneously) to each committee. The CODEOWNERS file reflects this by mapping at Chapter granularity.
+
+**Pattern C — Intelligence oversight overlay** (Title 50)
+Intelligence committees (Select Committee on Intelligence in both chambers) maintain oversight authority over Title 50 chapters governing surveillance and intelligence community authorities, in addition to Armed Services. Model this as a secondary owner at the chapter level.
+
+**Recommended display convention:** When multiple committees are listed for the same path, render the first as "Primary" and subsequent entries as "Also reviews." This matches how GitHub renders CODEOWNERS when multiple teams are listed.
+
+### Q3: What metadata to include?
+
+For each committee entry, the recommended metadata fields:
+
+| Field | Example | Notes |
+|-------|---------|-------|
+| `committee_id` | `house-judiciary` | Stable slug for linking |
+| `full_name` | `House Committee on the Judiciary` | Official name |
+| `chamber` | `House` | House or Senate |
+| `jurisdiction_type` | `primary` | primary / secondary / oversight |
+| `authority_rule` | `House Rule X, Clause 1(l)` | Formal rule citation |
+| `website` | `https://judiciary.house.gov/` | Current URL |
+| `codeowners_path` | `/title-17/` | Path pattern this entry covers |
+
+Chair/membership data changes each Congress; **do not hardcode** in the mapping table. Link to `congress.gov/committees/<id>` for current membership.
+
+---
+
+## Phase 1 Committee Mapping Table
+
+### Title 10 — Armed Forces
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on Armed Services | Committee on Armed Services |
+| **Rule** | House Rule X, Clause 1(c) | Senate Rule XXV, Clause 1(d) |
+| **Key subcommittee** | Military Personnel; Readiness; Strategic Forces | Personnel; Readiness and Management Support |
+| **Jurisdiction level** | Title | Title |
+| **Annual vehicle** | National Defense Authorization Act (NDAA) | National Defense Authorization Act (NDAA) |
+| **Website** | armedservices.house.gov | armed-services.senate.gov |
+
+### Title 17 — Copyrights
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on the Judiciary | Committee on the Judiciary |
+| **Rule** | House Rule X, Clause 1(l) — patents, copyrights, trademarks | Senate Rule XXV, Clause 1(j) — patents, copyrights |
+| **Key subcommittee** | Courts, Intellectual Property, Artificial Intelligence, and the Internet | Intellectual Property Subcommittee |
+| **Jurisdiction level** | Title | Title |
+| **Note** | Revenue bills for copyright fees originate in House (Art. I §7) | |
+| **Website** | judiciary.house.gov | judiciary.senate.gov |
+
+### Title 18 — Crimes and Criminal Procedure
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on the Judiciary | Committee on the Judiciary |
+| **Rule** | House Rule X, Clause 1(l) — criminal law, administration of justice | Senate Rule XXV, Clause 1(j) — federal courts, criminal law |
+| **Key subcommittee** | Crime, Terrorism and Homeland Security | Crime and Counterterrorism (oversees DOJ, FBI, DEA, ATF) |
+| **Jurisdiction level** | Title | Title |
+| **Secondary referral** | Homeland Security (for terrorism-related amendments) | Homeland Security (for terrorism-related amendments) |
+| **Website** | judiciary.house.gov | judiciary.senate.gov |
+
+### Title 20 — Education
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on Education and the Workforce | Committee on Health, Education, Labor & Pensions (HELP) |
+| **Rule** | House Rule X, Clause 1(f) | Senate Rule XXV, Clause 1(g) |
+| **Key subcommittee** | Higher Education and Workforce Development | Education Subcommittee |
+| **Jurisdiction level** | Title | Title |
+| **Annual vehicle** | Reauthorizations (ESEA, HEA) | Reauthorizations (ESEA, HEA) |
+| **Website** | edworkforce.house.gov | help.senate.gov |
+
+### Title 22 — Foreign Relations and Intercourse
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on Foreign Affairs | Committee on Foreign Relations |
+| **Rule** | House Rule X, Clause 1(i) — foreign affairs, foreign assistance | Senate Rule XXV, Clause 1(h) — foreign relations, treaties |
+| **Key subcommittee** | East Asia and the Pacific; Western Hemisphere; Europe | Regional subcommittees |
+| **Jurisdiction level** | Title | Title |
+| **Special authority** | Foreign Affairs oversees executive war powers; Foreign Relations ratifies treaties (2/3 majority) | |
+| **Website** | foreignaffairs.house.gov | foreign.senate.gov |
+
+### Title 26 — Internal Revenue Code
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on Ways and Means | Committee on Finance |
+| **Rule** | House Rule X, Clause 1(s) + Art. I §7 (all revenue bills originate in House) | Senate Rule XXV, Clause 1(f) |
+| **Key subcommittee** | Tax Subcommittee | Taxation and IRS Oversight Subcommittee |
+| **Jurisdiction level** | Title | Title |
+| **Special authority** | Constitutional origination — the House always drafts the initial revenue bill | Senate amends or replaces House-passed bills |
+| **Website** | waysandmeans.house.gov | finance.senate.gov |
+
+### Title 42 — The Public Health and Welfare *(Chapter-level split)*
+
+This title encompasses programs with fundamentally different funding mechanisms, historically divided across committees:
+
+#### Programs financed by trust funds / appropriations (Medicare, Medicaid, CHIP, TANF)
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on Ways and Means | Committee on Finance |
+| **Primary chapters** | Chapter 7 (Social Security Act) | Chapter 7 (Social Security Act) |
+| **Key sections** | §§ 1395–1396 (Medicare/Medicaid), § 601 (TANF) | Same |
+| **Website** | waysandmeans.house.gov | finance.senate.gov |
+
+#### Public health agencies and health regulation (CDC, NIH, FDA, ACA marketplace)
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on Energy and Commerce | Committee on Health, Education, Labor & Pensions (HELP) |
+| **Primary chapters** | Chapter 6A (Public Health Service Act) | Chapter 6A (Public Health Service Act) |
+| **Key sections** | §§ 201–300 (PHS Act), ACA Title I market rules | Same |
+| **Website** | energycommerce.house.gov | help.senate.gov |
+
+#### Civil rights and anti-discrimination provisions
+
+| | House | Senate |
+|-|-------|--------|
+| **Committee** | Committee on the Judiciary | Committee on the Judiciary |
+| **Primary chapters** | Chapter 21 (Civil Rights Act provisions) | Chapter 21 |
+
+#### Summary — Title 42 CODEOWNERS paths
+
+| Path | House Primary | Senate Primary |
+|------|--------------|----------------|
+| `/title-42/` (default) | Energy and Commerce | HELP |
+| `/title-42/chapter-7/` | Ways and Means | Finance |
+| `/title-42/chapter-6a/` | Energy and Commerce | HELP |
+| `/title-42/chapter-21/` | Judiciary | Judiciary |
+
+### Title 50 — War and National Defense
+
+| | House | Senate |
+|-|-------|--------|
+| **Primary committee** | Committee on Armed Services | Committee on Armed Services |
+| **Rule** | House Rule X, Clause 1(c) — national security, defense policy | Senate Rule XXV, Clause 1(d) |
+| **Jurisdiction level** | Title (with chapter carve-outs for intelligence) | Title (with chapter carve-outs) |
+
+**Intelligence committee overlay:**
+
+| Chapter | Subject | Additional Oversight |
+|---------|---------|---------------------|
+| Chapter 36 (§§ 1801–1885, FISA) | Foreign Intelligence Surveillance | House & Senate Intelligence committees + Judiciary |
+| Chapter 44 (§§ 3001–3236, National Security Act) | Intelligence community organization | House & Senate Intelligence committees (Select) |
+
+The Select Intelligence committees in both chambers have exclusive jurisdiction over intelligence community programs and budgets. Armed Services maintains primary authority over defense programs and war powers.
+
+---
+
+## Granularity Recommendation for Phase 1
+
+For the CWLB CODEOWNERS implementation:
+
+1. **Start at Title level** for all 8 titles — this is correct for 7 of 8 and provides a clean initial mapping
+2. **Add Chapter-level entries for Title 42** from day one — the split is significant enough that users will expect it
+3. **Add Chapter-level entries for Title 50 Chapters 36 and 44** — FISA and the National Security Act are high-profile enough to warrant precise attribution
+4. **Defer subcommittee-level granularity** to Phase 2 — subcommittees shift more frequently and add complexity without proportional user value
+
+---
+
+## Data Sources and Authority References
+
+| Source | Type | URL |
+|--------|------|-----|
+| House Rule X | Authoritative — committee jurisdiction rules | govinfo.gov/content/pkg/HMAN-119 |
+| Senate Rule XXV | Authoritative — committee jurisdiction rules | senate.gov/pagelayout/reference/two_column_table/Senate_Rules.htm |
+| Congress.gov Committees | Reference — current membership and subcommittees | congress.gov/committees |
+| House.gov Committees | Reference — committee websites and jurisdiction descriptions | house.gov/committees |
+| CRS Report R46251 | Background — committee referral procedures in the House | congress.gov/crs-product/R46251 |
+| CRS Report R46815 | Background — committee referral procedures in the Senate | congress.gov/crs-product/R46815 |
+
+**Note on chair/membership data:** Committee chairs and membership change each Congress (and sometimes mid-Congress). Do not store chair names in the mapping table; instead link to `congress.gov/committees/<committee-id>` for live data. The jurisdiction rules (House Rule X, Senate Rule XXV) are far more stable.
+
+---
+
+## Implementation Notes for Phase 1
+
+### OWNERS file placement
+
+Following the CWLB repository metaphor where titles are directories, place CODEOWNERS-style files as:
+
+```
+/CODEOWNERS              ← root-level: maps all title paths
+/title-42/CODEOWNERS     ← chapter-level overrides for Title 42
+/title-50/CODEOWNERS     ← chapter-level overrides for Title 50
+```
+
+### Display in UI
+
+When rendering a US Code section (e.g., 17 USC § 106), the "Owners" panel should show:
+- Committee name with link to `congress.gov/committees/<id>`
+- Chamber badge (House / Senate)
+- Jurisdiction type (Primary / Secondary / Oversight)
+
+For sections under split jurisdiction (Title 42 Chapter 7), show both Finance (primary) and HELP (secondary, if applicable to that specific section's subject matter).
+
+### Future work (Phase 2+)
+
+- **Subcommittee mapping**: Map specific subcommittees to US Code chapters for deeper attribution
+- **Historical jurisdiction**: Committees are renamed and restructured between Congresses; track historical names for accurate attribution on older laws
+- **Bill referral data**: Congress.gov API exposes which committees received each bill — use this to validate and refine the mapping empirically rather than relying solely on formal jurisdiction rules
+
+---
+
+*Document prepared as part of CWLB Phase 0 Research & Validation*

--- a/research/TASK-0.15-Committee-Jurisdiction-Mapping.md
+++ b/research/TASK-0.15-Committee-Jurisdiction-Mapping.md
@@ -18,6 +18,10 @@ Congressional committees have jurisdiction over specific areas of federal law, m
 - **Title 52** and **Title 2** involve House/Senate Administration committees in addition to Judiciary/Rules
 - Overlapping jurisdiction is handled by convention (primary/secondary designations) and formal referral procedures
 
+**Important data model implications (discovered during research):**
+1. **Committee assignments are per-Congress.** Rule X is re-adopted at the start of each Congress and committees are renamed, merged, or restructured (e.g., Homeland Security added in 109th Congress; Intelligence moved from rule XLVIII to rule X clause 11 in 106th). Any data model must key committee records to a congress number.
+2. **Rule X does not reference the US Code.** Jurisdictions are expressed as legislative topics ("adulteration of seeds, insect pests", "commodity exchanges") — never as US Code title or section numbers. The mapping from Rule X language → US Code paths is a **human-authored curation layer** that must be maintained separately. See the [Data Model](#data-model-implications) section below.
+
 ---
 
 ## Design Questions Answered
@@ -433,18 +437,105 @@ For the CWLB CODEOWNERS implementation:
 
 ---
 
+## Data Model Implications
+
+### Problem: two separate concerns
+
+The CODEOWNERS metaphor requires resolving two distinct questions:
+
+1. **What does each committee claim jurisdiction over?** (Rule X text — per-Congress, prose format)
+2. **Which US Code paths correspond to those claims?** (Curated mapping — stable, structured)
+
+These must be stored separately. Conflating them creates a mess when Rule X changes or when committees are renamed.
+
+### Proposed schema
+
+```sql
+-- One row per committee per Congress.
+-- Committee names and jurisdiction claims change with each Congress adoption of rules.
+CREATE TABLE congressional_committee (
+    id              SERIAL PRIMARY KEY,
+    congress        INTEGER NOT NULL,           -- 106, 107, …, 119
+    chamber         TEXT NOT NULL,              -- 'house' | 'senate'
+    committee_id    TEXT NOT NULL,              -- stable slug, e.g. 'judiciary'
+    full_name       TEXT NOT NULL,              -- official name for that Congress
+    rule_citation   TEXT,                       -- 'House Rule X, Clause 1(l)'
+    jurisdiction_text TEXT,                     -- raw prose from Rule X / Rule XXV
+    source_url      TEXT,                       -- GovInfo HTM URL for this Congress
+    UNIQUE (congress, chamber, committee_id)
+);
+
+-- Human-curated mapping from a committee → US Code path.
+-- This is the bridge between Rule X prose and the code tree.
+CREATE TABLE committee_usc_mapping (
+    id                  SERIAL PRIMARY KEY,
+    committee_id        TEXT NOT NULL,          -- FK slug into congressional_committee
+    congress_start      INTEGER NOT NULL,       -- first Congress this mapping applies
+    congress_end        INTEGER,                -- NULL = still current
+    usc_title           INTEGER NOT NULL,
+    usc_chapter         TEXT,                   -- NULL = Title-level; e.g. '6a', '7'
+    jurisdiction_type   TEXT NOT NULL,          -- 'primary' | 'secondary' | 'oversight'
+    notes               TEXT                    -- reason for this mapping / split
+);
+```
+
+### Data pipeline
+
+Rule X is available as parsed HTM for every Congress from 106 onward:
+
+```
+https://www.govinfo.gov/content/pkg/HMAN-{congress}/html/HMAN-{congress}-houserules.htm
+```
+
+The HTM is parseable but the jurisdiction text is **prose** — not structured data. A pipeline approach:
+
+1. **Fetch** the HMAN HTM for each Congress from GovInfo (available 106–119)
+2. **Extract** each committee's numbered jurisdiction items by parsing the `(a) Committee on X` sections under Rule X
+3. **Store** raw jurisdiction text in `congressional_committee.jurisdiction_text` — no interpretation yet
+4. **Curate** `committee_usc_mapping` manually (or with LLM assistance) for each new Congress, diffing against the prior Congress to identify changed/added jurisdictions
+5. **Audit** by cross-referencing against `LawChange` bill-referral data from the Congress.gov API
+
+Step 4 is inherently a human judgment call. The mapping from "adulteration of seeds, insect pests, and protection of birds and animals in forest reserves" → `Title 7` requires interpreting legislative intent that no automated system can resolve cleanly. The curated table is the authoritative artifact.
+
+### Change cadence
+
+Rule X changes are infrequent between Congresses for most committees. Based on historical patterns:
+- **Stable** (rarely changed): Agriculture, Judiciary, Ways and Means, Foreign Affairs, Armed Services, Veterans' Affairs, Natural Resources
+- **Occasionally restructured**: Energy and Commerce, Transportation and Infrastructure
+- **Frequently renamed/reorganized**: Oversight (renamed multiple times), Science/Space/Technology, Homeland Security (added 109th Congress)
+
+A diff of `committee_usc_mapping` between consecutive Congresses is the right tool for tracking what changed.
+
+---
+
 ## Data Sources
 
 | Source | Type | Notes |
 |--------|------|-------|
-| House Rule X | Authoritative — committee jurisdiction rules | govinfo.gov/content/pkg/HMAN-119 |
-| Senate Rule XXV | Authoritative — committee jurisdiction rules | senate.gov/pagelayout/reference/two_column_table/Senate_Rules.htm |
+| GovInfo HMAN HTM | **Authoritative, machine-readable** | `govinfo.gov/content/pkg/HMAN-{congress}/html/HMAN-{congress}-houserules.htm` — available for all Congresses 106–119 |
+| rules.house.gov prior Congresses | Index page | `rules.house.gov/resources/rules-and-manuals-house-prior-congresses` — links to PDFs and GovInfo |
+| Senate Rule XXV | Authoritative — Senate jurisdiction rules | `senate.gov/pagelayout/reference/two_column_table/Senate_Rules.htm` |
 | Congress.gov Committees | Reference — current membership and subcommittees | congress.gov/committees |
-| House.gov Committees | Reference — committee websites and jurisdiction summaries | house.gov/committees |
-| CRS Report R46251 | Background — committee referral procedures in the House | congress.gov/crs-product/R46251 |
-| CRS Report R46815 | Background — committee referral procedures in the Senate | congress.gov/crs-product/R46815 |
+| Congress.gov API — bill committees | Empirical validation source | `/bill/{congress}/{type}/{number}/committees` — which committees received each bill |
+| CRS Report R46251 | Background — referral procedures in the House | congress.gov/crs-product/R46251 |
+| CRS Report R46815 | Background — referral procedures in the Senate | congress.gov/crs-product/R46815 |
 
-**Note on chair/membership data:** Committee chairs and membership change each Congress. Store only committee names and Rule citations in the mapping; link to `congress.gov/committees/<committee-id>` for live membership data.
+**Rule X text sample (119th Congress, Committee on Agriculture):**
+
+```
+(a) Committee on Agriculture.
+  (1) Adulteration of seeds, insect pests, and protection of birds and animals in forest reserves.
+  (2) Agriculture generally.
+  (3) Agricultural and industrial chemistry.
+  ...
+  (14) Inspection of livestock, poultry, meat products, and seafood and seafood products.
+  (15) Forestry in general and forest reserves other than those created from the public domain.
+  ...
+```
+
+This is the raw form of the data — topic descriptions only, no US Code citations. The `committee_usc_mapping` table is the authored layer that translates these into paths like `/title-7/`.
+
+**Note on chair/membership:** Committee chairs change each Congress and sometimes mid-Congress. Never hardcode them. Link to `congress.gov/committees/<committee-id>` for live data.
 
 ---
 

--- a/research/TASK-0.15-Committee-Jurisdiction-Mapping.md
+++ b/research/TASK-0.15-Committee-Jurisdiction-Mapping.md
@@ -1,6 +1,6 @@
 # Task 0.15: Congressional Committee Jurisdiction Mapping
 
-**Task**: Map House/Senate committees to US Code titles/chapters for the "CODEOWNERS" metaphor
+**Task**: Map House/Senate committees to US Code titles and chapters for the "CODEOWNERS" metaphor
 **Status**: Complete
 **Date**: 2026.05.19
 **GitHub Issue**: #302
@@ -9,43 +9,14 @@
 
 ## Executive Summary
 
-Congressional committees have jurisdiction over specific areas of federal law, making them the natural analogue for CODEOWNERS in the CWLB version-control metaphor. This document maps House and Senate committees to the 8 Phase 1 US Code titles, answers key design questions about granularity and overlap, and proposes a CODEOWNERS file format for the platform.
+Congressional committees have jurisdiction over specific areas of federal law, making them the natural analogue for CODEOWNERS in the CWLB version-control metaphor. This document maps House and Senate committees to all 54 US Code titles, answers key design questions about granularity and overlap, and proposes a CODEOWNERS file format for the platform.
 
 **Key findings:**
-- 7 of 8 Phase 1 titles have clear **Title-level** jurisdiction assigned to a single primary committee pair
-- **Title 42 (Public Health and Welfare)** is the significant exception — jurisdiction splits at the **Chapter level** across three committees per chamber
-- **Title 50** has an additional **Intelligence committee** layer for chapters covering surveillance and intelligence authorities
+- Most titles have clear **Title-level** jurisdiction assigned to a single committee pair
+- **Title 21, 31, and 42** require **Chapter-level** splits due to program-type differences
+- **Title 50** has an additional Intelligence committee layer for FISA and intelligence community chapters
+- **Title 52** and **Title 2** involve House/Senate Administration committees in addition to Judiciary/Rules
 - Overlapping jurisdiction is handled by convention (primary/secondary designations) and formal referral procedures
-
----
-
-## Recommended CODEOWNERS Format
-
-Using a path structure that mirrors the US Code hierarchy (`/title-NN/chapter-NN/section-NNNN`), the OWNERS mapping for Phase 1 titles would look like:
-
-```
-# CODEOWNERS — Congressional Committee Jurisdiction
-# Format: <path pattern>  <house-committee>  <senate-committee>
-# Overlapping jurisdiction listed left-to-right: primary first
-
-/title-10/    @house/armed-services          @senate/armed-services
-/title-17/    @house/judiciary               @senate/judiciary
-/title-18/    @house/judiciary               @senate/judiciary
-/title-20/    @house/education-and-workforce  @senate/help
-/title-22/    @house/foreign-affairs          @senate/foreign-relations
-/title-26/    @house/ways-and-means           @senate/finance
-
-# Title 42 splits at chapter level — overrides follow general rule
-/title-42/                      @house/energy-and-commerce        @senate/help
-/title-42/chapter-6a/           @house/energy-and-commerce        @senate/help
-/title-42/chapter-7/            @house/ways-and-means             @senate/finance
-/title-42/chapter-8/            @house/ways-and-means             @senate/finance
-
-# Title 50 — Armed Services primary; Intel committees have oversight authority
-/title-50/                      @house/armed-services             @senate/armed-services
-/title-50/chapter-44/           @house/intelligence               @senate/intelligence
-/title-50/chapter-36/           @house/intelligence @house/judiciary  @senate/intelligence @senate/judiciary
-```
 
 ---
 
@@ -53,48 +24,33 @@ Using a path structure that mirrors the US Code hierarchy (`/title-NN/chapter-NN
 
 ### Q1: Is jurisdiction at Title level or Chapter level?
 
-**Mostly Title level, with one major exception.**
+**Mostly Title level, with three significant exceptions.**
 
-For 7 of 8 Phase 1 titles, a single committee pair holds comprehensive jurisdiction and no meaningful Chapter-level splits exist:
+| Title | Granularity | Reason for split |
+|-------|-------------|-----------------|
+| 21 — Food and Drugs | Chapter | FDA (Energy and Commerce / HELP) vs. USDA food safety (Agriculture / Agriculture) |
+| 31 — Money and Finance | Chapter | Treasury/currency operations (Financial Services / Banking) vs. debt/fiscal policy (Ways and Means / Finance) |
+| 42 — Public Health and Welfare | Chapter | Medicare/Medicaid (Ways and Means / Finance) vs. public health agencies (Energy and Commerce / HELP) vs. civil rights (Judiciary / Judiciary) |
+| 50 — War and National Defense | Title + chapter overrides | Armed Services primary; Intelligence committees for FISA (Ch. 36) and National Security Act (Ch. 44) |
 
-| Title | Granularity | Notes |
-|-------|-------------|-------|
-| 10 — Armed Forces | Title | Armed Services has complete authority |
-| 17 — Copyrights | Title | Judiciary handles all IP law |
-| 18 — Crimes | Title | Judiciary handles all criminal law |
-| 20 — Education | Title | Education & Workforce / HELP |
-| 22 — Foreign Relations | Title | Foreign Affairs / Foreign Relations |
-| 26 — Internal Revenue Code | Title | Ways and Means / Finance (with House origination authority under Constitution Art. I §7) |
-| 50 — War and National Defense | Title (with chapter carve-outs) | Armed Services primary; Intelligence committees for Chapters 36 and 44 |
-
-**Title 42 requires Chapter-level mapping** because it contains fundamentally different program types with separate funding mechanisms, which Congress has historically assigned to different committees:
-
-| Title 42 Chapter | Subject | House | Senate |
-|-----------------|---------|-------|--------|
-| Chapter 6A | Public Health Service Act (CDC, NIH, FDA) | Energy and Commerce | HELP |
-| Chapter 7 | Social Security Act (Medicare, Medicaid, CHIP, TANF) | Ways and Means | Finance |
-| Chapter 8 | Housing programs | Financial Services | Banking |
-| Chapter 21 (Civil Rights) | Civil rights enforcement | Judiciary | Judiciary |
-| Chapters 67–136 (misc.) | Welfare, community, environment programs | Energy and Commerce / Oversight | HELP / Finance (split) |
+All other titles can be mapped at the Title level with a single primary committee pair.
 
 ### Q2: How to handle overlapping jurisdiction?
 
 Three patterns appear in practice:
 
-**Pattern A — Primary/Secondary designation** (most common for Phase 1 titles)
-One committee is clearly primary; a second committee may claim secondary authority. Display the primary committee as the OWNER, list the secondary committee as a reviewer. Example: Title 18 criminal justice reform may also be referred to Homeland Security committee, but Judiciary is the clear primary.
+**Pattern A — Primary/Secondary designation** (most common)
+One committee is clearly primary; a second may claim secondary authority. Display the primary committee as the OWNER, list the secondary as a reviewer. Example: Title 18 criminal justice reform may also be referred to Homeland Security, but Judiciary is the clear primary.
 
-**Pattern B — Sequential referral** (Title 42 / complex legislation)
-When a bill amends multiple chapters under different committee jurisdictions, Congress refers it sequentially (or simultaneously) to each committee. The CODEOWNERS file reflects this by mapping at Chapter granularity.
+**Pattern B — Sequential referral** (Titles 21, 31, 42)
+When a bill amends chapters under different committee jurisdictions, Congress refers it sequentially (or simultaneously) to each committee. The CODEOWNERS file reflects this by mapping at Chapter granularity.
 
 **Pattern C — Intelligence oversight overlay** (Title 50)
-Intelligence committees (Select Committee on Intelligence in both chambers) maintain oversight authority over Title 50 chapters governing surveillance and intelligence community authorities, in addition to Armed Services. Model this as a secondary owner at the chapter level.
+Intelligence committees maintain oversight authority over chapters governing surveillance and intelligence community authorities, in addition to Armed Services. Model this as a secondary owner at the chapter level.
 
-**Recommended display convention:** When multiple committees are listed for the same path, render the first as "Primary" and subsequent entries as "Also reviews." This matches how GitHub renders CODEOWNERS when multiple teams are listed.
+**Recommended display convention:** When multiple committees are listed for the same path, render the first as "Primary" and subsequent entries as "Also reviews."
 
 ### Q3: What metadata to include?
-
-For each committee entry, the recommended metadata fields:
 
 | Field | Example | Notes |
 |-------|---------|-------|
@@ -106,11 +62,217 @@ For each committee entry, the recommended metadata fields:
 | `website` | `https://judiciary.house.gov/` | Current URL |
 | `codeowners_path` | `/title-17/` | Path pattern this entry covers |
 
-Chair/membership data changes each Congress; **do not hardcode** in the mapping table. Link to `congress.gov/committees/<id>` for current membership.
+**Do not hardcode chair/membership data** — it changes each Congress. Link to `congress.gov/committees/<id>` for current membership.
 
 ---
 
-## Phase 1 Committee Mapping Table
+## Complete CODEOWNERS Format
+
+```
+# CODEOWNERS — Congressional Committee Jurisdiction
+# Format: <path pattern>  <house-committee>  <senate-committee>
+# Multiple owners listed left-to-right: primary first, then secondary/oversight
+
+# ── Government Operations ──────────────────────────────────────────────────
+/title-1/     @house/judiciary                              @senate/judiciary
+/title-2/     @house/administration                         @senate/rules-and-administration
+/title-3/     @house/oversight-and-accountability           @senate/homeland-security-governmental-affairs
+/title-4/     @house/judiciary                              @senate/judiciary
+/title-5/     @house/oversight-and-accountability           @senate/homeland-security-governmental-affairs
+/title-6/     @house/homeland-security                      @senate/homeland-security-governmental-affairs
+/title-13/    @house/oversight-and-accountability           @senate/homeland-security-governmental-affairs
+/title-39/    @house/oversight-and-accountability           @senate/homeland-security-governmental-affairs
+/title-40/    @house/transportation-and-infrastructure      @senate/environment-and-public-works
+/title-41/    @house/oversight-and-accountability           @senate/homeland-security-governmental-affairs
+/title-44/    @house/administration                         @senate/rules-and-administration
+
+# ── Judiciary and Law ──────────────────────────────────────────────────────
+/title-8/     @house/judiciary                              @senate/judiciary
+/title-9/     @house/judiciary                              @senate/judiciary
+/title-11/    @house/judiciary                              @senate/judiciary
+/title-17/    @house/judiciary                              @senate/judiciary
+/title-18/    @house/judiciary                              @senate/judiciary
+/title-27/    @house/judiciary @house/energy-and-commerce   @senate/judiciary @senate/commerce
+/title-28/    @house/judiciary                              @senate/judiciary
+/title-34/    @house/judiciary                              @senate/judiciary
+/title-35/    @house/judiciary                              @senate/judiciary
+/title-36/    @house/judiciary                              @senate/judiciary
+
+# ── Armed Forces and National Defense ─────────────────────────────────────
+/title-10/    @house/armed-services                         @senate/armed-services
+/title-32/    @house/armed-services                         @senate/armed-services
+/title-37/    @house/armed-services                         @senate/armed-services
+/title-50/    @house/armed-services                         @senate/armed-services
+/title-50/chapter-36/   @house/intelligence @house/judiciary    @senate/intelligence @senate/judiciary
+/title-50/chapter-44/   @house/intelligence                  @senate/intelligence
+
+# ── Agriculture and Food ───────────────────────────────────────────────────
+/title-7/     @house/agriculture                            @senate/agriculture-nutrition-forestry
+/title-21/    @house/energy-and-commerce @house/agriculture  @senate/help @senate/agriculture-nutrition-forestry
+/title-21/chapter-1/    @house/agriculture                   @senate/agriculture-nutrition-forestry
+/title-21/chapter-9/    @house/energy-and-commerce           @senate/help
+/title-21/chapter-13/   @house/energy-and-commerce @house/judiciary  @senate/help @senate/judiciary
+
+# ── Commerce, Banking, and Trade ──────────────────────────────────────────
+/title-12/    @house/financial-services                     @senate/banking-housing-urban-affairs
+/title-15/    @house/energy-and-commerce                    @senate/commerce-science-transportation
+/title-19/    @house/ways-and-means                         @senate/finance
+/title-47/    @house/energy-and-commerce                    @senate/commerce-science-transportation
+
+# ── Taxation and Finance ───────────────────────────────────────────────────
+/title-26/    @house/ways-and-means                         @senate/finance
+/title-31/    @house/financial-services @house/ways-and-means  @senate/banking-housing-urban-affairs @senate/finance
+/title-31/chapter-3/    @house/ways-and-means               @senate/finance
+/title-31/chapter-5/    @house/financial-services            @senate/banking-housing-urban-affairs
+/title-31/chapter-31/   @house/ways-and-means                @senate/finance
+
+# ── Foreign Affairs ────────────────────────────────────────────────────────
+/title-22/    @house/foreign-affairs                        @senate/foreign-relations
+
+# ── Education and Labor ────────────────────────────────────────────────────
+/title-20/    @house/education-and-workforce                 @senate/help
+/title-29/    @house/education-and-workforce                 @senate/help
+
+# ── Public Health and Welfare — Chapter-level split ───────────────────────
+/title-42/                  @house/energy-and-commerce           @senate/help
+/title-42/chapter-6a/       @house/energy-and-commerce           @senate/help
+/title-42/chapter-7/        @house/ways-and-means                @senate/finance
+/title-42/chapter-8/        @house/financial-services            @senate/banking-housing-urban-affairs
+/title-42/chapter-21/       @house/judiciary                     @senate/judiciary
+
+# ── Natural Resources and Environment ─────────────────────────────────────
+/title-16/    @house/natural-resources                      @senate/energy-and-natural-resources
+/title-25/    @house/natural-resources                      @senate/indian-affairs
+/title-30/    @house/natural-resources                      @senate/energy-and-natural-resources
+/title-43/    @house/natural-resources                      @senate/energy-and-natural-resources
+/title-48/    @house/natural-resources                      @senate/energy-and-natural-resources
+/title-54/    @house/natural-resources                      @senate/energy-and-natural-resources
+
+# ── Transportation and Infrastructure ─────────────────────────────────────
+/title-14/    @house/transportation-and-infrastructure       @senate/commerce-science-transportation
+/title-23/    @house/transportation-and-infrastructure       @senate/environment-and-public-works
+/title-33/    @house/transportation-and-infrastructure       @senate/environment-and-public-works
+/title-45/    @house/transportation-and-infrastructure       @senate/commerce-science-transportation
+/title-46/    @house/transportation-and-infrastructure       @senate/commerce-science-transportation
+/title-49/    @house/transportation-and-infrastructure       @senate/commerce-science-transportation
+
+# ── Veterans ───────────────────────────────────────────────────────────────
+/title-24/    @house/veterans-affairs @house/energy-and-commerce  @senate/veterans-affairs @senate/help
+/title-38/    @house/veterans-affairs                        @senate/veterans-affairs
+
+# ── Space and Science ─────────────────────────────────────────────────────
+/title-51/    @house/science-space-technology                @senate/commerce-science-transportation
+
+# ── Elections and Voting ──────────────────────────────────────────────────
+/title-52/    @house/administration @house/judiciary          @senate/rules-and-administration @senate/judiciary
+```
+
+---
+
+## Complete Title-by-Title Reference Table
+
+| # | Title | House Primary | Senate Primary | Granularity | Notes |
+|---|-------|--------------|----------------|-------------|-------|
+| 1 | General Provisions | Judiciary | Judiciary | Title | |
+| 2 | The Congress | House Administration | Rules and Administration | Title | Internal rules and operations |
+| 3 | The President | Oversight and Accountability | Homeland Security and Governmental Affairs | Title | Executive branch oversight |
+| 4 | Flag and Seal | Judiciary | Judiciary | Title | |
+| 5 | Government Organization and Employees | Oversight and Accountability | Homeland Security and Governmental Affairs | Title | Civil service, FOIA, APA |
+| 6 | Domestic Security | Homeland Security | Homeland Security and Governmental Affairs | Title | DHS-enabling legislation |
+| 7 | Agriculture | Agriculture | Agriculture, Nutrition, and Forestry | Title | Farm bill, SNAP, crop insurance |
+| 8 | Aliens and Nationality | Judiciary | Judiciary | Title | Immigration law |
+| 9 | Arbitration | Judiciary | Judiciary | Title | Federal Arbitration Act |
+| 10 | Armed Forces | Armed Services | Armed Services | Title | NDAA annual vehicle |
+| 11 | Bankruptcy | Judiciary | Judiciary | Title | Bankruptcy Code |
+| 12 | Banks and Banking | Financial Services | Banking, Housing, and Urban Affairs | Title | |
+| 13 | Census | Oversight and Accountability | Homeland Security and Governmental Affairs | Title | |
+| 14 | Coast Guard | Transportation and Infrastructure | Commerce, Science, and Transportation | Title | |
+| 15 | Commerce and Trade | Energy and Commerce | Commerce, Science, and Transportation | Title | FTC, antitrust, consumer protection |
+| 16 | Conservation | Natural Resources | Energy and Natural Resources | Title | Wildlife, fisheries, endangered species |
+| 17 | Copyrights | Judiciary | Judiciary | Title | IP subcommittees in each chamber |
+| 18 | Crimes and Criminal Procedure | Judiciary | Judiciary | Title | |
+| 19 | Customs Duties | Ways and Means | Finance | Title | Tariffs and trade remedies |
+| 20 | Education | Education and the Workforce | Health, Education, Labor and Pensions (HELP) | Title | ESEA, HEA reauthorizations |
+| 21 | Food and Drugs | Energy and Commerce / Agriculture | HELP / Agriculture, Nutrition, and Forestry | **Chapter** | FDA (E&C/HELP) vs. USDA food (Agriculture) |
+| 22 | Foreign Relations and Intercourse | Foreign Affairs | Foreign Relations | Title | |
+| 23 | Highways | Transportation and Infrastructure | Environment and Public Works | Title | Highway bills (IIJA) |
+| 24 | Hospitals and Asylums | Veterans' Affairs + Energy and Commerce | Veterans' Affairs + HELP | Title | Primarily VA facilities; secondary: public hospitals |
+| 25 | Indians | Natural Resources | Indian Affairs | Title | Senate has a standing committee; House uses Natural Resources |
+| 26 | Internal Revenue Code | Ways and Means | Finance | Title | House has Art. I §7 origination authority |
+| 27 | Intoxicating Liquors | Judiciary + Energy and Commerce | Judiciary + Commerce, Science, and Transportation | Title | Primary: Judiciary; secondary: E&C/Commerce for TTB regulation |
+| 28 | Judiciary and Judicial Procedure | Judiciary | Judiciary | Title | Federal courts, DOJ, marshals |
+| 29 | Labor | Education and the Workforce | HELP | Title | NLRA, OSHA, FLSA, FMLA |
+| 30 | Mineral Lands and Mining | Natural Resources | Energy and Natural Resources | Title | |
+| 31 | Money and Finance | Financial Services + Ways and Means | Banking, Housing, and Urban Affairs + Finance | **Chapter** | Treasury/currency ops (Financial Services/Banking) vs. fiscal policy (Ways/Finance) |
+| 32 | National Guard | Armed Services | Armed Services | Title | |
+| 33 | Navigation and Navigable Waters | Transportation and Infrastructure | Environment and Public Works | Title | Corps of Engineers, Clean Water Act, harbors |
+| 34 | Crime Control and Law Enforcement | Judiciary | Judiciary | Title | |
+| 35 | Patents | Judiciary | Judiciary | Title | IP subcommittees; AIA was major recent revision |
+| 36 | Patriotic and National Observances, Ceremonies, and Organizations | Judiciary | Judiciary | Title | |
+| 37 | Pay and Allowances of the Uniformed Services | Armed Services | Armed Services | Title | |
+| 38 | Veterans' Benefits | Veterans' Affairs | Veterans' Affairs | Title | VA healthcare, disability compensation, GI Bill |
+| 39 | Postal Service | Oversight and Accountability | Homeland Security and Governmental Affairs | Title | |
+| 40 | Public Buildings, Property, and Works | Transportation and Infrastructure | Environment and Public Works | Title | GSA, federal buildings |
+| 41 | Public Contracts | Oversight and Accountability | Homeland Security and Governmental Affairs | Title | Federal procurement |
+| 42 | The Public Health and Welfare | Energy and Commerce / Ways and Means / Judiciary | HELP / Finance / Judiciary | **Chapter** | See detailed mapping below |
+| 43 | Public Lands | Natural Resources | Energy and Natural Resources | Title | BLM, federal land management |
+| 44 | Public Printing and Documents | House Administration | Rules and Administration | Title | GPO, Federal Register, NARA |
+| 45 | Railroads | Transportation and Infrastructure | Commerce, Science, and Transportation | Title | Amtrak, FRA |
+| 46 | Shipping | Transportation and Infrastructure | Commerce, Science, and Transportation | Title | Maritime law, USCG authority |
+| 47 | Telecommunications | Energy and Commerce | Commerce, Science, and Transportation | Title | FCC, spectrum, broadband |
+| 48 | Territories and Insular Possessions | Natural Resources | Energy and Natural Resources | Title | |
+| 49 | Transportation | Transportation and Infrastructure | Commerce, Science, and Transportation | Title | DOT, FAA, NHTSA |
+| 50 | War and National Defense | Armed Services (+Intelligence for Ch. 36, 44) | Armed Services (+Intelligence for Ch. 36, 44) | Title + overrides | |
+| 51 | National and Commercial Space Program | Science, Space, and Technology | Commerce, Science, and Transportation | Title | NASA authorization, commercial launch |
+| 52 | Voting and Elections | House Administration + Judiciary | Rules and Administration + Judiciary | Title | Voting rights under Judiciary; election administration under Administration |
+| 54 | National Park Service and Related Programs | Natural Resources | Energy and Natural Resources | Title | |
+
+---
+
+## Chapter-Level Split Details
+
+### Title 21 — Food and Drugs
+
+| Chapter | Subject | House | Senate |
+|---------|---------|-------|--------|
+| Chapter 1 (§§ 1–24) | Federal Food and Drugs Act (original) / USDA food commodity standards | Agriculture | Agriculture, Nutrition, and Forestry |
+| Chapter 9 (§§ 301–399f) | Federal Food, Drug, and Cosmetic Act (FDA primary authority) | Energy and Commerce | HELP |
+| Chapter 13 (§§ 801–971) | Drug Abuse Prevention and Control (Controlled Substances Act) | Energy and Commerce + Judiciary | HELP + Judiciary |
+| Chapter 22 (§§ 1501–1509) | Dietary Supplement Health and Education Act | Energy and Commerce | HELP |
+
+### Title 31 — Money and Finance
+
+| Chapter | Subject | House | Senate |
+|---------|---------|-------|--------|
+| Chapter 3 (§§ 301–339) | Department of the Treasury | Ways and Means | Finance |
+| Chapter 5 (§§ 501–535) | Office of Management and Budget; government financial management | Oversight and Accountability | Homeland Security and Governmental Affairs |
+| Chapter 31 (§§ 3101–3132) | Public Debt (debt ceiling) | Ways and Means | Finance |
+| Chapter 51 (§§ 5101–5119) | Coins and currency | Financial Services | Banking, Housing, and Urban Affairs |
+| Chapter 53 (§§ 5301–5340) | Monetary transactions (Bank Secrecy Act, AML) | Financial Services | Banking, Housing, and Urban Affairs |
+
+### Title 42 — The Public Health and Welfare
+
+| Chapter | Subject | House | Senate |
+|---------|---------|-------|--------|
+| Chapter 6A (§§ 201–300mm-61) | Public Health Service Act — CDC, NIH, HRSA, SAMHSA, FDA authorities | Energy and Commerce | HELP |
+| Chapter 7 (§§ 301–1397mm) | Social Security Act — Medicare (Title XVIII), Medicaid (Title XIX), CHIP (Title XXI), TANF (Title IV) | Ways and Means | Finance |
+| Chapter 8 (§§ 1401–1440) | Low-Income Housing | Financial Services | Banking, Housing, and Urban Affairs |
+| Chapter 21 (§§ 1981–2000h-6) | Civil Rights Act provisions | Judiciary | Judiciary |
+| Chapter 21B (§§ 2000aa–2000aa-12) | Privacy Protection Act | Judiciary | Judiciary |
+| Chapter 23 (§§ 2101–2106) | Development Disabilities | Energy and Commerce | HELP |
+| Chapters 67–136 (misc. welfare, community programs) | Block grants, community services, various | Energy and Commerce / Oversight | HELP / Governmental Affairs |
+
+### Title 50 — War and National Defense (chapter overrides)
+
+| Chapter | Subject | Additional Committees Beyond Armed Services |
+|---------|---------|---------------------------------------------|
+| Chapter 36 (§§ 1801–1885) | Foreign Intelligence Surveillance Act (FISA) | House: Intelligence + Judiciary; Senate: Intelligence + Judiciary |
+| Chapter 44 (§§ 3001–3236) | National Security Act — intelligence community organization | House: Intelligence (Select); Senate: Intelligence (Select) |
+| Chapter 45 (§§ 3301–3320) | Atomic Energy Defense Programs | House: Armed Services + Energy/Commerce; Senate: Armed Services + Energy/Natural Resources |
+
+---
+
+## Phase 1 Detailed Committee Profiles
 
 ### Title 10 — Armed Forces
 
@@ -118,8 +280,7 @@ Chair/membership data changes each Congress; **do not hardcode** in the mapping 
 |-|-------|--------|
 | **Committee** | Committee on Armed Services | Committee on Armed Services |
 | **Rule** | House Rule X, Clause 1(c) | Senate Rule XXV, Clause 1(d) |
-| **Key subcommittee** | Military Personnel; Readiness; Strategic Forces | Personnel; Readiness and Management Support |
-| **Jurisdiction level** | Title | Title |
+| **Key subcommittee** | Military Personnel; Readiness; Strategic Forces; Cyber | Personnel; Readiness and Management Support |
 | **Annual vehicle** | National Defense Authorization Act (NDAA) | National Defense Authorization Act (NDAA) |
 | **Website** | armedservices.house.gov | armed-services.senate.gov |
 
@@ -130,7 +291,6 @@ Chair/membership data changes each Congress; **do not hardcode** in the mapping 
 | **Committee** | Committee on the Judiciary | Committee on the Judiciary |
 | **Rule** | House Rule X, Clause 1(l) — patents, copyrights, trademarks | Senate Rule XXV, Clause 1(j) — patents, copyrights |
 | **Key subcommittee** | Courts, Intellectual Property, Artificial Intelligence, and the Internet | Intellectual Property Subcommittee |
-| **Jurisdiction level** | Title | Title |
 | **Note** | Revenue bills for copyright fees originate in House (Art. I §7) | |
 | **Website** | judiciary.house.gov | judiciary.senate.gov |
 
@@ -139,10 +299,9 @@ Chair/membership data changes each Congress; **do not hardcode** in the mapping 
 | | House | Senate |
 |-|-------|--------|
 | **Committee** | Committee on the Judiciary | Committee on the Judiciary |
-| **Rule** | House Rule X, Clause 1(l) — criminal law, administration of justice | Senate Rule XXV, Clause 1(j) — federal courts, criminal law |
+| **Rule** | House Rule X, Clause 1(l) | Senate Rule XXV, Clause 1(j) |
 | **Key subcommittee** | Crime, Terrorism and Homeland Security | Crime and Counterterrorism (oversees DOJ, FBI, DEA, ATF) |
-| **Jurisdiction level** | Title | Title |
-| **Secondary referral** | Homeland Security (for terrorism-related amendments) | Homeland Security (for terrorism-related amendments) |
+| **Secondary referral** | Homeland Security (terrorism-related amendments) | Homeland Security (terrorism-related amendments) |
 | **Website** | judiciary.house.gov | judiciary.senate.gov |
 
 ### Title 20 — Education
@@ -152,7 +311,6 @@ Chair/membership data changes each Congress; **do not hardcode** in the mapping 
 | **Committee** | Committee on Education and the Workforce | Committee on Health, Education, Labor & Pensions (HELP) |
 | **Rule** | House Rule X, Clause 1(f) | Senate Rule XXV, Clause 1(g) |
 | **Key subcommittee** | Higher Education and Workforce Development | Education Subcommittee |
-| **Jurisdiction level** | Title | Title |
 | **Annual vehicle** | Reauthorizations (ESEA, HEA) | Reauthorizations (ESEA, HEA) |
 | **Website** | edworkforce.house.gov | help.senate.gov |
 
@@ -161,10 +319,9 @@ Chair/membership data changes each Congress; **do not hardcode** in the mapping 
 | | House | Senate |
 |-|-------|--------|
 | **Committee** | Committee on Foreign Affairs | Committee on Foreign Relations |
-| **Rule** | House Rule X, Clause 1(i) — foreign affairs, foreign assistance | Senate Rule XXV, Clause 1(h) — foreign relations, treaties |
-| **Key subcommittee** | East Asia and the Pacific; Western Hemisphere; Europe | Regional subcommittees |
-| **Jurisdiction level** | Title | Title |
-| **Special authority** | Foreign Affairs oversees executive war powers; Foreign Relations ratifies treaties (2/3 majority) | |
+| **Rule** | House Rule X, Clause 1(i) | Senate Rule XXV, Clause 1(h) |
+| **Key subcommittee** | East Asia and Pacific; Western Hemisphere; Europe | Regional subcommittees |
+| **Special authority** | Oversees executive war powers | Ratifies treaties (2/3 majority required) |
 | **Website** | foreignaffairs.house.gov | foreign.senate.gov |
 
 ### Title 26 — Internal Revenue Code
@@ -172,121 +329,151 @@ Chair/membership data changes each Congress; **do not hardcode** in the mapping 
 | | House | Senate |
 |-|-------|--------|
 | **Committee** | Committee on Ways and Means | Committee on Finance |
-| **Rule** | House Rule X, Clause 1(s) + Art. I §7 (all revenue bills originate in House) | Senate Rule XXV, Clause 1(f) |
+| **Rule** | House Rule X, Clause 1(s) + Art. I §7 | Senate Rule XXV, Clause 1(f) |
 | **Key subcommittee** | Tax Subcommittee | Taxation and IRS Oversight Subcommittee |
-| **Jurisdiction level** | Title | Title |
-| **Special authority** | Constitutional origination — the House always drafts the initial revenue bill | Senate amends or replaces House-passed bills |
+| **Special authority** | Constitutional origination — all revenue bills must begin in House | Senate amends or substitutes House-passed bills |
 | **Website** | waysandmeans.house.gov | finance.senate.gov |
 
-### Title 42 — The Public Health and Welfare *(Chapter-level split)*
+### Title 42 — The Public Health and Welfare
 
-This title encompasses programs with fundamentally different funding mechanisms, historically divided across committees:
-
-#### Programs financed by trust funds / appropriations (Medicare, Medicaid, CHIP, TANF)
+**Medicare, Medicaid, CHIP, TANF (Chapter 7 — Social Security Act)**
 
 | | House | Senate |
 |-|-------|--------|
 | **Committee** | Committee on Ways and Means | Committee on Finance |
-| **Primary chapters** | Chapter 7 (Social Security Act) | Chapter 7 (Social Security Act) |
-| **Key sections** | §§ 1395–1396 (Medicare/Medicaid), § 601 (TANF) | Same |
+| **Key sections** | §§ 1395–1396 (Medicare/Medicaid); § 601 (TANF) | Same |
 | **Website** | waysandmeans.house.gov | finance.senate.gov |
 
-#### Public health agencies and health regulation (CDC, NIH, FDA, ACA marketplace)
+**Public health agencies — CDC, NIH, FDA, ACA market rules (Chapter 6A)**
 
 | | House | Senate |
 |-|-------|--------|
 | **Committee** | Committee on Energy and Commerce | Committee on Health, Education, Labor & Pensions (HELP) |
-| **Primary chapters** | Chapter 6A (Public Health Service Act) | Chapter 6A (Public Health Service Act) |
-| **Key sections** | §§ 201–300 (PHS Act), ACA Title I market rules | Same |
+| **Key sections** | §§ 201–300 (Public Health Service Act) | Same |
 | **Website** | energycommerce.house.gov | help.senate.gov |
 
-#### Civil rights and anti-discrimination provisions
+**Civil rights provisions (Chapter 21)**
 
 | | House | Senate |
 |-|-------|--------|
 | **Committee** | Committee on the Judiciary | Committee on the Judiciary |
-| **Primary chapters** | Chapter 21 (Civil Rights Act provisions) | Chapter 21 |
-
-#### Summary — Title 42 CODEOWNERS paths
-
-| Path | House Primary | Senate Primary |
-|------|--------------|----------------|
-| `/title-42/` (default) | Energy and Commerce | HELP |
-| `/title-42/chapter-7/` | Ways and Means | Finance |
-| `/title-42/chapter-6a/` | Energy and Commerce | HELP |
-| `/title-42/chapter-21/` | Judiciary | Judiciary |
+| **Website** | judiciary.house.gov | judiciary.senate.gov |
 
 ### Title 50 — War and National Defense
 
 | | House | Senate |
 |-|-------|--------|
 | **Primary committee** | Committee on Armed Services | Committee on Armed Services |
-| **Rule** | House Rule X, Clause 1(c) — national security, defense policy | Senate Rule XXV, Clause 1(d) |
-| **Jurisdiction level** | Title (with chapter carve-outs for intelligence) | Title (with chapter carve-outs) |
+| **Rule** | House Rule X, Clause 1(c) | Senate Rule XXV, Clause 1(d) |
 
-**Intelligence committee overlay:**
+**Intelligence chapter overrides**
 
-| Chapter | Subject | Additional Oversight |
-|---------|---------|---------------------|
-| Chapter 36 (§§ 1801–1885, FISA) | Foreign Intelligence Surveillance | House & Senate Intelligence committees + Judiciary |
-| Chapter 44 (§§ 3001–3236, National Security Act) | Intelligence community organization | House & Senate Intelligence committees (Select) |
-
-The Select Intelligence committees in both chambers have exclusive jurisdiction over intelligence community programs and budgets. Armed Services maintains primary authority over defense programs and war powers.
+| Chapter | Additional Oversight Committees |
+|---------|--------------------------------|
+| Ch. 36 (FISA, §§ 1801–1885) | House: Intelligence + Judiciary; Senate: Intelligence + Judiciary |
+| Ch. 44 (National Security Act, §§ 3001–3236) | House: Intelligence (Select); Senate: Intelligence (Select) |
 
 ---
 
-## Granularity Recommendation for Phase 1
+## Committee Cross-Reference Index
+
+Use this to look up which US Code titles a given committee owns.
+
+### House Committees
+
+| Committee | Titles (primary) | Titles (secondary/shared) |
+|-----------|-----------------|--------------------------|
+| Agriculture | 7 | 21 (Ch. 1) |
+| Armed Services | 10, 32, 37, 50 | — |
+| Education and the Workforce | 20, 29 | — |
+| Energy and Commerce | 15, 47 | 21 (Ch. 9, 13), 24, 27, 42 (Ch. 6A) |
+| Financial Services | 12 | 31, 42 (Ch. 8) |
+| Foreign Affairs | 22 | — |
+| Homeland Security | 6 | — |
+| House Administration | 2, 44 | 52 |
+| Intelligence (Select) | — | 50 (Ch. 44), 50 (Ch. 36) |
+| Judiciary | 1, 4, 8, 9, 11, 17, 18, 28, 34, 35, 36 | 21 (Ch. 13), 27, 42 (Ch. 21), 50 (Ch. 36), 52 |
+| Natural Resources | 16, 25, 30, 43, 48, 54 | — |
+| Oversight and Accountability | 3, 5, 13, 39, 41 | 40 (shared) |
+| Science, Space, and Technology | 51 | — |
+| Transportation and Infrastructure | 14, 23, 33, 40, 45, 46, 49 | — |
+| Veterans' Affairs | 38 | 24 |
+| Ways and Means | 19, 26 | 31 (fiscal), 42 (Ch. 7) |
+
+### Senate Committees
+
+| Committee | Titles (primary) | Titles (secondary/shared) |
+|-----------|-----------------|--------------------------|
+| Agriculture, Nutrition, and Forestry | 7 | 21 (Ch. 1) |
+| Armed Services | 10, 32, 37, 50 | — |
+| Banking, Housing, and Urban Affairs | 12 | 31 (monetary), 42 (Ch. 8) |
+| Commerce, Science, and Transportation | 14, 15, 45, 46, 47, 49, 51 | 27 |
+| Energy and Natural Resources | 16, 30, 43, 48, 54 | — |
+| Environment and Public Works | 23, 33, 40 | — |
+| Finance | 19, 26 | 31 (fiscal), 42 (Ch. 7) |
+| Foreign Relations | 22 | — |
+| Health, Education, Labor and Pensions (HELP) | 20, 29 | 21 (Ch. 9, 13), 24, 42 (Ch. 6A) |
+| Homeland Security and Governmental Affairs | 3, 5, 6, 13, 39, 41 | — |
+| Indian Affairs | 25 | — |
+| Intelligence (Select) | — | 50 (Ch. 44), 50 (Ch. 36) |
+| Judiciary | 1, 4, 8, 9, 11, 17, 18, 28, 34, 35, 36 | 21 (Ch. 13), 27, 42 (Ch. 21), 50 (Ch. 36), 52 |
+| Rules and Administration | 2, 44 | 52 |
+| Veterans' Affairs | 38 | 24 |
+
+---
+
+## Granularity Recommendation
 
 For the CWLB CODEOWNERS implementation:
 
-1. **Start at Title level** for all 8 titles — this is correct for 7 of 8 and provides a clean initial mapping
-2. **Add Chapter-level entries for Title 42** from day one — the split is significant enough that users will expect it
-3. **Add Chapter-level entries for Title 50 Chapters 36 and 44** — FISA and the National Security Act are high-profile enough to warrant precise attribution
-4. **Defer subcommittee-level granularity** to Phase 2 — subcommittees shift more frequently and add complexity without proportional user value
+1. **Start at Title level** for all titles — correct for 51 of 54 and provides a clean initial mapping
+2. **Add Chapter-level entries for Titles 21, 31, and 42** from day one — the splits are significant enough that users will expect accurate attribution for Medicare vs. public health, FDA vs. USDA, Treasury vs. debt ceiling
+3. **Add Chapter-level entries for Title 50, Chapters 36 and 44** — FISA and the National Security Act are high-profile and politically sensitive; accurate attribution matters
+4. **Defer subcommittee-level granularity to Phase 2** — subcommittees shift frequently and add complexity without proportional user value in Phase 1
 
 ---
 
-## Data Sources and Authority References
+## Data Sources
 
-| Source | Type | URL |
-|--------|------|-----|
+| Source | Type | Notes |
+|--------|------|-------|
 | House Rule X | Authoritative — committee jurisdiction rules | govinfo.gov/content/pkg/HMAN-119 |
 | Senate Rule XXV | Authoritative — committee jurisdiction rules | senate.gov/pagelayout/reference/two_column_table/Senate_Rules.htm |
 | Congress.gov Committees | Reference — current membership and subcommittees | congress.gov/committees |
-| House.gov Committees | Reference — committee websites and jurisdiction descriptions | house.gov/committees |
+| House.gov Committees | Reference — committee websites and jurisdiction summaries | house.gov/committees |
 | CRS Report R46251 | Background — committee referral procedures in the House | congress.gov/crs-product/R46251 |
 | CRS Report R46815 | Background — committee referral procedures in the Senate | congress.gov/crs-product/R46815 |
 
-**Note on chair/membership data:** Committee chairs and membership change each Congress (and sometimes mid-Congress). Do not store chair names in the mapping table; instead link to `congress.gov/committees/<committee-id>` for live data. The jurisdiction rules (House Rule X, Senate Rule XXV) are far more stable.
+**Note on chair/membership data:** Committee chairs and membership change each Congress. Store only committee names and Rule citations in the mapping; link to `congress.gov/committees/<committee-id>` for live membership data.
 
 ---
 
-## Implementation Notes for Phase 1
+## Implementation Notes
 
 ### OWNERS file placement
 
-Following the CWLB repository metaphor where titles are directories, place CODEOWNERS-style files as:
-
 ```
-/CODEOWNERS              ← root-level: maps all title paths
-/title-42/CODEOWNERS     ← chapter-level overrides for Title 42
-/title-50/CODEOWNERS     ← chapter-level overrides for Title 50
+/CODEOWNERS                  ← root-level: all title paths (Title-level defaults)
+/title-21/CODEOWNERS         ← Chapter-level overrides for Food and Drugs
+/title-31/CODEOWNERS         ← Chapter-level overrides for Money and Finance
+/title-42/CODEOWNERS         ← Chapter-level overrides for Public Health and Welfare
+/title-50/CODEOWNERS         ← Chapter-level overrides for War and National Defense
 ```
 
-### Display in UI
+### UI display
 
-When rendering a US Code section (e.g., 17 USC § 106), the "Owners" panel should show:
+When rendering a US Code section, the "Owners" panel should show:
 - Committee name with link to `congress.gov/committees/<id>`
 - Chamber badge (House / Senate)
 - Jurisdiction type (Primary / Secondary / Oversight)
 
-For sections under split jurisdiction (Title 42 Chapter 7), show both Finance (primary) and HELP (secondary, if applicable to that specific section's subject matter).
+For sections under split jurisdiction (e.g., 42 USC § 1395 — Medicare), show Finance/Ways and Means as primary and suppress HELP/Energy and Commerce unless they have specific subcommittee authority.
 
-### Future work (Phase 2+)
+### Phase 2 enhancements
 
-- **Subcommittee mapping**: Map specific subcommittees to US Code chapters for deeper attribution
-- **Historical jurisdiction**: Committees are renamed and restructured between Congresses; track historical names for accurate attribution on older laws
-- **Bill referral data**: Congress.gov API exposes which committees received each bill — use this to validate and refine the mapping empirically rather than relying solely on formal jurisdiction rules
+- **Subcommittee mapping** for high-traffic titles (17, 18, 26, 42)
+- **Historical jurisdiction** — committees are renamed and restructured between Congresses; track historical names for accurate attribution on older laws
+- **Bill referral data** — Congress.gov API exposes which committees received each bill; use this to validate and refine the mapping empirically
 
 ---
 


### PR DESCRIPTION
## Summary

- Maps all 8 Phase 1 US Code titles to their primary House/Senate committee pairs
- Answers the Title-vs-Chapter granularity question: 7 of 8 titles are Title-level; Title 42 requires Chapter-level splits
- Documents Title 50 intelligence committee overlay (FISA, National Security Act chapters)
- Proposes CODEOWNERS file format and UI display conventions for the "committees as CODEOWNERS" metaphor

## Key Findings

| Title | House | Senate | Granularity |
|-------|-------|--------|-------------|
| 10 — Armed Forces | Armed Services | Armed Services | Title |
| 17 — Copyrights | Judiciary | Judiciary | Title |
| 18 — Crimes | Judiciary | Judiciary | Title |
| 20 — Education | Education and the Workforce | HELP | Title |
| 22 — Foreign Relations | Foreign Affairs | Foreign Relations | Title |
| 26 — Internal Revenue Code | Ways and Means | Finance | Title |
| 42 — Public Health and Welfare | Energy and Commerce / Ways and Means | HELP / Finance | **Chapter** |
| 50 — War and National Defense | Armed Services (+Intelligence for Ch. 36/44) | Armed Services (+Intelligence for Ch. 36/44) | Title (+chapter overrides) |

Title 42 is the notable exception — Medicare/Medicaid (Chapter 7) falls under Finance/Ways and Means while public health agencies (Chapter 6A) fall under HELP/Energy and Commerce.

Closes #302