### PR TITLE
fix: parse full ISO date from source credit instead of defaulting to year-start (Task 466)

### DIFF
--- a/backend/app/crud/us_code.py
+++ b/backend/app/crud/us_code.py
@@ -486,17 +486,11 @@ async def get_section(
 
                 enacted_date = _parse_citation_date(law_data["date"])
 
-        # Extract last_modified_date from amendments
-        amendments = state.normalized_notes.get("amendments", [])
-        if amendments:
-            from datetime import date
-
-            max_year = max(a["year"] for a in amendments if "year" in a)
-            last_modified_date = date(max_year, 1, 1)
-
-        # Fallback: derive last_modified_date from amendment citations when
-        # the amendments list is empty (e.g. stale ingestion or unstructured notes)
-        if last_modified_date is None and citations:
+        # Extract last_modified_date from amendment citations (full ISO date).
+        # Prefer the precise date from citation law.date over the year-only
+        # value stored on amendment entries, which would otherwise default to
+        # {year}-01-01 and misrepresent the actual amendment date.
+        if citations:
             from pipeline.olrc.group_service import _parse_citation_date
 
             amendment_dates = []
@@ -509,6 +503,17 @@ async def get_section(
                             amendment_dates.append(parsed)
             if amendment_dates:
                 last_modified_date = max(amendment_dates)
+
+        # Fallback: when citation dates are unavailable, use the year from
+        # the amendments list (e.g. stale ingestion or unstructured notes).
+        if last_modified_date is None:
+            amendments = state.normalized_notes.get("amendments", [])
+            if amendments:
+                from datetime import date
+
+                years = [a["year"] for a in amendments if "year" in a]
+                if years:
+                    last_modified_date = date(max(years), 1, 1)
 
     # Find the revision that last *changed* this section's content.
     # Reuse the same chain to avoid re-fetching HEAD + CTE.

--- a/backend/tests/test_last_modified_date.py
+++ b/backend/tests/test_last_modified_date.py
@@ -1,9 +1,8 @@
 """Unit tests for last_modified_date derivation from amendment citations.
 
-These tests verify the fallback logic added to get_section() in
-app/crud/us_code.py: when the `amendments` list is empty but `citations`
-contains entries with relationship "Amendment", last_modified_date should be
-derived from the most recent amendment citation date.
+These tests verify the logic in get_section() in app/crud/us_code.py:
+last_modified_date is derived from the most recent amendment citation date,
+using the full ISO date (YYYY-MM-DD) rather than falling back to {year}-01-01.
 
 The tests exercise the same computation as the production code by calling
 _parse_citation_date directly and running the equivalent selection logic.
@@ -14,8 +13,17 @@ from datetime import date
 from pipeline.olrc.group_service import _parse_citation_date
 
 
-def _compute_last_modified_date_from_citations(citations: list[dict]) -> date | None:
-    """Mirror of the fallback logic in get_section() for isolated testing."""
+def _compute_last_modified_date(
+    citations: list[dict],
+    amendments: list[dict] | None = None,
+) -> date | None:
+    """Mirror of the primary + fallback logic in get_section() for isolated testing.
+
+    Primary path: derive the full date from amendment citations (relationship == "Amendment").
+    Fallback path: when no citation dates are available, use the year from the amendments
+    list and default to {year}-01-01.
+    """
+    # Primary: use full date from amendment citations
     amendment_dates = []
     for c in citations:
         if c.get("relationship") == "Amendment":
@@ -24,7 +32,21 @@ def _compute_last_modified_date_from_citations(citations: list[dict]) -> date | 
                 parsed = _parse_citation_date(law_data["date"])
                 if parsed is not None:
                     amendment_dates.append(parsed)
-    return max(amendment_dates) if amendment_dates else None
+    if amendment_dates:
+        return max(amendment_dates)
+
+    # Fallback: use year from amendments list
+    if amendments:
+        years = [a["year"] for a in amendments if "year" in a]
+        if years:
+            return date(max(years), 1, 1)
+
+    return None
+
+
+def _compute_last_modified_date_from_citations(citations: list[dict]) -> date | None:
+    """Mirror of the citation-only logic in get_section() for isolated testing."""
+    return _compute_last_modified_date(citations, amendments=None)
 
 
 class TestLastModifiedDateFromCitations:
@@ -140,3 +162,75 @@ class TestLastModifiedDateFromCitations:
         ]
         result = _compute_last_modified_date_from_citations(citations)
         assert result == date(1996, 10, 12)
+
+
+class TestLastModifiedDateFullDateNotYearStart:
+    """Verify that last_modified_date uses the full ISO date, not {year}-01-01.
+
+    Regression tests for issue #466: 2 U.S.C. § 33 was returning
+    last_modified_date=1981-01-01 instead of 1981-10-01 because the code
+    extracted only the year from the amendments list and constructed
+    date(year, 1, 1) rather than parsing the full date from citations.
+    """
+
+    def test_2usc33_oct_1981_full_date(self) -> None:
+        """2 U.S.C. § 33 scenario: Oct. 1, 1981 must yield 1981-10-01, not 1981-01-01.
+
+        OLRC source credit:
+            (June 19, 1934, ch. 648, title I, § 1, 48 Stat. 1022;
+             Pub. L. 97–51, § 112(b)(2), Oct. 1, 1981, 95 Stat. 963.)
+        The amendment date Oct. 1, 1981 must be fully parsed, not truncated to year-start.
+        """
+        citations = [
+            {
+                "law_id": "PL 97-51",
+                "law": {"date": "Oct. 1, 1981", "congress": 97, "law_number": 51},
+                "relationship": "Amendment",
+            },
+        ]
+        amendments = [
+            {"year": 1981, "law": {"congress": 97, "law_number": 51}},
+        ]
+        result = _compute_last_modified_date(citations, amendments)
+        assert result == date(1981, 10, 1), (
+            f"Expected 1981-10-01 (full date from citation), got {result} "
+            f"(year-start fallback would give 1981-01-01)"
+        )
+
+    def test_citation_date_preferred_over_year_start(self) -> None:
+        """When both citations and amendments are present, citation date wins over year-start."""
+        citations = [
+            {
+                "law_id": "PL 100-1",
+                "law": {"date": "Nov. 15, 1987", "congress": 100, "law_number": 1},
+                "relationship": "Enactment",
+            },
+            {
+                "law_id": "PL 101-5",
+                "law": {"date": "Mar. 7, 1990", "congress": 101, "law_number": 5},
+                "relationship": "Amendment",
+            },
+        ]
+        # amendments list only has year, not full date
+        amendments = [
+            {"year": 1990, "law": {"congress": 101, "law_number": 5}},
+        ]
+        result = _compute_last_modified_date(citations, amendments)
+        # Must be Mar. 7 not Jan. 1
+        assert result == date(1990, 3, 7)
+
+    def test_fallback_to_year_start_when_no_citation_dates(self) -> None:
+        """When citation dates are absent, fall back to {year}-01-01 from amendments list."""
+        # Citations exist but none are amendments with dates
+        citations = [
+            {
+                "law_id": "PL 100-1",
+                "law": {"congress": 100, "law_number": 1},  # no date field
+                "relationship": "Amendment",
+            },
+        ]
+        amendments = [
+            {"year": 1988, "law": {"congress": 100, "law_number": 1}},
+        ]
+        result = _compute_last_modified_date(citations, amendments)
+        assert result == date(1988, 1, 1)


### PR DESCRIPTION
## Bug

`last_modified_date` for 2 U.S.C. § 33 was returned as `1981-01-01` instead of `1981-10-01`.

**Root cause**: The old code derived `last_modified_date` by extracting only the year from the `amendments` list and constructing `date(year, 1, 1)`:

```python
# OLD (buggy)
amendments = state.normalized_notes.get("amendments", [])
if amendments:
    max_year = max(a["year"] for a in amendments if "year" in a)
    last_modified_date = date(max_year, 1, 1)   # always Jan 1!

# Then checked citations only as a fallback (when amendments is empty)
if last_modified_date is None and citations:
    ...
```

The `amendments` list stores only a `year` field (extracted from the "Amendments" editorial note), so a section with `year=1981` would get `last_modified_date=1981-01-01` even when the citation stored the full date `"Oct. 1, 1981"`.

## Fix

Reorder the derivation so **citation dates are checked first**. Amendment citations already carry the full prose date (e.g. `"Oct. 1, 1981"`) which `_parse_citation_date` normalises to `1981-10-01`. The `{year}-01-01` fallback is retained for legacy data where citations lack a date field.

## Before / After

Source credit for 2 U.S.C. § 33:
```
(June 19, 1934, ch. 648, title I, § 1, 48 Stat. 1022; Pub. L. 97–51, § 112(b)(2), Oct. 1, 1981, 95 Stat. 963.)
```

| Field | Before | After |
|---|---|---|
| `last_modified_date` | `1981-01-01` | `1981-10-01` |

## Tests

Added `TestLastModifiedDateFullDateNotYearStart` class with three regression tests:
- `test_2usc33_oct_1981_full_date` — the exact 2 U.S.C. § 33 scenario
- `test_citation_date_preferred_over_year_start` — citation date wins when both sources present
- `test_fallback_to_year_start_when_no_citation_dates` — year-only fallback still works

All 800 tests pass (0 failures).

Closes #466

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpCmhjC77cUax94kWtSAyD)_