### PR TITLE
fix: remove spurious spaces around inline ref elements adjacent to quotes

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1828,6 +1828,13 @@ class USLMParser:
         # Always strip whitespace from each part and join with a single
         # space so that inconsistent leading/trailing spaces in XML
         # text/tail never produce double-spaces or missing separators.
+        #
+        # Exception: do NOT add a separator space when the previous token ends
+        # with a quote character or the current token starts with a quote
+        # character.  This prevents spurious spaces inside quoted spans that
+        # arise when a <ref> element is directly adjacent to a " character in
+        # the XML (e.g. `"<ref>section 104</ref>"` → `"section 104"` not
+        # `" section 104 "`).
         result: list[str] = []
         for part in parts:
             if part == "[PARA]":
@@ -1854,6 +1861,15 @@ class USLMParser:
             # "“ section X of this title ”" — see issue #632.
             prev_ends_open_quote = bool(result) and result[-1].endswith("“")
             current_starts_close_quote = bool(stripped) and stripped[0] == "”"
+            # Do not insert a space when the previous fragment ends with a
+            # straight double-quote (") or the current fragment starts with
+            # one.  Some OLRC XML uses a plain " character (instead of the
+            # curly “ ” pair above) around a <ref> cross-reference, e.g.
+            # `substituted "<ref>section 1069f(a)(1) of this title</ref>"`.
+            # Stripping and joining with spaces produces spurious
+            # `" section 1069f(a)(1) of this title "` — see issue #472.
+            prev_ends_straight_quote = bool(result) and result[-1].endswith('"')
+            current_starts_straight_quote = bool(stripped) and stripped[0] == '"'
             if (
                 not result
                 or result[-1] == "\n\n"
@@ -1861,6 +1877,8 @@ class USLMParser:
                 or prev_ends_em_dash
                 or prev_ends_open_quote
                 or current_starts_close_quote
+                or prev_ends_straight_quote
+                or current_starts_straight_quote
             ):
                 result.append(stripped)
             else:

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2166,7 +2166,7 @@ class TestParserNotesContent:
             '<note topic="amendments">'
             "<heading>Amendments</heading>"
             '<p>1981—<ref href="/us/pl/97/34">Pub. L. 97–34</ref>'
-            ", § 442(a)(4)(D), substituted text.</p>"
+            ", § 442(a)(4)(D), substituted text.</p>"
             '<p>1970—<ref href="/us/pl/91/614">Pub. L. 91–614</ref>'
             " substituted other text.</p>"
             "<p>1998—Subsec. (c). Pub. L. 105–34 did something.</p>"
@@ -2276,6 +2276,58 @@ class TestParserNotesContent:
         assert "“section 2 of the Shipping Act" in content, (
             f"Expected second quoted string unchanged: {content!r}"
         )
+
+    def test_ref_adjacent_to_opening_quote_no_extra_space(self) -> None:
+        """Ref element immediately after opening quote must not inject a leading space.
+
+        Issue #472: XML like substituted "<ref>section 104</ref>" was rendered
+        as substituted " section 104 " instead of substituted "section 104".
+        """
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        # Simulate: substituted "<ref>section 1069f(a)(1) of this title</ref>"
+        xml = (
+            '<notes><p>substituted "<ref>section 1069f(a)(1) of this title</ref>"'
+            ' for "<ref>section 1069d(a)(1) of this title</ref>".</p></notes>'
+        )
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # Must NOT have a space after opening quote or before closing quote
+        assert '" section' not in content
+        assert 'title "' not in content
+        assert '"section 1069f(a)(1) of this title"' in content
+        assert '"section 1069d(a)(1) of this title"' in content
+
+    def test_ref_adjacent_to_closing_quote_no_trailing_space(self) -> None:
+        """Ref element that ends a quoted span must not inject a trailing space.
+
+        Issue #472: XML like "subsection (b) and <ref>section 1068</ref> " was
+        rendered with a trailing space before the closing quote.
+        """
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        # Simulate: "subsection (b) and <ref>section 1068 of this title</ref>"
+        xml = (
+            '<notes><p>substituted "subsection (b) and '
+            '<ref>section 1068 of this title</ref>" for "subsection (c)".</p></notes>'
+        )
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # Must NOT have a space before closing quote
+        assert 'title "' not in content
+        assert '"subsection (b) and section 1068 of this title"' in content
 
 
 class TestStripNoteMarkers:


### PR DESCRIPTION
## Summary

- Fixes spurious whitespace injected around inline cross-reference text when a `<ref>` element is directly adjacent to a `"` character in USLM XML amendment notes
- Adds two regression tests covering the opening-quote and closing-quote edge cases identified in issue #472

## Root Cause

`_get_notes_text_content` in `backend/pipeline/olrc/parser.py` joins text parts with a space separator. When parsing XML like:

```xml
substituted "<ref>section 1069f(a)(1) of this title</ref>" for ...
```

The parts list is `['substituted "', 'section 1069f(a)(1) of this title', '"']`. The joining loop added a space before each stripped part unconditionally (except for `;,.` punctuation), producing:

```
substituted " section 1069f(a)(1) of this title "
```

## Fix

Added a `prev_char == '"'` and `stripped[0] == '"'` guard to the no-space condition, so the separator space is skipped whenever the accumulated result ends with a `"` or the next token starts with a `"`.

## Before / After

**Before (1987 amendment note, 20 USC § 1057):**
```
substituted " section 1069f(a)(1) of this title " for " section 1069d(a)(1) of this title "
```

**After:**
```
substituted "section 1069f(a)(1) of this title" for "section 1069d(a)(1) of this title"
```

**Before (2008 amendment note):**
```
substituted "subsection (b) and section 1068 of this title " for "subsection (c)"
```

**After:**
```
substituted "subsection (b) and section 1068 of this title" for "subsection (c)"
```

Closes #472

https://claude.ai/code/session_01PMGCscTUi9Whiu2ECrvxaE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGCscTUi9Whiu2ECrvxaE)_