### PR TITLE
chore: gitignore .claude/worktrees/ runtime directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ Thumbs.db
 
 # Downloaded data
 backend/data/
+
+# Claude Code agent worktrees (runtime only, not tracked)
+.claude/worktrees/


### PR DESCRIPTION
The `.claude/worktrees/` directory is created at runtime by the Claude Code agent worktree isolation feature and should never be committed. Adding it to `.gitignore` prevents it from showing up as untracked files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp33ymkHdu9rCCBiXd84Nn)_