### PR TITLE
fix: assign source-credit dates to correct law citation (off-by-one)

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1563,86 +1563,93 @@ class USLMParser:
         if source_credit is None:
             return pl_refs, act_refs
 
-        # Find all ref elements within sourceCredit
-        ref_elems = source_credit.findall(".//{*}ref")
-        if not ref_elems:
-            ref_elems = source_credit.findall(".//ref")
-
-        # Track current stat volume/page for associating with refs
+        # Walk source credit in document order, processing <ref> and <date>
+        # elements together so each <date> is assigned to the PL ref that
+        # immediately precedes it in the XML (not the one before that).
+        #
+        # In OLRC XML, a <date> always follows the <ref> it belongs to:
+        #   Pub. L. 99–498, ..., <date>Oct. 17, 1986</date>, ...
+        # A two-pass approach (collect all refs, then collect all dates and
+        # zip by index) incorrectly assigns each date to the preceding law
+        # rather than the law it actually dates.
         current_stat_volume: int | None = None
         current_stat_page: int | None = None
-        # Track the most recent ref (either PL or Act) for stat association
+        # Track the most recent ref (either PL or Act) for stat/date association
         last_ref_type: str | None = None
 
-        for ref_elem in ref_elems:
-            href = ref_elem.get("href", "")
-            text = "".join(ref_elem.itertext()).strip()
+        ns_tag_ref = f"{{{NAMESPACES['uslm']}}}ref"
+        ns_tag_date = f"{{{NAMESPACES['uslm']}}}date"
 
