### PR TITLE
fix: correct Congress.gov bill-ref parsing in law history seed

### DIFF
--- a/backend/pipeline/congress/law_history_ingestion.py
+++ b/backend/pipeline/congress/law_history_ingestion.py
@@ -268,9 +268,9 @@ class LawHistoryIngestionService:
         if data is None:
             return None
 
-        # Congress.gov /law/{congress}/{type}/{number} returns:
-        # {"law": {"bill": {"type": "HR", "number": "667", ...}}}
-        bill_ref = data.get("law", {}).get("bill", {})
+        # Congress.gov /law/{congress}/{type}/{number} returns the bill at the
+        # top level: {"bill": {"type": "HR", "number": "667", ...}}
+        bill_ref = data.get("bill", {})
         b_type = (bill_ref.get("type") or "").lower()
         b_number = bill_ref.get("number")
         if not b_type or not b_number:

--- a/backend/tests/pipeline/test_law_history_ingestion.py
+++ b/backend/tests/pipeline/test_law_history_ingestion.py
@@ -1,7 +1,7 @@
 """Tests for LawHistoryIngestionService._resolve_bill_ref.
 
 Covers the Congress.gov /law/{congress}/{type}/{number} response structure,
-which returns {"law": {"bill": {"type": ..., "number": ...}}} at the top level.
+which returns {"bill": {"type": ..., "number": ...}} at the top level.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -43,18 +43,15 @@ class TestResolveBillRef:
 
     @pytest.mark.asyncio
     async def test_resolves_from_congress_api_response(self) -> None:
-        """Falls back to Congress.gov API and parses {"law": {"bill": {...}}} correctly."""
+        """Falls back to Congress.gov API and parses {"bill": {...}} correctly."""
         law = _make_law(origin_bill=None)
         client = AsyncMock()
         client.get_law_bill_info.return_value = {
-            "law": {
-                "bill": {
-                    "type": "HR",
-                    "number": "667",
-                    "originChamber": "House",
-                },
-                "number": "23",
-                "type": "PUBLIC_LAW",
+            "bill": {
+                "type": "HR",
+                "number": "667",
+                "originChamber": "House",
+                "laws": [{"number": "113-23", "type": "Public Law"}],
             },
             "request": {},
         }
@@ -77,10 +74,10 @@ class TestResolveBillRef:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_bill_missing_from_response(self) -> None:
-        """API response has a law key but no nested bill."""
+        """API response has no bill key."""
         law = _make_law(origin_bill=None)
         client = AsyncMock()
-        client.get_law_bill_info.return_value = {"law": {}, "request": {}}
+        client.get_law_bill_info.return_value = {"request": {}}
 
         service = _make_service()
         result = await service._resolve_bill_ref(law, client)
@@ -103,7 +100,7 @@ class TestResolveBillRef:
         law = _make_law(origin_bill=None)
         client = AsyncMock()
         client.get_law_bill_info.return_value = {
-            "law": {"bill": {"type": "S", "number": "42"}},
+            "bill": {"type": "S", "number": "42"},
         }
 
         service = _make_service()


### PR DESCRIPTION
## Summary

- The `seed-congress-law-history` step in `seed_finalize.sh` was silently failing for all 296 laws in Congress 113, leaving the History tab empty on every law detail page
- Root cause: `_resolve_bill_ref` expected the Congress.gov `/v3/law/{congress}/{type}/{number}` response to be `{"law": {"bill": {...}}}`, but the actual response is `{"bill": {...}}` at the top level
- Fix: change `data.get("law", {}).get("bill", {})` → `data.get("bill", {})` — a one-line change
- Updated tests to use the real response shape

## Before / After

**Before (all 296 laws failed):**
```
ERROR [__main__] Congress 113: 296/296 laws failed — first: PL 113-1: Could not resolve bill reference for PL 113-1
WARNING: seed-congress-law-history failed, continuing
```

**After (verified locally against PL 113-10):**
```
Status: completed
Details: 19 actions, 3 sponsors
```
Timeline now includes introduction (2013-03-12), committee referral, House vote (2013-04-24), Senate vote (2013-05-07), and presidential signature (2013-05-17).

## Test plan

- [x] All 6 unit tests in `tests/pipeline/test_law_history_ingestion.py` pass
- [x] Ran `seed_law(113, 10)` locally — completed with 19 actions and 3 sponsors ingested
- [ ] After merge, verify `seed-congress-law-history` step succeeds in the next seed job

🤖 Generated with [Claude Code](https://claude.com/claude-code)