### PR TITLE
fix: multi-sentence no-marker subsections render at indent_level=0

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -2126,7 +2126,10 @@ def _normalize_subsection_recursive(
                     marker = None
                     # Indent one level deeper so continuation lines align with
                     # the text portion of the first line, not the marker.
-                    line_indent = base_indent + 1
+                    # Only applies when there is a marker; without one, all
+                    # sentences are flush at base_indent (e.g. 17 U.S.C. § 107
+                    # chapeau where both sentences are section-level text).
+                    line_indent = base_indent + 1 if subsection.marker else base_indent
 
                 line_counter[0] += 1
                 start_pos = char_pos[0]

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -885,6 +885,55 @@ class TestNormalizeParsedSection:
         assert result.provisions[5].content == "(2) Second term"
         assert result.provisions[6].content == "Another definition."
 
+    def test_multi_sentence_no_marker_all_at_same_indent(self) -> None:
+        """Multiple sentences in a no-marker subsection all render at base_indent.
+
+        Regression test for Issue #450: 17 U.S.C. § 107's synthetic wrapper has
+        no marker, so "In determining whether..." must not be bumped to indent_level=1.
+        """
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        section = ParsedSection(
+            section_number="107",
+            heading="Fair use",
+            full_citation="17 U.S.C. § 107",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="",
+                    heading=None,
+                    content=(
+                        "Notwithstanding the provisions of sections 106 and 106A, "
+                        "fair use is not infringement. "
+                        "In determining whether the use is a fair use the factors shall include—"
+                    ),
+                    level="subsection",
+                    children=[
+                        ParsedSubsection(
+                            marker="(1)",
+                            heading=None,
+                            content="the purpose of the use;",
+                            level="paragraph",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+
+        sentence_lines = [
+            p for p in result.provisions if p.content and not p.content.startswith("(")
+        ]
+        # Both section-level sentences must be at indent_level=0
+        for line in sentence_lines:
+            if "Notwithstanding" in line.content or "In determining" in line.content:
+                assert line.indent_level == 0, (
+                    f"Expected indent_level=0 for '{line.content[:40]}...', "
+                    f"got {line.indent_level}"
+                )
+
 
 class TestNormalizeParsedSectionDirectParagraphs:
     """Tests for sections with paragraphs directly under section (no subsection).


### PR DESCRIPTION
## Summary

- In `_normalize_subsection_recursive`, subsequent sentences in a multi-sentence content block were always bumped to `base_indent + 1`. This is correct when there's a marker (e.g. `(a)`) so the second sentence aligns with the text, not the marker — but wrong when there's no marker, where all sentences should stay flush at `base_indent`.
- Fix: `line_indent = base_indent + 1 if subsection.marker else base_indent` (one line change in `normalized_section.py`).
- Adds a regression test covering the § 107 pattern (no-marker wrapper with two section-level sentences).

Closes #450

## Before / After

17 USC § 107 has two section-level sentences before the enumerated list of factors. Before the fix:

```
indent_level=0  Notwithstanding the provisions of sections 106 and 106A...is not an infringement of copyright.
indent_level=1  In determining whether the use made of a work in any particular case is a fair use...  ← BUG
indent_level=1  (1) the purpose and character of the use;
...
```

After:

```
indent_level=0  Notwithstanding the provisions of sections 106 and 106A...is not an infringement of copyright.
indent_level=0  In determining whether the use made of a work in any particular case is a fair use...  ← FIXED
indent_level=1  (1) the purpose and character of the use;
...
```