-            # Parse /us/pl/CONGRESS/LAW/... hrefs (Public Laws, post-1957)
-            if "/us/pl/" in href:
-                match = re.match(
-                    r"/us/pl/(\d+)/(\d+)"  # Congress and law number
-                    r"(?:/d([A-Z]+))?"  # Optional division (can be multi-letter: LL, FF)
-                    r"(?:/t([IVXLCDM]+))?"  # Optional title
-                    r"(?:/s([\w()]+))?",  # Optional section
-                    href,
-                )
-                if match:
-                    ref = SourceCreditRef(
-                        congress=int(match.group(1)),
-                        law_number=int(match.group(2)),
-                        division=match.group(3),
-                        title=match.group(4),
-                        section=match.group(5),
-                        raw_text=text,
+        for elem in source_credit.iter():
+            local = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
+
+            if local == "ref":
+                href = elem.get("href", "")
+                text = "".join(elem.itertext()).strip()
+
+                # Parse /us/pl/CONGRESS/LAW/... hrefs (Public Laws, post-1957)
+                if "/us/pl/" in href:
+                    match = re.match(
+                        r"/us/pl/(\d+)/(\d+)"  # Congress and law number
+                        r"(?:/d([A-Z]+))?"  # Optional division (can be multi-letter: LL, FF)
+                        r"(?:/t([IVXLCDM]+))?"  # Optional title
+                        r"(?:/s([\w()]+))?",  # Optional section
+                        href,
                     )
-                    pl_refs.append(ref)
-                    last_ref_type = "pl"
+                    if match:
+                        ref = SourceCreditRef(
+                            congress=int(match.group(1)),
+                            law_number=int(match.group(2)),
+                            division=match.group(3),
+                            title=match.group(4),
+                            section=match.group(5),
+                            raw_text=text,
+                        )
+                        pl_refs.append(ref)
+                        last_ref_type = "pl"
 
-            # Parse /us/act/YYYY-MM-DD/chNNN/... hrefs (Acts, pre-1957)
-            elif "/us/act/" in href:
-                match = re.match(
-                    r"/us/act/(\d{4}-\d{2}-\d{2})/ch(\d+)"  # Date and chapter
-                    r"(?:/t([IVXLCDM]+))?"  # Optional title
-                    r"(?:/s([\w()]+))?",  # Optional section
-                    href,
-                )
-                if match:
-                    act_ref = ActRef(
-                        date=match.group(1),  # e.g., "1935-08-14"
-                        chapter=int(match.group(2)),
-                        title=match.group(3),
-                        section=match.group(4),
-                        raw_text=text,
+                # Parse /us/act/YYYY-MM-DD/chNNN/... hrefs (Acts, pre-1957)
+                elif "/us/act/" in href:
+                    match = re.match(
+                        r"/us/act/(\d{4}-\d{2}-\d{2})/ch(\d+)"  # Date and chapter
+                        r"(?:/t([IVXLCDM]+))?"  # Optional title
+                        r"(?:/s([\w()]+))?",  # Optional section
+                        href,
                     )
-                    act_refs.append(act_ref)
-                    last_ref_type = "act"
+                    if match:
+                        act_ref = ActRef(
+                            date=match.group(1),  # e.g., "1935-08-14"
+                            chapter=int(match.group(2)),
+                            title=match.group(3),
+                            section=match.group(4),
+                            raw_text=text,
+                        )
+                        act_refs.append(act_ref)
+                        last_ref_type = "act"
 
-            # Parse /us/stat/VOLUME/PAGE hrefs to capture Stat references
-            elif "/us/stat/" in href:
-                match = re.match(r"/us/stat/(\d+)/(\d+)", href)
-                if match:
-                    current_stat_volume = int(match.group(1))
-                    current_stat_page = int(match.group(2))
-                    # Apply to the most recent ref
-                    if last_ref_type == "pl" and pl_refs:
-                        pl_refs[-1].stat_volume = current_stat_volume
-                        pl_refs[-1].stat_page = current_stat_page
-                    elif last_ref_type == "act" and act_refs:
-                        act_refs[-1].stat_volume = current_stat_volume
-                        act_refs[-1].stat_page = current_stat_page
+                # Parse /us/stat/VOLUME/PAGE hrefs to capture Stat references
+                elif "/us/stat/" in href:
+                    match = re.match(r"/us/stat/(\d+)/(\d+)", href)
+                    if match:
+                        current_stat_volume = int(match.group(1))
+                        current_stat_page = int(match.group(2))
+                        # Apply to the most recent ref
+                        if last_ref_type == "pl" and pl_refs:
+                            pl_refs[-1].stat_volume = current_stat_volume
+                            pl_refs[-1].stat_page = current_stat_page
+                        elif last_ref_type == "act" and act_refs:
+                            act_refs[-1].stat_volume = current_stat_volume
+                            act_refs[-1].stat_page = current_stat_page
 
-        # Extract dates from <date> elements and associate with PL refs
-        # Act refs already have dates in the href, so all <date> elements belong to PL refs
-        date_elems = source_credit.findall(".//{*}date")
-        if not date_elems:
-            date_elems = source_credit.findall(".//date")
-
-        # Simple heuristic: dates appear after their associated PL ref, in order
-        for i, date_elem in enumerate(date_elems):
-            date_text = "".join(date_elem.itertext()).strip()
-            if i < len(pl_refs):
-                pl_refs[i].date = date_text
+            elif local == "date":
+                # <date> elements appear after their associated PL ref in document
+                # order, so assign to the most recently seen PL ref.
+                # Act refs already have dates encoded in the href, so <date>
+                # elements in the source credit belong exclusively to PL refs.
+                if last_ref_type == "pl" and pl_refs:
+                    date_text = "".join(elem.itertext()).strip()
+                    if date_text:
+                        pl_refs[-1].date = date_text
 
         return pl_refs, act_refs
 

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1577,9 +1577,6 @@ class USLMParser:
         # Track the most recent ref (either PL or Act) for stat/date association
         last_ref_type: str | None = None
 
-        ns_tag_ref = f"{{{NAMESPACES['uslm']}}}ref"
-        ns_tag_date = f"{{{NAMESPACES['uslm']}}}date"
-
         for elem in source_credit.iter():
             local = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -1112,3 +1112,123 @@ class TestNoteRefDataclass:
         assert ref.ref_type == "act"
         assert ref.act_date == "1935-08-14"
         assert ref.act_chapter == 531
+
+
+class TestSourceCreditDateAssignment:
+    """Tests for source-credit date assignment to the correct PL citation.
+
+    Regression tests for Issue #471: dates were shifted by one position
+    because the parser collected all <ref> elements first and all <date>
+    elements second, then zipped them by index.  In OLRC XML, a <date>
+    element always follows the <ref> it belongs to, so the original act
+    (PL 89–329) has no accompanying date while every subsequent amendment
+    does.  The fix iterates elements in document order so each <date> is
+    attached to the immediately-preceding PL ref.
+    """
+
+    @pytest.fixture
+    def parser(self) -> USLMParser:
+        """Create a parser instance."""
+        return USLMParser()
+
+    def test_source_credit_dates_assigned_to_correct_law(
+        self, parser: USLMParser
+    ) -> None:
+        """Each <date> in a sourceCredit must be assigned to the PL ref that
+        immediately precedes it in the XML, not the one before that.
+
+        Regression test for Issue #471, using the 20 U.S.C. § 1057 source
+        credit pattern:
+
+          (Pub. L. 89–329, title III, § 311, as added Pub. L. 99–498,
+          title III, § 301(a), Oct. 17, 1986, 100 Stat. 1291; amended
+          Pub. L. 100–50, § 2(a)(1), June 3, 1987, 101 Stat. 335;
+          Pub. L. 105–244, title III, §§ 301(c)(1), 303(a), Oct. 7, 1998,
+          112 Stat. 1636, 1638; Pub. L. 110–315, title III, § 301,
+          Aug. 14, 2008, 122 Stat. 3166.)
+
+        Expected date mapping:
+          PL 89-329  → None (original framework act, no date cited)
+          PL 99-498  → "Oct. 17, 1986"
+          PL 100-50  → "June 3, 1987"
+          PL 105-244 → "Oct. 7, 1998"
+          PL 110-315 → "Aug. 14, 2008"
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t20/s1057">
+          <num value="1057">§ 1057.</num>
+          <heading>Strengthening institutions</heading>
+          <content><p>Test content.</p></content>
+          <sourceCredit>(
+            <ref href="/us/pl/89/329/tIII/s311">Pub. L. 89–329, title III, § 311</ref>,
+            as added
+            <ref href="/us/pl/99/498/tIII/s301">Pub. L. 99–498, title III, § 301(a)</ref>,
+            <date date="1986-10-17">Oct. 17, 1986</date>,
+            <ref href="/us/stat/100/1291">100 Stat. 1291</ref>;
+            amended
+            <ref href="/us/pl/100/50/s2">Pub. L. 100–50, § 2(a)(1)</ref>,
+            <date date="1987-06-03">June 3, 1987</date>,
+            <ref href="/us/stat/101/335">101 Stat. 335</ref>;
+            <ref href="/us/pl/105/244/tIII/s301">Pub. L. 105–244, title III, §§ 301(c)(1), 303(a)</ref>,
+            <date date="1998-10-07">Oct. 7, 1998</date>,
+            <ref href="/us/stat/112/1636">112 Stat. 1636</ref>,
+            <ref href="/us/stat/112/1638">1638</ref>;
+            <ref href="/us/pl/110/315/tIII/s301">Pub. L. 110–315, title III, § 301</ref>,
+            <date date="2008-08-14">Aug. 14, 2008</date>,
+            <ref href="/us/stat/122/3166">122 Stat. 3166</ref>.)
+          </sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml)
+        pl_refs, act_refs = parser._extract_source_credit_refs(elem)
+
+        assert len(act_refs) == 0
+        assert len(pl_refs) == 5
+
+        # PL 89-329: original framework act — no date in the source credit
+        assert pl_refs[0].congress == 89
+        assert pl_refs[0].law_number == 329
+        assert pl_refs[0].date is None
+
+        # PL 99-498: "Oct. 17, 1986"
+        assert pl_refs[1].congress == 99
+        assert pl_refs[1].law_number == 498
+        assert pl_refs[1].date == "Oct. 17, 1986"
+
+        # PL 100-50: "June 3, 1987"
+        assert pl_refs[2].congress == 100
+        assert pl_refs[2].law_number == 50
+        assert pl_refs[2].date == "June 3, 1987"
+
+        # PL 105-244: "Oct. 7, 1998"
+        assert pl_refs[3].congress == 105
+        assert pl_refs[3].law_number == 244
+        assert pl_refs[3].date == "Oct. 7, 1998"
+
+        # PL 110-315: "Aug. 14, 2008"
+        assert pl_refs[4].congress == 110
+        assert pl_refs[4].law_number == 315
+        assert pl_refs[4].date == "Aug. 14, 2008"
+
+    def test_source_credit_first_law_with_date(self, parser: USLMParser) -> None:
+        """When the first law in a source credit has a date (e.g., for sections
+        added by amendment where the original act is not listed), its date is
+        correctly assigned to index 0.
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t17/s101">
+          <num value="101">§ 101.</num>
+          <heading>Test</heading>
+          <content><p>Test.</p></content>
+          <sourceCredit>(
+            <ref href="/us/pl/94/553/s101">Pub. L. 94–553, § 101</ref>,
+            <date date="1976-10-19">Oct. 19, 1976</date>,
+            <ref href="/us/stat/90/2541">90 Stat. 2541</ref>.)
+          </sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml)
+        pl_refs, act_refs = parser._extract_source_credit_refs(elem)
+
+        assert len(pl_refs) == 1
+        assert pl_refs[0].congress == 94
+        assert pl_refs[0].law_number == 553
+        assert pl_refs[0].date == "Oct. 19, 1976"


### PR DESCRIPTION
## Context

Closes #471

In `GET /api/v1/sections/20/1057` (and all other sections), every law's `date` field in `notes.citations` was set to the date of the *next* law in the sequence. The last law got `null` instead of its actual date.

**Root cause:** The parser collected all `<ref>` elements in a first pass, then all `<date>` elements in a second pass, and zipped them by index. In OLRC XML, a `<date>` always appears *after* the `<ref>` it belongs to — so the first law (the original framework act) has no date while every amendment does. The index-based zip was therefore off by one: each date was assigned to the law before the one it actually dates.

## Changes

- **`backend/pipeline/olrc/parser.py`** (`_extract_source_credit_refs`): Replaced the two-pass approach with a single document-order iteration over all child elements. When a `<date>` is encountered, it is assigned to the most-recently-seen PL ref — which is exactly the law it belongs to.
- **`backend/tests/pipeline/test_parser.py`**: Added `TestSourceCreditDateAssignment` with two regression tests using the 20 U.S.C. § 1057 source-credit pattern.

## Before / After — 20 U.S.C. § 1057 source credit

**OLRC authoritative text:**
```
(Pub. L. 89–329, title III, § 311, as added Pub. L. 99–498, title III, § 301(a),
Oct. 17, 1986, 100 Stat. 1291; amended Pub. L. 100–50, § 2(a)(1), June 3, 1987,
101 Stat. 335; Pub. L. 105–244, title III, §§ 301(c)(1), 303(a), Oct. 7, 1998,
112 Stat. 1636, 1638; Pub. L. 110–315, title III, § 301, Aug. 14, 2008,
122 Stat. 3166.)
```

| Law | Before (wrong) | After (correct) |
|-----|---------------|-----------------|
| PL 89-329 | "Oct. 17, 1986" | `null` (original act — no date cited) |
| PL 99-498 | "June 3, 1987" | "Oct. 17, 1986" |
| PL 100-50 | "Oct. 7, 1998" | "June 3, 1987" |
| PL 105-244 | "Aug. 14, 2008" | "Oct. 7, 1998" |
| PL 110-315 | `null` | "Aug. 14, 2008" |

## Test plan

- [x] `uv run mypy app --ignore-missing-imports` — no issues
- [x] `uv run pytest` — 799 passed, 21 skipped
- [x] New `TestSourceCreditDateAssignment::test_source_credit_dates_assigned_to_correct_law` verifies the exact § 1057 pattern
- [x] New `TestSourceCreditDateAssignment::test_source_credit_first_law_with_date` verifies that when the first law in a source credit has a date, it is correctly assigned to index 0

https://claude.ai/code/session_01PMGCscTUi9Whiu2ECrvxaE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGCscTUi9Whiu2ECrvxaE)_