### PR TITLE
fix: backfill missing T17 Chapter 10 SectionGroup (§§1001–1010)

### DIFF
--- a/backend/alembic/versions/883637321672_backfill_t17_ch10_section_group.py
+++ b/backend/alembic/versions/883637321672_backfill_t17_ch10_section_group.py
@@ -1,0 +1,124 @@
+"""backfill_t17_ch10_section_group
+
+Backfill the missing SectionGroup for Title 17, Chapter 10
+("Digital Audio Recording Devices and Media", §§1001–1010).
+
+Chapter 10 was absent from the structure endpoint (issue #215) because
+it was ingested before the SectionGroup model existed.  The group row
+was never created and sections 1001–1010 carry group_id = NULL.
+
+This migration:
+  1. Inserts the SectionGroup for chapter:10 under title:17.
+  2. Updates section_snapshot.group_id for §§1001–1010 of title 17.
+  3. Updates us_code_section.group_id for §§1001–1010 of title 17.
+
+Group UUIDs are the deterministic UUID5 values produced by
+pipeline.olrc.group_service.group_id_from_key:
+  title:17            → aae4c5a6-db32-5662-91ae-e53b1f162ee5
+  title:17/chapter:10 → dabd190c-3193-5cae-acdf-338267a2d869
+
+Revision ID: 883637321672
+Revises: ce275a30c5ec
+Create Date: 2026-05-20 19:27:33.563904
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "883637321672"
+down_revision: str | None = "ce275a30c5ec"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TITLE17_GROUP_ID = "aae4c5a6-db32-5662-91ae-e53b1f162ee5"
+_CH10_GROUP_ID = "dabd190c-3193-5cae-acdf-338267a2d869"
+_CH10_SECTIONS = [str(n) for n in range(1001, 1011)]
+
+
+def upgrade() -> None:
+    """Insert the missing Chapter 10 SectionGroup and wire §§1001–1010."""
+    conn = op.get_bind()
+
+    # 1. Insert Chapter 10 group (idempotent — skip if already present).
+    conn.execute(
+        sa.text("""
+            INSERT INTO section_group
+                (group_id, parent_id, group_type, number, name, sort_order,
+                 is_positive_law, positive_law_date, positive_law_citation,
+                 created_at, updated_at)
+            SELECT
+                :ch10_id::uuid,
+                :title17_id::uuid,
+                'chapter',
+                '10',
+                'Digital Audio Recording Devices and Media',
+                999,
+                TRUE,
+                (SELECT positive_law_date FROM section_group
+                 WHERE group_id = :title17_id::uuid),
+                (SELECT positive_law_citation FROM section_group
+                 WHERE group_id = :title17_id::uuid),
+                now(),
+                now()
+            WHERE EXISTS (
+                SELECT 1 FROM section_group WHERE group_id = :title17_id::uuid
+            )
+            ON CONFLICT (group_id) DO NOTHING
+        """),
+        {"ch10_id": _CH10_GROUP_ID, "title17_id": _TITLE17_GROUP_ID},
+    )
+
+    # 2. Assign group_id in section_snapshot for §§1001–1010 of title 17.
+    conn.execute(
+        sa.text("""
+            UPDATE section_snapshot
+            SET group_id = :ch10_id::uuid
+            WHERE title_number = 17
+              AND section_number = ANY(:sections)
+              AND group_id IS NULL
+        """),
+        {"ch10_id": _CH10_GROUP_ID, "sections": _CH10_SECTIONS},
+    )
+
+    # 3. Assign group_id in us_code_section for §§1001–1010 of title 17.
+    conn.execute(
+        sa.text("""
+            UPDATE us_code_section
+            SET group_id = :ch10_id::uuid
+            WHERE title_number = 17
+              AND section_number = ANY(:sections)
+              AND group_id IS NULL
+        """),
+        {"ch10_id": _CH10_GROUP_ID, "sections": _CH10_SECTIONS},
+    )
+
+
+def downgrade() -> None:
+    """Remove the Chapter 10 group and clear its group_id references."""
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text("""
+            UPDATE section_snapshot
+            SET group_id = NULL
+            WHERE group_id = :ch10_id::uuid
+        """),
+        {"ch10_id": _CH10_GROUP_ID},
+    )
+
+    conn.execute(
+        sa.text("""
+            UPDATE us_code_section
+            SET group_id = NULL
+            WHERE group_id = :ch10_id::uuid
+        """),
+        {"ch10_id": _CH10_GROUP_ID},
+    )
+
+    conn.execute(
+        sa.text("DELETE FROM section_group WHERE group_id = :ch10_id::uuid"),
+        {"ch10_id": _CH10_GROUP_ID},
+    )

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -690,6 +690,66 @@ class TestChapterGroups:
         # Chapter's parent should be the title
         assert "title:17" in non_title_groups[0].parent_key
 
+    def test_t17_ch10_no_subchapters_alongside_subchapter_chapters(
+        self, parser: USLMParser, tmp_path: Path
+    ) -> None:
+        """Regression test for issue #215: T17 Chapter 10 missing from structure.
+
+        Chapters with subchapters (1-9) coexist with Chapter 10 which has no
+        subchapters and goes directly chapter → section.  All chapters must
+        appear in result.groups and Chapter 10's sections must carry the
+        correct parent_group_key.
+        """
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<usc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <main>
+    <title identifier="/us/usc/t17" number="17">
+      <heading>COPYRIGHTS</heading>
+      <chapter identifier="/us/usc/t17/ch1" number="1">
+        <heading>SUBJECT MATTER AND SCOPE OF COPYRIGHT</heading>
+        <subchapter identifier="/us/usc/t17/ch1/schI" number="I">
+          <heading>General Provisions</heading>
+          <section identifier="/us/usc/t17/s101" number="101">
+            <heading>Definitions</heading>
+            <content><p>As used in this title.</p></content>
+          </section>
+        </subchapter>
+      </chapter>
+      <chapter identifier="/us/usc/t17/ch10" number="10">
+        <heading>DIGITAL AUDIO RECORDING DEVICES AND MEDIA</heading>
+        <section identifier="/us/usc/t17/s1001" number="1001">
+          <heading>Definitions</heading>
+          <content><p>As used in this chapter.</p></content>
+        </section>
+        <section identifier="/us/usc/t17/s1002" number="1002">
+          <heading>Incorporation of copying controls</heading>
+          <content><p>No person shall import.</p></content>
+        </section>
+      </chapter>
+    </title>
+  </main>
+</usc>"""
+        xml_path = tmp_path / "t17_ch10.xml"
+        xml_path.write_text(xml_content)
+        result = parser.parse_file(xml_path)
+
+        chapters = [g for g in result.groups if g.group_type == "chapter"]
+        assert len(chapters) == 2, "Both chapters must be in result.groups"
+
+        ch1 = next(g for g in chapters if g.number == "1")
+        ch10 = next(g for g in chapters if g.number == "10")
+
+        assert "title:17" in ch1.parent_key
+        assert "title:17" in ch10.parent_key
+
+        # Chapter 10 sections must reference the chapter group, not a subchapter
+        ch10_sections = [
+            s for s in result.sections if s.section_number in ("1001", "1002")
+        ]
+        assert len(ch10_sections) == 2
+        for s in ch10_sections:
+            assert s.parent_group_key == ch10.key
+
 
 class TestExtractNotesRefs:
     """Tests for _extract_notes_refs method (Task 1.17b)."""


