### PR TITLE
fix: concatenate inline italic elements into parent paragraph in notes

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1502,16 +1502,31 @@ class USLMParser:
                     header_text = text.rstrip(".")
                     parts.append(f"[H1]{header_text}[/H1]")
                 elif tag == "i":
-                    # Italic text might be a sub-header if followed by ".—"
-                    # But NOT if it's a case citation (contains " v. ")
-                    # or other inline emphasis (Latin terms, etc.)
+                    # Italic text is a sub-header only when it is followed
+                    # immediately by ".—" (an em-dash introducer), e.g.:
+                    #   <i>Reproduction</i>.—The right to reproduce.
+                    # If the tail does NOT start with ".—" the element is
+                    # inline formatting (case name, emphasis) and must be
+                    # kept as plain text so the surrounding sentence is not
+                    # fragmented.  Also exclude known case-citation patterns
+                    # (" v. ") and common Latin phrases.
                     inline_latin = {"et seq", "et al", "supra", "infra", "id"}
                     stripped_text = text.strip().rstrip(".")
-                    if " v. " in text or stripped_text.lower() in inline_latin:
-                        # Case citation or Latin phrase - keep as inline text
+                    tail = el.tail or ""
+                    is_subheader_tail = bool(
+                        re.match(r"^\s*\.?\s*—", tail)
+                    )
+                    if (
+                        " v. " in text
+                        or stripped_text.lower() in inline_latin
+                        or not is_subheader_tail
+                    ):
+                        # Inline text (case citation, Latin phrase, or
+                        # mid-sentence emphasis) — keep as plain text
                         parts.append(text)
                     else:
-                        # Mark as potential sub-header for normalizer
+                        # Standalone italic introducer followed by ".—":
+                        # mark as sub-header for the normalizer
                         parts.append(f"[H2]{text}[/H2]")
                 else:
                     parts.append(text)

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1513,9 +1513,7 @@ class USLMParser:
                     inline_latin = {"et seq", "et al", "supra", "infra", "id"}
                     stripped_text = text.strip().rstrip(".")
                     tail = el.tail or ""
-                    is_subheader_tail = bool(
-                        re.match(r"^\s*\.?\s*—", tail)
-                    )
+                    is_subheader_tail = bool(re.match(r"^\s*\.?\s*—", tail))
                     if (
                         " v. " in text
                         or stripped_text.lower() in inline_latin

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1689,6 +1689,63 @@ class TestParserNotesContent:
         assert "[H2]" not in content
         assert "et seq" in content
 
+    def test_inline_italic_case_name_not_marked_as_header(self) -> None:
+        """Inline <i> case names mid-sentence must not become H2 headers.
+
+        Reproduces Issue #460: 17 USC § 110 note paragraph containing
+        'The <i>Aiken</i> decision...' was fragmenting into three lines
+        with is_header=True on the case name.
+        """
+        from lxml import etree
+
+        from pipeline.olrc.normalized_section import normalize_note_content
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        xml = (
+            "<notes><p>The <i>Aiken</i> decision is based squarely on the "
+            "two Supreme Court decisions dealing with cable television.</p></notes>"
+        )
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # The inline italic must NOT be wrapped in [H2] markers
+        assert "[H2]" not in content
+        assert "Aiken" in content
+
+        # When normalized, the full paragraph should be a single non-header line
+        lines = normalize_note_content(content)
+        content_lines = [ln for ln in lines if ln.content]
+        assert len(content_lines) == 1, (
+            f"Expected 1 line, got {len(content_lines)}: "
+            + str([ln.content for ln in content_lines])
+        )
+        assert content_lines[0].is_header is False
+        assert "Aiken" in content_lines[0].content
+        assert content_lines[0].content.startswith("The")
+
+    def test_standalone_italic_subheader_still_marked_as_h2(self) -> None:
+        """Italic text followed by '.—' must still be treated as an H2 sub-header.
+
+        This ensures the inline-italic fix does not break legitimate sub-header
+        detection (e.g., 'Reproduction.—The right to reproduce.').
+        """
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        xml = "<notes><p><i>Reproduction</i>.—The right to reproduce.</p></notes>"
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # Standalone italic introducer followed by ".—" must keep [H2] marker
+        assert "[H2]Reproduction" in content
+
 
 class TestStripNoteMarkers:
     """Tests for _strip_note_markers function."""


### PR DESCRIPTION
## Bug

In note paragraphs containing inline `<i>` elements (e.g. legal case citations), the parser was splitting each italic element into its own provision line and marking it `is_header: true`. Surrounding sentence fragments were emitted as separate lines with mismatched indent levels.

**OLRC XML (correct — single paragraph):**
```xml
<p>The <i>Aiken</i> decision is based squarely on the two Supreme Court decisions dealing with cable television.</p>
```

**CWLB output before fix (wrong — three fragmented lines):**
```json
{ "line_number": 108, "content": "The", "indent_level": 2, "is_header": false }
{ "line_number": 109, "content": "Aiken", "indent_level": 2, "is_header": true }
{ "line_number": 110, "content": "decision is based squarely on the two Supreme Court decisions dealing with cable television.", "indent_level": 3, "is_header": false }
```

**CWLB output after fix (correct — single line):**
```json
{ "line_number": 108, "content": "The Aiken decision is based squarely on the two Supreme Court decisions dealing with cable television.", "indent_level": 2, "is_header": false }
```

This affected 6+ case citations (*Aiken*, *Jewell-LaSalle*, etc.) in the 17 USC § 110 House Report note.

## Fix

The key insight is that `<i>` is a block-level sub-header **only** when its tail text immediately starts with `.—` (an em-dash introducer), e.g.:

```xml
<i>Reproduction</i>.—The right to reproduce.
```

Any other `<i>` — case names, Latin phrases, mid-sentence emphasis — is inline formatting and must be concatenated into the surrounding sentence as plain text.

**Change in `backend/pipeline/olrc/parser.py`:** The `<i>` handler in `_get_notes_text_content` now inspects `el.tail` via `re.match(r"^\s*\.?\s*—", tail)`. Only when the tail matches is the text wrapped in `[H2]...[/H2]`; otherwise it is appended as plain text.

**Two new regression tests in `backend/tests/pipeline/test_normalized_section.py`:**
- `test_inline_italic_case_name_not_marked_as_header` — verifies the Aiken-style paragraph produces a single line with `is_header=False`
- `test_standalone_italic_subheader_still_marked_as_h2` — verifies that a legitimate `.—` sub-header still emits `[H2]` markers

Closes #460

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp33ymkHdu9rCCBiXd84Nn)_