### PR TITLE
fix: parse full paragraph text for amendments with multiple law refs (Issue #454)

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -364,14 +364,17 @@ _REPORT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _YEAR_PATTERN = re.compile(r"(\d{4})\s*[—–-]\s*", re.MULTILINE)
+# Pattern to extract the optional subsection prefix and the FIRST Pub. L. reference
+# from a single amendment paragraph.  The description runs to end-of-string so that
+# secondary Pub. L. cross-references within the same paragraph are captured as part
+# of the description rather than triggering a new amendment record.
 _PUB_L_PATTERN = re.compile(
-    r"((?:Subsec\.?\s*"  # "Subsec." or "Subsec"
+    r"((?:Subsec[s]?\.?\s*"  # "Subsec.", "Subsec", "Subsecs.", "Subsecs"
     r"(?:\([^)]+\))+"  # One or more parenthesized markers like (c)(1)
     r"(?:\s*,\s*(?:\([^)]+\))+)*"  # Optional comma-separated markers like , (2)(A)
     r"\.?\s*)?)"  # Optional trailing period and whitespace
-    r"(Pub\.\s*L\.\s*(\d+)[—–-](\d+))"  # Pub. L. reference
-    r"(.*?)"  # Description (including any text after)
-    r"(?=Subsec\.?\s*(?:\([^)]+\))+|Pub\.\s*L\.\s*\d+[—–-]\d+|$)",  # Until next Subsec. or Pub. L. or end
+    r"(Pub\.\s*L\.\s*(\d+)[—–-](\d+))"  # First Pub. L. reference (primary law)
+    r"(.*)",  # Description — extends to end of string (captures all secondary refs)
     re.DOTALL,
 )
 
@@ -1173,7 +1176,7 @@ def _parse_amendments(text: str) -> list[Amendment]:
         text: The amendments subsection text.
 
     Returns:
-        List of Amendment objects, one per Pub. L. reference.
+        List of Amendment objects, one per XML paragraph (one per primary law).
     """
     amendments = []
 
@@ -1189,47 +1192,58 @@ def _parse_amendments(text: str) -> list[Amendment]:
 
         year_block = text[start:end].strip()
 
-        # Find all Pub. L. references within this year block; save the list so we
-        # can reuse it below without running finditer a second time (Finding 2).
-        matches = list(_PUB_L_PATTERN.finditer(year_block))
+        # Split the year block into individual paragraphs.  Each paragraph
+        # corresponds to one <p> element in the USLM XML and represents a
+        # single amendment entry.  Paragraphs are delimited by double newlines
+        # (inserted by the XML parser as [PARA] -> "\n\n").  Single newlines
+        # inside a paragraph are collapsed to spaces during processing.
+        paragraphs = [p.strip() for p in re.split(r"\n\n+", year_block) if p.strip()]
 
-        for pub_match in matches:
-            subsec_prefix = (pub_match.group(1) or "").strip()
-            public_law_text = pub_match.group(2)
-            congress = int(pub_match.group(3))
-            law_number = int(pub_match.group(4))
-            after_text = pub_match.group(5)
+        found_any = False
+        for paragraph in paragraphs:
+            # Apply the pattern only ONCE per paragraph (first match only).
+            # Secondary Pub. L. references are captured inside group(5) as part
+            # of the description and must not create new records.
+            pub_match = _PUB_L_PATTERN.search(paragraph)
+            if pub_match:
+                subsec_prefix = (pub_match.group(1) or "").strip()
+                public_law_text = pub_match.group(2)
+                congress = int(pub_match.group(3))
+                law_number = int(pub_match.group(4))
+                after_text = pub_match.group(5)
 
-            # Build description: subsec prefix + Pub. L. + rest
-            if subsec_prefix:
-                description = f"{subsec_prefix} {public_law_text}{after_text}"
-            else:
-                description = f"{public_law_text}{after_text}"
+                # Build description: subsec prefix + Pub. L. + rest
+                if subsec_prefix:
+                    description = f"{subsec_prefix} {public_law_text}{after_text}"
+                else:
+                    description = f"{public_law_text}{after_text}"
 
-            # Clean up description - normalize whitespace (handles multiple spaces)
-            description = " ".join(description.split())
+                # Clean up description - normalize whitespace (handles multiple spaces)
+                description = " ".join(description.split())
 
-            # Fix whitespace inside quotes (from XML date element spacing)
-            # e.g., '" December 31, 2021 "' -> '"December 31, 2021"'
-            # Match quoted content and strip leading/trailing spaces inside quotes
-            # Handle both straight quotes (") and curly quotes (" ")
-            description = re.sub(r'"(\s*)(.*?)(\s*)"', r'"\2"', description)
-            # Curly quotes: " (U+201C left) and " (U+201D right)
-            description = re.sub(
-                r"\u201c(\s*)(.*?)(\s*)\u201d", "\u201c\\2\u201d", description
-            )
-
-            law = ParsedPublicLaw(congress=congress, law_number=law_number)
-            amendments.append(
-                Amendment(
-                    law=law,
-                    year=year,
-                    description=description,
+                # Fix whitespace inside quotes (from XML date element spacing)
+                # e.g., '" December 31, 2021 "' -> '"December 31, 2021"'
+                # Match quoted content and strip leading/trailing spaces inside quotes
+                # Handle both straight quotes (") and curly quotes (" ")
+                description = re.sub(r'"(\s*)(.*?)(\s*)"', r'"\2"', description)
+                # Curly quotes: " (U+201C left) and " (U+201D right)
+                description = re.sub(
+                    r"\u201c(\s*)(.*?)(\s*)\u201d", "\u201c\\2\u201d", description
                 )
-            )
 
-        # If no Pub. L. found in the block, still record the year with the description
-        if not matches and year_block:
+                found_any = True
+                law = ParsedPublicLaw(congress=congress, law_number=law_number)
+                amendments.append(
+                    Amendment(
+                        law=law,
+                        year=year,
+                        description=description,
+                    )
+                )
+
+        # If no Pub. L. found in any paragraph, try a simple fallback search
+        # over the whole year block to handle unusual formats.
+        if not found_any and year_block:
             # Try to extract any Pub. L. reference
             simple_pub_match = re.search(r"Pub\.\s*L\.\s*(\d+)[—–-](\d+)", year_block)
             if simple_pub_match:

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2310,8 +2310,7 @@ class TestAmendmentMultiRef:
         assert len(amendments) == 1, (
             f"Expected 1 amendment, got {len(amendments)}: "
             + ", ".join(
-                f"PL {a.law.congress}-{a.law.law_number} ({a.year})"
-                for a in amendments
+                f"PL {a.law.congress}-{a.law.law_number} ({a.year})" for a in amendments
             )
         )
         a = amendments[0]

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2266,6 +2266,108 @@ class TestAmendmentSubsectionPrefix:
         assert "Subsec." not in amendments[0].description
 
 
+class TestAmendmentMultiRef:
+    """Tests for Issue #454 — amendment paragraphs containing multiple Pub. L. refs.
+
+    Each USLM <p> element must produce exactly ONE amendment record, even when
+    that paragraph contains inline cross-references to other public laws.
+    """
+
+    def test_single_ref_paragraph_produces_one_record(self) -> None:
+        """Regression: a paragraph with a single <ref> still produces one record."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        # Simulates a single-paragraph year block (one <p> element, one Pub. L.)
+        text = "2002—Pub. L. 107–273 made a technical correction."
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].year == 2002
+        assert amendments[0].law.congress == 107
+        assert amendments[0].law.law_number == 273
+        assert "technical correction" in amendments[0].description
+
+    def test_two_ref_paragraph_produces_one_record(self) -> None:
+        """Main bug case: a paragraph with two Pub. L. refs must emit ONE record.
+
+        The second Pub. L. is an inline cross-reference within the description
+        (e.g. 'made technical correction to directory language of Pub. L. 106-113'),
+        NOT a separate amendment entry.
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        # Two Pub. L. references within a single paragraph (single <p> element
+        # in USLM XML).  The second reference is a cross-reference inside the
+        # description text, not a new amendment.
+        text = (
+            "2002—Subsecs. (a), (c), (d). Pub. L. 107–273 made technical"
+            " correction to directory language of Pub. L. 106–113,"
+            " §  1000(a)(9) [title IV, §  4732(a)(10)(A)]."
+            " See 1999 Amendment notes below."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1, (
+            f"Expected 1 amendment, got {len(amendments)}: "
+            + ", ".join(
+                f"PL {a.law.congress}-{a.law.law_number} ({a.year})"
+                for a in amendments
+            )
+        )
+        a = amendments[0]
+        assert a.year == 2002
+        assert a.law.congress == 107
+        assert a.law.law_number == 273
+        # Description must include the subsection prefix
+        assert "Subsecs. (a), (c), (d)." in a.description
+        # Description must include the cross-reference to the second law
+        assert "Pub. L. 106–113" in a.description
+        # Description must not be truncated before the cross-reference
+        assert "directory language" in a.description
+
+    def test_text_before_first_ref_stays_with_paragraph(self) -> None:
+        """Subsection prefix text before the first Pub. L. belongs to the same record.
+
+        Verifies that leading text (e.g. 'Subsecs. (a), (c), (d).') is NOT
+        appended to the previous paragraph's record (no prefix bleeding).
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        # Two paragraphs separated by double newline (two <p> elements).
+        # The second paragraph has a subsection prefix.
+        text = (
+            "2002—Pub. L. 107–273 amended section generally.\n\n"
+            "Subsecs. (a), (b). Pub. L. 107–306 inserted text."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 2
+        first, second = amendments[0], amendments[1]
+        # First amendment should NOT contain the second paragraph's subsec prefix
+        assert "Subsecs. (a), (b)." not in first.description
+        # Second amendment must include its own subsec prefix
+        assert "Subsecs. (a), (b)." in second.description
+        assert second.law.congress == 107
+        assert second.law.law_number == 306
+
+    def test_two_separate_paragraphs_in_same_year_produce_two_records(self) -> None:
+        """Two <p> elements in the same year block each produce their own record."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        # Two paragraphs (two <p> elements) separated by double newline.
+        text = (
+            "1999—Pub. L. 106–113, § 1000(a)(9), substituted text.\n\n"
+            "Subsec. (a). Pub. L. 106–113, § 4803, redesignated text."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 2
+        years = [a.year for a in amendments]
+        assert years == [1999, 1999]
+        congress_nums = [a.law.congress for a in amendments]
+        assert all(c == 106 for c in congress_nums)
+
+
 class TestAmendmentDateSpacing:
     """Tests for fixing whitespace inside quotes in amendments."""
 


### PR DESCRIPTION
## Summary

**Bug**: The `_parse_amendments` function in `backend/pipeline/olrc/normalized_section.py` was producing spurious amendment records when a USLM XML `<p>` element contained multiple inline `<ref>` cross-references to different public laws.

**Root cause**: `_PUB_L_PATTERN` used a lookahead `(?=Pub. L. \d+|$)` that terminated each match at the next `Pub. L.` occurrence — including secondary cross-references within the same paragraph. The pattern ran as `finditer` across the full year block, so each `Pub. L.` token, even those embedded mid-sentence, started a new match and generated a spurious amendment record.

**Fix** (two changes, both in `normalized_section.py`):

1. **`_PUB_L_PATTERN`**: Removed the lookahead terminator. The description capture group now extends to end-of-string (`(.*)`) so all secondary cross-references in the same paragraph are captured inside `after_text` rather than splitting into new matches. Also widened the subsection prefix from `Subsec` to `Subsec[s]?` to handle the plural form (`Subsecs.`) used in multi-section amendment prefixes.

2. **`_parse_amendments`**: Changed from `finditer` over the full year block to splitting the year block on `\n\n` boundaries (each paragraph = one `<p>` element from USLM XML) and calling `_PUB_L_PATTERN.search()` exactly once per paragraph. This ensures one amendment record per `<p>` element regardless of how many `Pub. L.` cross-references appear inside it.

## Before / After (35 USC § 135, 2002 amendment paragraph)

Input XML paragraph:
```xml
<p>Subsecs. (a), (c), (d). <ref href="/us/pl/107/273">Pub. L. 107–273</ref> made technical correction to directory language of <ref href="/us/pl/106/113/s1000/a/9">Pub. L. 106–113, § 1000(a)(9)</ref> [title IV, § 4732(a)(10)(A)]. See 1999 Amendment notes below.</p>
```

**Before** (3 records from 1 paragraph):
- Record for PL 107-273: `"Pub. L. 107–273 made technical correction to directory language of"` ← TRUNCATED
- Record for PL 106-113: `"Pub. L. 106–113, § 1000(a)(9) [title IV, § 4732(a)(10)(A)]. See 1999 Amendment notes below."` ← SPURIOUS
- (`Subsecs. (a), (c), (d).` prefix bled into the previous paragraph's record)

**After** (1 record from 1 paragraph):
- Record for PL 107-273: `"Subsecs. (a), (c), (d). Pub. L. 107–273 made technical correction to directory language of Pub. L. 106–113, § 1000(a)(9) [title IV, § 4732(a)(10)(A)]. See 1999 Amendment notes below."` ← FULL TEXT, CORRECT LAW

## Test coverage added

Four new tests in `TestAmendmentMultiRef`:
- `test_single_ref_paragraph_produces_one_record` — regression: single `<ref>` paragraph still works
- `test_two_ref_paragraph_produces_one_record` — main bug: two `Pub. L.` in one paragraph → one record with full description
- `test_text_before_first_ref_stays_with_paragraph` — no subsection prefix bleeding to previous record
- `test_two_separate_paragraphs_in_same_year_produce_two_records` — two `<p>` elements in same year → two records (correctness preserved)

All 793 tests pass, 21 skipped (fixtures requiring `seed-laws`).

Closes #454

https://claude.ai/code/session_013RFR3Cvig7yVuiedNrsAsw

---
_Generated by [Claude Code](https://claude.ai/code/session_013RFR3Cvig7yVuiedNrsAsw)_