### PR TITLE
fix: use as-added law date for enacted_date when section added by amendment

### DIFF
--- a/backend/pipeline/olrc/ingestion.py
+++ b/backend/pipeline/olrc/ingestion.py
@@ -17,6 +17,7 @@ from app.models import (
     SectionGroup,
     USCodeSection,
 )
+from app.models.enums import SourceRelationship
 from pipeline.olrc.downloader import OLRCDownloader
 from pipeline.olrc.group_service import (
     _parse_citation_date,
@@ -211,31 +212,50 @@ class USCodeIngestionService:
         if normalized.section_notes:
             normalized_notes = normalized.section_notes.model_dump(mode="json")
 
-            # Extract enacted_date and statutes_at_large_citation from first citation
+            # Extract enacted_date and statutes_at_large_citation from the
+            # enacting citation.  When a section has an "as added" source
+            # credit (e.g. "June 25, 1938, ch. 675, § 503B, as added
+            # Pub. L. 110–85, … Sept. 27, 2007"), the citations list contains:
+            #   [0] Framework Act (1938) — the parent organic statute
+            #   [1] Enactment PL (2007) — the law that actually created this section
+            # Using citations[0] in that case produces the wrong date.  Instead,
+            # prefer the first citation whose relationship is ENACTMENT; fall back
+            # to citations[0] when no explicit enactment citation is present (e.g.
+            # older sections that only have a single Act reference).
             if normalized.section_notes.citations:
-                first_citation = normalized.section_notes.citations[0]
+                enactment_citation = next(
+                    (
+                        c
+                        for c in normalized.section_notes.citations
+                        if c.relationship == SourceRelationship.ENACTMENT
+                    ),
+                    normalized.section_notes.citations[0],
+                )
 
-                # Get date from the first citation (either Public Law or Act)
-                if first_citation.law and first_citation.law.date:
-                    enacted_date = _parse_citation_date(first_citation.law.date)
-                elif first_citation.act and first_citation.act.date:
-                    enacted_date = _parse_citation_date(first_citation.act.date)
+                # Get date from the enacting citation (either Public Law or Act)
+                if enactment_citation.law and enactment_citation.law.date:
+                    enacted_date = _parse_citation_date(enactment_citation.law.date)
+                elif enactment_citation.act and enactment_citation.act.date:
+                    enacted_date = _parse_citation_date(enactment_citation.act.date)
 
                 # Get Statutes at Large citation
-                if first_citation.law:
-                    if first_citation.law.stat_volume and first_citation.law.stat_page:
+                if enactment_citation.law:
+                    if (
+                        enactment_citation.law.stat_volume
+                        and enactment_citation.law.stat_page
+                    ):
                         statutes_at_large_citation = (
-                            f"{first_citation.law.stat_volume} Stat. "
-                            f"{first_citation.law.stat_page}"
+                            f"{enactment_citation.law.stat_volume} Stat. "
+                            f"{enactment_citation.law.stat_page}"
                         )
                 elif (
-                    first_citation.act
-                    and first_citation.act.stat_volume
-                    and first_citation.act.stat_page
+                    enactment_citation.act
+                    and enactment_citation.act.stat_volume
+                    and enactment_citation.act.stat_page
                 ):
                     statutes_at_large_citation = (
-                        f"{first_citation.act.stat_volume} Stat. "
-                        f"{first_citation.act.stat_page}"
+                        f"{enactment_citation.act.stat_volume} Stat. "
+                        f"{enactment_citation.act.stat_page}"
                     )
 
         # Derive last_modified_date from the most recent amendment year

--- a/backend/tests/pipeline/test_section_ingestion.py
+++ b/backend/tests/pipeline/test_section_ingestion.py
@@ -380,3 +380,133 @@ class TestUpsertSectionWithActRefs:
         # Verify statutes_at_large_citation is set
         added_section = mock_session.add.call_args[0][0]
         assert added_section.statutes_at_large_citation == "49 Stat. 477"
+
+
+class TestUpsertSectionAsAdded:
+    """Tests for enacted_date when a section has 'as added' in the source credit.
+
+    Issue #474: For sections where the source credit contains "as added",
+    the enacted_date should reflect the adding law's date, not the parent
+    organic statute's date.
+
+    Example (21 U.S.C. § 353b):
+        Source credit:
+            (June 25, 1938, ch. 675, § 503B, as added
+             Pub. L. 110–85, title IX, § 901(d)(2), Sept. 27, 2007, 121 Stat. 939.)
+        Wrong: enacted_date = 1938-06-25  (parent organic statute)
+        Right: enacted_date = 2007-09-27  (the adding law)
+    """
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock async session."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def parsed_section_as_added(self):
+        """Create a ParsedSection mirroring 21 U.S.C. § 353b.
+
+        Source credit:
+            (June 25, 1938, ch. 675, § 503B, as added Pub. L. 110-85,
+             title IX, § 901(d)(2), Sept. 27, 2007, 121 Stat. 939.)
+
+        This produces:
+          - act_refs: [ActRef(date="1938-06-25", chapter=675)]  → Framework
+          - source_credit_refs: [SourceCreditRef(congress=110, law_number=85,
+                date="Sept. 27, 2007", stat_volume=121, stat_page=939)]  → Enactment
+        """
+        from pipeline.olrc.parser import ActRef, ParsedSection, SourceCreditRef
+
+        return ParsedSection(
+            section_number="353b",
+            heading="Outsourcing Facility",
+            full_citation="21 U.S.C. § 353b",
+            text_content="Conditions for exemption from pharmacy compounding...",
+            subsections=[],
+            act_refs=[
+                ActRef(
+                    date="1938-06-25",
+                    chapter=675,
+                    section="503B",
+                    stat_volume=None,
+                    stat_page=None,
+                    raw_text="June 25, 1938, ch. 675, § 503B",
+                ),
+            ],
+            source_credit_refs=[
+                SourceCreditRef(
+                    congress=110,
+                    law_number=85,
+                    title="IX",
+                    section="901(d)(2)",
+                    date="Sept. 27, 2007",
+                    stat_volume=121,
+                    stat_page=939,
+                    raw_text="Pub. L. 110-85, title IX, § 901(d)(2), Sept. 27, 2007, 121 Stat. 939",
+                ),
+            ],
+            notes=(
+                "(June 25, 1938, ch. 675, § 503B, as added Pub. L. 110-85, "
+                "title IX, § 901(d)(2), Sept. 27, 2007, 121 Stat. 939.)"
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_as_added_section_uses_adding_law_date(
+        self, mock_session, parsed_section_as_added
+    ) -> None:
+        """enacted_date must be the adding law's date, not the organic statute's date.
+
+        Before the fix, citations[0] (the 1938 Framework Act) was used, returning
+        1938-06-25.  The correct date is 2007-09-27 from the Enactment citation.
+        """
+        from pipeline.olrc.ingestion import USCodeIngestionService
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        service = USCodeIngestionService(mock_session)
+        await service._upsert_section(
+            parsed_section_as_added,
+            group_id=1,
+            title_number=21,
+            force=False,
+        )
+
+        added_section = mock_session.add.call_args[0][0]
+        # Must be the adding law date (2007-09-27), NOT the organic statute (1938-06-25)
+        assert added_section.enacted_date == date(2007, 9, 27), (
+            f"Expected 2007-09-27 (adding law date) but got {added_section.enacted_date}. "
+            "The enacted_date must come from the Enactment citation, not the Framework Act."
+        )
+
+    @pytest.mark.asyncio
+    async def test_as_added_section_uses_adding_law_statutes_citation(
+        self, mock_session, parsed_section_as_added
+    ) -> None:
+        """statutes_at_large_citation must come from the adding law, not the organic statute."""
+        from pipeline.olrc.ingestion import USCodeIngestionService
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        service = USCodeIngestionService(mock_session)
+        await service._upsert_section(
+            parsed_section_as_added,
+            group_id=1,
+            title_number=21,
+            force=False,
+        )
+
+        added_section = mock_session.add.call_args[0][0]
+        # Must be from the adding law (Pub. L. 110-85), not the organic statute
+        assert added_section.statutes_at_large_citation == "121 Stat. 939", (
+            f"Expected '121 Stat. 939' (adding law) but got "
+            f"'{added_section.statutes_at_large_citation}'."
+        )


### PR DESCRIPTION
## Bug

Issue #474: For US Code sections whose source credit contains "as added", `enacted_date` was returning the founding date of the parent organic statute instead of the actual creation date.

**Example — 21 U.S.C. § 353b:**
```
Source credit:
  (June 25, 1938, ch. 675, § 503B, as added Pub. L. 110–85, title IX, § 901(d)(2), Sept. 27, 2007, 121 Stat. 939.)
```

| Field | Before | After |
|---|---|---|
| `enacted_date` | `1938-06-25` (parent organic statute) | `2007-09-27` (adding law) |
| `statutes_at_large_citation` | `null` (Act had no stat ref) | `121 Stat. 939` (adding law) |

## Root Cause

`_upsert_section` unconditionally used `citations[0]` as the enacting citation. For "as added" sections, the citations list is:
- `citations[0]` — Framework Act (1938) — structural context only
- `citations[1]` — Enactment PL (2007) — the law that actually created the section

`citations_from_source_credit_refs` already correctly marks the Public Law as `relationship=ENACTMENT` and the Act as `relationship=FRAMEWORK`. The ingestion layer just wasn't using that signal.

## Fix

In `backend/pipeline/olrc/ingestion.py`, replace `citations[0]` with a lookup that selects the first citation whose `relationship == SourceRelationship.ENACTMENT`, falling back to `citations[0]` for older sections that only have a single Act reference (no framework/enactment split).

## Tests Added

`TestUpsertSectionAsAdded` in `backend/tests/pipeline/test_section_ingestion.py` with two new test cases:
- `test_as_added_section_uses_adding_law_date` — verifies `enacted_date == 2007-09-27`
- `test_as_added_section_uses_adding_law_statutes_citation` — verifies `statutes_at_large_citation == "121 Stat. 939"`

Both tests use a `ParsedSection` fixture mirroring the real 21 U.S.C. § 353b data.

## Parsing Proof

**Before fix** — `citations[0]` is the 1938 Framework Act:
```
enacted_date = 1938-06-25
statutes_at_large_citation = null
```

**After fix** — first `ENACTMENT` citation is Pub. L. 110-85:
```
enacted_date = 2007-09-27
statutes_at_large_citation = "121 Stat. 939"
```

Closes #474

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGCscTUi9Whiu2ECrvxaE)_