### PR TITLE
fix: render <continuation> after enumerated list at indent_level=0 (Issue #447)

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1001,6 +1001,53 @@ class USLMParser:
         text = _PUNCT_RE.sub(r"\1", text)
         return text
 
+    def _get_text_content_excluding(
+        self,
+        elem: etree._Element,
+        excluded: list[etree._Element],
+        strip_footnotes: bool = False,
+    ) -> str:
+        """Get text content from an element, skipping specified child elements.
+
+        Used to extract content text from a <content> element while excluding
+        embedded <continuation> children so their text can be captured at the
+        correct semantic level (e.g. section level for 17 U.S.C. § 107).
+
+        Args:
+            elem: The XML element to extract text from.
+            excluded: Child elements whose text (and their children's text) should
+                be omitted from the result.
+            strip_footnotes: If True, also skip footnote refs and notes.
+        """
+        excluded_set = set(id(e) for e in excluded)
+
+        def itertext_excluding(
+            el: etree._Element,
+        ) -> Generator[str, None, None]:
+            tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+            if strip_footnotes:
+                if tag == "ref" and el.get("class", "") == "footnoteRef":
+                    return
+                if tag == "note" and el.get("type", "") == "footnote":
+                    return
+            if el.text:
+                yield el.text
+            for child in el:
+                if id(child) in excluded_set:
+                    # Skip this child entirely; still yield its tail (text after
+                    # the closing tag) so surrounding punctuation is preserved.
+                    if child.tail:
+                        yield child.tail
+                    continue
+                yield from itertext_excluding(child)
+                if child.tail:
+                    yield child.tail
+
+        parts = list(itertext_excluding(elem))
+        text = _WS_RE.sub(" ", "".join(parts)).strip()
+        text = _PUNCT_RE.sub(r"\1", text)
+        return text
+
     @staticmethod
     def _itertext_skip_footnotes(elem: etree._Element) -> Generator[str, None, None]:
         """Like elem.itertext() but skips footnote refs and notes."""
@@ -1062,14 +1109,38 @@ class USLMParser:
             chapeau_elem = elem.find("chapeau")
 
         content_parts = []
+        # Collect continuation elements that appear inside <content> (not direct
+        # children of the paragraph/subsection element).  These are semantically
+        # "flush-left" continuations that apply at the parent (section) level —
+        # e.g. 17 U.S.C. § 107 where "The fact that a work is unpublished…"
+        # appears as <continuation> inside <content> inside the last <paragraph>.
+        # We strip them from the content text and collect them separately so
+        # callers can promote them to the correct indent level.
+        content_continuations: list[str] = []
         if chapeau_elem is not None:
             content_parts.append(
                 self._get_text_content(chapeau_elem, strip_footnotes=True)
             )
         if content_elem is not None:
-            content_parts.append(
-                self._get_text_content(content_elem, strip_footnotes=True)
-            )
+            # Check for <continuation> children inside <content>.
+            cont_in_content = content_elem.findall(
+                "{*}continuation"
+            ) or content_elem.findall("continuation")
+            if cont_in_content:
+                # Get content text excluding the <continuation> children.
+                content_text = self._get_text_content_excluding(
+                    content_elem, cont_in_content, strip_footnotes=True
+                )
+                if content_text:
+                    content_parts.append(content_text)
+                for cont_elem in cont_in_content:
+                    cont_text = self._get_text_content(cont_elem, strip_footnotes=True)
+                    if cont_text:
+                        content_continuations.append(cont_text)
+            else:
+                content_parts.append(
+                    self._get_text_content(content_elem, strip_footnotes=True)
+                )
 
         content = " ".join(content_parts).strip()
 
@@ -1091,8 +1162,10 @@ class USLMParser:
                 children.append(self._parse_subsection(child_elem, child_level))
 
         # Collect continuation elements (closing text that follows a numbered list,
-        # e.g. the penalty clause in 18 U.S.C. § 1001(a))
-        continuation: list[str] = []
+        # e.g. the penalty clause in 18 U.S.C. § 1001(a)).
+        # Continuations extracted from within <content> above are prepended so
+        # they appear in document order before any direct-child continuations.
+        continuation: list[str] = list(content_continuations)
         continuation_elems = elem.findall("{*}continuation") or elem.findall(
             "continuation"
         )
@@ -1157,10 +1230,43 @@ class USLMParser:
                     if cont_text:
                         section_continuation.append(cont_text)
 
-                # Parse each paragraph
+                # Parse each paragraph, then bubble up any <continuation> elements
+                # that were nested inside a paragraph's <content>.  In OLRC XML
+                # (e.g. 17 U.S.C. § 107) these represent flush-left closing text
+                # that applies to the entire section — semantically equivalent to
+                # indent_level=0 — not a sub-clause of the individual paragraph.
+                # We promote them to the synthetic section-wrapper's continuation
+                # so they render at indent_level=0.  The paragraph's own
+                # continuation list is cleared after promotion to avoid duplication.
                 children = []
                 for para_elem in para_elems:
-                    children.append(self._parse_subsection(para_elem, "paragraph"))
+                    parsed_para = self._parse_subsection(para_elem, "paragraph")
+                    # Detect which continuation items originated inside <content>
+                    # (captured by _parse_subsection via content_continuations).
+                    para_content_elem = para_elem.find("{*}content")
+                    if para_content_elem is None:
+                        para_content_elem = para_elem.find("content")
+                    if para_content_elem is not None:
+                        in_content_cont_texts = {
+                            self._get_text_content(ce, strip_footnotes=True)
+                            for ce in (
+                                para_content_elem.findall("{*}continuation")
+                                or para_content_elem.findall("continuation")
+                            )
+                        }
+                        if in_content_cont_texts:
+                            # Bubble these up to section level and remove from
+                            # the paragraph so they don't render at indent_level=1.
+                            promoted: list[str] = []
+                            kept: list[str] = []
+                            for ct in parsed_para.continuation:
+                                if ct in in_content_cont_texts:
+                                    promoted.append(ct)
+                                else:
+                                    kept.append(ct)
+                            section_continuation.extend(promoted)
+                            parsed_para.continuation = kept
+                    children.append(parsed_para)
 
                 # Wrap in a synthetic subsection so normalization handles it
                 subsections.append(

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1019,7 +1019,7 @@ class USLMParser:
                 be omitted from the result.
             strip_footnotes: If True, also skip footnote refs and notes.
         """
-        excluded_set = set(id(e) for e in excluded)
+        excluded_set = {id(e) for e in excluded}
 
         def itertext_excluding(
             el: etree._Element,

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -966,6 +966,120 @@ class TestNormalizeParsedSectionDirectParagraphs:
         assert result.provisions[4].indent_level == 2
 
 
+class TestNormalizeParsedSectionContinuationInsideContent:
+    """End-to-end tests for <continuation> inside <content> in enumerated lists.
+
+    Regression tests for Issue #447: 17 U.S.C. § 107's closing sentence
+    ("The fact that a work is unpublished...") appears as a <continuation>
+    element inside the <content> of the last <paragraph>.  The parser
+    must promote it to section level so it renders at indent_level=0.
+    """
+
+    def test_continuation_inside_content_renders_at_indent_level_0(self) -> None:
+        """A <continuation> inside a paragraph's <content> is promoted to
+        section level and renders at indent_level=0.
+
+        Models 17 U.S.C. § 107: four numbered factors followed by a flush-left
+        closing sentence that applies to the entire section, not just factor (4).
+        """
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        # Simulate what the parser produces AFTER the fix: the continuation
+        # has been promoted out of para4 and into the synthetic wrapper.
+        section = ParsedSection(
+            section_number="107",
+            heading="Limitations on exclusive rights: Fair use",
+            full_citation="17 U.S.C. § 107",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="",
+                    heading=None,
+                    content=(
+                        "Notwithstanding the provisions of sections 106 and 106A, "
+                        "in determining whether the use made of a work in any "
+                        "particular case is a fair use the factors to be considered "
+                        "shall include—"
+                    ),
+                    level="subsection",
+                    children=[
+                        ParsedSubsection(
+                            marker="(1)",
+                            heading=None,
+                            content="the purpose and character of the use;",
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(2)",
+                            heading=None,
+                            content="the nature of the copyrighted work;",
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(3)",
+                            heading=None,
+                            content=(
+                                "the amount and substantiality of the portion used;"
+                            ),
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(4)",
+                            heading=None,
+                            content=(
+                                "the effect of the use upon the potential market for "
+                                "or value of the copyrighted work."
+                            ),
+                            level="paragraph",
+                            continuation=[],  # NOT here — promoted to wrapper
+                        ),
+                    ],
+                    continuation=[
+                        "The fact that a work is unpublished shall not itself bar "
+                        "a finding of fair use if such finding is made upon "
+                        "consideration of all the above factors."
+                    ],
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+
+        # Find the continuation line
+        continuation_lines = [
+            p for p in result.provisions if "unpublished" in p.content
+        ]
+        assert len(continuation_lines) == 1, (
+            "Expected exactly one line containing the continuation text"
+        )
+        cont_line = continuation_lines[0]
+
+        # The continuation must be at indent_level=0 (flush-left, section level)
+        assert cont_line.indent_level == 0, (
+            f"Expected indent_level=0 for continuation, got {cont_line.indent_level}"
+        )
+        assert cont_line.marker is None
+
+        # The numbered factors should be at indent_level=1
+        factor_lines = [
+            p for p in result.provisions if p.marker in {"(1)", "(2)", "(3)", "(4)"}
+        ]
+        assert len(factor_lines) == 4
+        for fl in factor_lines:
+            assert fl.indent_level == 1, (
+                f"Factor {fl.marker} expected indent_level=1, got {fl.indent_level}"
+            )
+
+        # The continuation must appear after all four factors
+        cont_line_num = cont_line.line_number
+        for fl in factor_lines:
+            assert fl.line_number < cont_line_num, (
+                f"Factor {fl.marker} (line {fl.line_number}) must come before "
+                f"continuation (line {cont_line_num})"
+            )
+
+
 class TestNormalizeParsedSectionContinuation:
     """Tests for <continuation> elements in parsed sections.
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -336,6 +336,86 @@ class TestUSLMParser:
         assert "shall be fined" in sub_a.continuation[0]
 
 
+    def test_extract_subsections_continuation_inside_content_bubbled_to_section_level(
+        self, parser: USLMParser
+    ) -> None:
+        """A <continuation> nested inside a paragraph's <content> is promoted to
+        the section-level synthetic wrapper, not left on the paragraph.
+
+        Regression test for Issue #447: 17 U.S.C. § 107 has a flush-left closing
+        sentence ("The fact that a work is unpublished...") encoded as a
+        <continuation> inside the <content> of the last <paragraph>.  OLRC
+        semantics treat this as a section-level statement (indent_level=0), but
+        the parser was previously including it as part of the paragraph's text,
+        causing it to render at indent_level=2 instead of 0.
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t17/s107">
+          <num value="107">§ 107.</num>
+          <heading>Limitations on exclusive rights: Fair use</heading>
+          <chapeau>Notwithstanding the provisions of sections 106 and 106A, the fair
+          use of a copyrighted work, including such use by reproduction in copies or
+          phonorecords or by any other means specified by that section, for purposes
+          such as criticism, comment, news reporting, teaching (including multiple
+          copies for classroom use), scholarship, or research, is not an infringement
+          of copyright. In determining whether the use made of a work in any
+          particular case is a fair use the factors to be considered shall include—
+          </chapeau>
+          <paragraph identifier="/us/usc/t17/s107/1">
+            <num value="1">(1)</num>
+            <content>the purpose and character of the use, including whether such
+            use is of a commercial nature or is for nonprofit educational
+            purposes;</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t17/s107/2">
+            <num value="2">(2)</num>
+            <content>the nature of the copyrighted work;</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t17/s107/3">
+            <num value="3">(3)</num>
+            <content>the amount and substantiality of the portion used in relation
+            to the copyrighted work as a whole; and</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t17/s107/4">
+            <num value="4">(4)</num>
+            <content>the effect of the use upon the potential market for or value
+            of the copyrighted work.
+            <continuation>The fact that a work is unpublished shall not itself bar
+            a finding of fair use if such finding is made upon consideration of all
+            the above factors.</continuation>
+            </content>
+          </paragraph>
+        </section>"""
+        elem = etree.fromstring(xml)
+        subsections = parser._extract_subsections(elem)
+
+        # Should produce one synthetic wrapper subsection
+        assert len(subsections) == 1
+        wrapper = subsections[0]
+        assert wrapper.marker == ""
+
+        # The wrapper should have 4 paragraph children
+        assert len(wrapper.children) == 4
+
+        # Paragraph (4) should NOT include the continuation text in its content
+        para4 = wrapper.children[3]
+        assert para4.marker == "(4)"
+        assert "effect of the use" in para4.content
+        assert "unpublished" not in para4.content, (
+            "Continuation text must not appear in paragraph (4) content"
+        )
+        # Paragraph (4) should have no continuation of its own
+        assert para4.continuation == [], (
+            "Continuation from <content> must be promoted to section level"
+        )
+
+        # The wrapper (section-level) should carry the continuation
+        assert len(wrapper.continuation) == 1
+        assert "unpublished" in wrapper.continuation[0], (
+            "Continuation text must be promoted to the section-level wrapper"
+        )
+
+
 class TestToTitleCase:
     """Tests for to_title_case function."""
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -335,7 +335,6 @@ class TestUSLMParser:
         assert len(sub_a.continuation) == 1
         assert "shall be fined" in sub_a.continuation[0]
 
-
     def test_extract_subsections_continuation_inside_content_bubbled_to_section_level(
         self, parser: USLMParser
     ) -> None:


### PR DESCRIPTION
## What was the bug

In 17 USC § 107, the OLRC XML encodes the closing sentence "The fact that a work is unpublished..." as a `<continuation>` element **inside** the `<content>` of the last `<paragraph>`:

```xml
<paragraph identifier="/us/usc/t17/s107/4">
  <num>(4)</num>
  <content>
    the effect of the use upon the potential market for or value of the copyrighted work.
    <continuation>The fact that a work is unpublished shall not itself bar a finding of
    fair use if such finding is made upon consideration of all the above factors.</continuation>
  </content>
</paragraph>
```

This sentence is flush-left text that applies to the **entire section** (semantically `indent_level=0`), but the parser was including it as part of paragraph (4)'s text content. When `_normalize_subsection_recursive` processed the two-sentence content at `base_indent=1`, the second sentence got emitted at `indent_level=2` — visually appearing as a sub-item nested under factor (4) rather than a section-level statement.

**Before:**
```
line 5  indent_level=1  "(4) the effect of the use upon the potential market..."
line 6  indent_level=2  "The fact that a work is unpublished..."  ← BUG (level 2)
```

**After:**
```
line 5  indent_level=1  "(4) the effect of the use upon the potential market..."
line 6  indent_level=0  "The fact that a work is unpublished..."  ← FIXED (level 0)
```

## What the fix does

**`backend/pipeline/olrc/parser.py`**

- Adds `_get_text_content_excluding()` — a helper that collects text from an element while skipping specified child elements (used to get content text without embedded `<continuation>` children).
- Modifies `_parse_subsection()` so that when a `<content>` element has `<continuation>` children, those children are stripped from the content text and captured separately in `content_continuations`.
- Modifies `_extract_subsections()` Pattern 2 (direct paragraphs under section) to detect content-level continuations and **promote them** from each paragraph to the synthetic section-wrapper's `continuation` list. The paragraph's `continuation` is cleared of those promoted items to prevent duplication. Because the synthetic wrapper has `base_indent=0`, the normalizer emits these at `indent_level=0`.

**`backend/tests/pipeline/test_parser.py`**

- Adds `test_extract_subsections_continuation_inside_content_bubbled_to_section_level` — parser-level test asserting that paragraph (4)'s `content` excludes the continuation text, paragraph (4)'s `continuation` list is empty, and the synthetic wrapper's `continuation` carries the promoted text.

**`backend/tests/pipeline/test_normalized_section.py`**

- Adds `TestNormalizeParsedSectionContinuationInsideContent` with an end-to-end test asserting that the promoted continuation renders at `indent_level=0`, the four numbered factors render at `indent_level=1`, and the continuation appears after all four factors.

Closes #447