### PR DESCRIPTION
## Summary

Fixes the missing Chapter 10 of Title 17 ("Digital Audio Recording Devices and Media", §§1001–1010) from the `/api/v1/titles/17/structure` endpoint.

- **Root cause**: Sections 1001–1010 were ingested with `group_id = NULL` because the `SectionGroup` model didn't exist yet at original ingestion time. After the group model was introduced, the `force_parse=False` early-return guard prevented re-ingestion from backfilling the missing chapter group.
- **Parser code is correct**: `_parse_chapter` already handles chapters with no subchapters (lines 722–728). No code change needed there.
- **Fix**: Alembic data migration that inserts the `section_group` row for `title:17/chapter:10` (using its deterministic UUID5 key) and updates `group_id` on both `section_snapshot` and `us_code_section` for §§1001–1010.

## Changes

- `backend/alembic/versions/883637321672_backfill_t17_ch10_section_group.py` — data migration; idempotent (`ON CONFLICT DO NOTHING`, `WHERE group_id IS NULL`)
- `backend/tests/pipeline/test_parser.py` — regression test `test_t17_ch10_no_subchapters_alongside_subchapter_chapters` covering mixed chapters (some with subchapters, one without) to prevent future regressions

## Before / After

**Before** (`GET /api/v1/titles/17/structure`): 130 sections, Chapter 10 absent.

**After** (post-migration): Chapter 10 appears as a sibling chapter under title:17 with §§1001–1010 correctly nested inside it.

```
title:17 (Copyrights)
├── chapter:1  (Subject Matter and Scope of Copyright)
│   ├── subchapter:I …
│   └── …
├── chapter:2 … chapter:9
└── chapter:10 (Digital Audio Recording Devices and Media)   ← now visible
    ├── §1001 Definitions
    ├── §1002 Incorporation of copying controls
    └── … §§1003–1010
```

Closes #215