### PR TITLE
fix: strip [NH]..[/NH] internal tags from notes raw_text field

### DIFF
--- a/backend/app/schemas/public_law.py
+++ b/backend/app/schemas/public_law.py
@@ -4,7 +4,9 @@ These schemas are used for API responses and data transfer between
 the pipeline and application layers.
 """
 
-from pydantic import BaseModel, Field, computed_field
+import re
+
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from app.models.enums import LawLevel, SourceRelationship
 
@@ -220,6 +222,21 @@ class SourceLawSchema(BaseModel):
     order: int = Field(
         0, description="Position in source list (0 = first/oldest reference)"
     )
+
+    @field_validator("raw_text", mode="before")
+    @classmethod
+    def strip_internal_markup_tokens(cls, v: object) -> object:
+        """Strip internal XML serialization markers before surfacing in the API.
+
+        [NH]...[/NH] markers are generated during XML ingestion to encode note
+        headers for the notes normalizer. They should not appear in raw_text.
+        """
+        if not isinstance(v, str):
+            return v
+        v = re.sub(r"\[NH\].*?\[/NH\]", "", v, flags=re.DOTALL)
+        # Strip any orphaned closing tags left by multiline patterns
+        v = re.sub(r"\[/NH\]", "", v)
+        return v.strip()
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/tests/test_section_notes_schema.py
+++ b/backend/tests/test_section_notes_schema.py
@@ -1,5 +1,7 @@
 """Tests for SectionNotesSchema — specifically the raw_notes markup-stripping validator."""
 
+from app.models.enums import SourceRelationship
+from app.schemas.public_law import PublicLawSchema, SourceLawSchema
 from app.schemas.us_code import SectionNotesSchema
 
 
@@ -61,3 +63,57 @@ class TestRawNotesMarkupStripping:
         assert "as defined by section 101." in result.raw_notes
         assert "Definition" in result.raw_notes
         assert "Further clarification." in result.raw_notes
+
+
+class TestSourceLawSchemaRawTextStripping:
+    """SourceLawSchema.raw_text must have [NH]..[/NH] tags stripped (Issue #458).
+
+    When a note topic attribute is synthesised into an [NH]...[/NH] marker and
+    that marker ends up prepended to the citation text (because the note block
+    has no other separator), the raw_text field previously leaked the tag into
+    the API response.  Example from 37 U.S.C. § 426:
+
+        raw_text was: "[NH]Removaldescription[/NH]\\n\\nSection, Pub. L. 87-649..."
+        raw_text should be: "Section, Pub. L. 87-649..."
+    """
+
+    def _make_citation(self, raw_text: str) -> SourceLawSchema:
+        return SourceLawSchema.model_validate(
+            {
+                "law": {
+                    "congress": 87,
+                    "law_number": 649,
+                },
+                "relationship": SourceRelationship.ENACTMENT,
+                "raw_text": raw_text,
+            }
+        )
+
+    def test_nh_tag_stripped_from_raw_text(self) -> None:
+        """[NH]...[/NH] tag is removed and the citation text is preserved."""
+        raw = "[NH]Removaldescription[/NH]\n\nSection, Pub. L. 87-649, Sept. 7, 1962, 76 Stat. 451."
+        result = self._make_citation(raw)
+        assert "[NH]" not in result.raw_text
+        assert "[/NH]" not in result.raw_text
+        assert "Pub. L. 87-649" in result.raw_text
+
+    def test_nh_tag_with_multiword_topic_stripped(self) -> None:
+        """[NH] tag with multi-word note topic is fully removed."""
+        raw = "[NH]Effective Date Of 2013 Amendment[/NH] Pub. L. 113-66, § 631, Dec. 26, 2013."
+        result = self._make_citation(raw)
+        assert "[NH]" not in result.raw_text
+        assert "[/NH]" not in result.raw_text
+        assert "Pub. L. 113-66" in result.raw_text
+
+    def test_plain_citation_unchanged(self) -> None:
+        """Citations without any [NH] markup are returned as-is."""
+        raw = "Pub. L. 87-649, Sept. 7, 1962, 76 Stat. 451."
+        result = self._make_citation(raw)
+        assert result.raw_text == raw
+
+    def test_orphaned_closing_tag_stripped(self) -> None:
+        """A stray [/NH] closing tag without an opening tag is also removed."""
+        raw = "[/NH] Pub. L. 87-649, Sept. 7, 1962, 76 Stat. 451."
+        result = self._make_citation(raw)
+        assert "[/NH]" not in result.raw_text
+        assert "Pub. L. 87-649" in result.raw_text

--- a/backend/tests/test_section_notes_schema.py
+++ b/backend/tests/test_section_notes_schema.py
@@ -1,7 +1,7 @@
 """Tests for SectionNotesSchema — specifically the raw_notes markup-stripping validator."""
 
 from app.models.enums import SourceRelationship
-from app.schemas.public_law import PublicLawSchema, SourceLawSchema
+from app.schemas.public_law import SourceLawSchema
 from app.schemas.us_code import SectionNotesSchema
 
 


### PR DESCRIPTION
## Bug

`[NH]...[/NH]` internal formatting markers were leaking into the `notes.citations[].raw_text` field returned by `/api/v1/sections/{title}/{section}`.

**Example (37 U.S.C. § 426, notes.citations[0]):**

Before:
```json
"raw_text": "[NH]Removaldescription[/NH]\n\nSection, Pub. L. 87–649, Sept. 7, 1962..."
```

After:
```json
"raw_text": "Section, Pub. L. 87–649, Sept. 7, 1962..."
```

`[NH]...[/NH]` tags are BBCode-style markers injected by the XML parser when it encounters `<note topic="...">` elements without a `<heading>` child — the topic attribute (e.g. `removalDescription`) is title-cased and wrapped as `[NH]Removaldescription[/NH]`. The notes normalizer uses these markers internally to split note blocks. When the note block has no separator between the topic header and the citation text, the tag ends up prepended to the citation string and stored in `SourceLawSchema.raw_text`.

## Fix

Added a `field_validator` on `SourceLawSchema.raw_text` in `app/schemas/public_law.py` that strips `[NH]...[/NH]` tags (and any orphaned `[/NH]` closing tags) before the value is surfaced via the API. This mirrors the existing `strip_internal_markup_tokens` validator already present on `SectionNotesSchema.raw_notes`.

## Tests

Added `TestSourceLawSchemaRawTextStripping` in `tests/test_section_notes_schema.py` with four cases:
- `[NH]Removaldescription[/NH]` prefix stripped, citation text preserved (exact Issue #458 pattern)
- Multi-word topic header stripped
- Plain citation without markup unchanged
- Orphaned `[/NH]` closing tag stripped

All 801 tests pass.

Closes #458

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp33ymkHdu9rCCBiXd84Nn)_