### PR TITLE
fix: use proper title-case for note headings, preserving lowercase prepositions

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1411,13 +1411,13 @@ def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
     """
     EDITORIAL_HEADERS = {
         "Amendments",
-        "Change Of Name",
-        "References In Text",
+        "Change of Name",
+        "References in Text",
         "Codification",
         "Prior Provisions",
         "Construction",
         "Recodification",
-        "Effective Date Of Repeal",
+        "Effective Date of Repeal",
     }
 
     header_positions: list[tuple[int, int, str]] = []

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -53,6 +53,41 @@ def _capitalize_word(word: str) -> str:
     return word.capitalize()
 
 
+def _note_heading_title_case(text: str) -> str:
+    """Apply proper title case to a note heading from OLRC XML.
+
+    OLRC note headings come in two forms:
+    - Heading element text: already mixed-case from OLRC (e.g. "Effective Date
+      of 1981 Amendment"). We must NOT apply str.title() because that would
+      capitalize prepositions like "of" -> "Of".
+    - Topic attribute values: lowercase (e.g. "amendments"). These need
+      capitalization but still must respect minor-word rules.
+
+    This function applies standard English title-case rules to the text
+    regardless of its original casing:
+    - First and last words are always capitalized.
+    - Minor words (articles, conjunctions, short prepositions) are lowercase.
+    - Hyphenated compounds are capitalized on each part.
+    """
+    if not text:
+        return text
+
+    words = text.split()
+    if not words:
+        return text
+
+    last_idx = len(words) - 1
+    result: list[str] = []
+    for i, word in enumerate(words):
+        lower = word.lower()
+        if i == 0 or i == last_idx or lower not in _TITLE_CASE_MINOR_WORDS:
+            result.append(_capitalize_word(word))
+        else:
+            result.append(lower)
+
+    return " ".join(result)
+
+
 def title_case_heading(text: str) -> str:
     """Convert an ALL-CAPS heading to Title Case.
 
@@ -1472,7 +1507,7 @@ class USLMParser:
                         (c.tag.split("}")[-1] if "}" in c.tag else c.tag) for c in el
                     }
                     if "heading" not in child_tags:
-                        parts.append(f"[NH]{topic.title()}[/NH]")
+                        parts.append(f"[NH]{_note_heading_title_case(topic)}[/NH]")
 
             # Preserve paragraph boundaries with a special marker
             # We use [PARA] marker instead of \n\n because tail text often contains \n
@@ -1487,7 +1522,7 @@ class USLMParser:
             if tag == "heading":
                 text = "".join(el.itertext()).strip()
                 if text:
-                    parts.append(f"[NH]{text.title()}[/NH]")
+                    parts.append(f"[NH]{_note_heading_title_case(text)}[/NH]")
                 return  # Don't process children
 
             # Track bold/italic state

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1667,7 +1667,7 @@ class TestParserNotesContent:
         content = parser._get_notes_text_content(elem)
 
         # SmallCaps heading should be wrapped in [NH]...[/NH]
-        assert "[NH]Delegation Of Functions[/NH]" in content
+        assert "[NH]Delegation of Functions[/NH]" in content
         # Paragraph content should NOT be wrapped in [NH]
         assert "[NH]Memorandum" not in content
         assert "Memorandum of President" in content
@@ -1798,7 +1798,7 @@ class TestStatutoryNotesHeaderParsing:
 
         # Simulate notes text with [NH] markers from XML parser
         raw_notes = """Statutory Notes and Related Subsidiaries
-        [NH]Delegation Of Reporting Functions[/NH]
+        [NH]Delegation of Reporting Functions[/NH]
         Memorandum of President of the United States, Mar. 16, 2012.
         Memorandum for the Secretary of State.
         By the authority vested in me as President.
@@ -1810,7 +1810,7 @@ class TestStatutoryNotesHeaderParsing:
         # Should have exactly one note
         statutory_notes = [n for n in notes.notes if n.header]
         assert len(statutory_notes) == 1
-        assert statutory_notes[0].header == "Delegation Of Reporting Functions"
+        assert statutory_notes[0].header == "Delegation of Reporting Functions"
 
         # Lines should include the Memorandum paragraphs
         all_text = " ".join(line.content for line in statutory_notes[0].lines)
@@ -1825,9 +1825,9 @@ class TestStatutoryNotesHeaderParsing:
         )
 
         raw_notes = """Statutory Notes and Related Subsidiaries
-        [NH]Effective Date Of 2013 Amendment[/NH]
+        [NH]Effective Date of 2013 Amendment[/NH]
         Amendment effective Oct. 1, 2012.
-        [NH]Termination Of Reporting Requirements[/NH]
+        [NH]Termination of Reporting Requirements[/NH]
         For termination, see section 1061.
         """
 
@@ -1835,8 +1835,8 @@ class TestStatutoryNotesHeaderParsing:
         _parse_statutory_notes(raw_notes, notes)
 
         headers = [n.header for n in notes.notes]
-        assert "Effective Date Of 2013 Amendment" in headers
-        assert "Termination Of Reporting Requirements" in headers
+        assert "Effective Date of 2013 Amendment" in headers
+        assert "Termination of Reporting Requirements" in headers
         assert len(notes.notes) == 2
 
     def test_cross_heading_stripped_from_content(self) -> None:
@@ -1851,7 +1851,7 @@ class TestStatutoryNotesHeaderParsing:
         [NH]Congressional Committees Defined[/NH]
         The term 'congressional defense committees' means the committees on appropriations and armed services.
         [H1]Executive Documents[/H1]
-        [NH]Delegation Of Functions[/NH]
+        [NH]Delegation of Functions[/NH]
         Memorandum of the President of the United States dated March 16, 2012, provided as follows.
         """
 
@@ -1897,7 +1897,7 @@ class TestFlatNotesParser:
         from pipeline.olrc.normalized_section import SectionNotes, _parse_flat_notes
 
         raw_notes = (
-            "[NH]Effective Date Of 1986 Amendment[/NH] "
+            "[NH]Effective Date of 1986 Amendment[/NH] "
             "Pub. L. 99–495, § 18, Oct. 16, 1986, 100 Stat. 1259, provided that "
             "the amendments shall take effect with respect to each license issued after enactment."
         )
@@ -1905,7 +1905,7 @@ class TestFlatNotesParser:
         _parse_flat_notes(raw_notes, notes)
 
         assert len(notes.notes) == 1
-        assert notes.notes[0].header == "Effective Date Of 1986 Amendment"
+        assert notes.notes[0].header == "Effective Date of 1986 Amendment"
         assert notes.notes[0].category.value == "statutory"
 
     def test_flat_notes_multiple_headers(self) -> None:
@@ -1916,7 +1916,7 @@ class TestFlatNotesParser:
             "[NH]Amendments[/NH] "
             "2005—Subsec. (e). Pub. L. 109–58, inserted text after first proviso. "
             "1986—Subsec. (e). Pub. L. 99–495 inserted additional provisions. "
-            "[NH]Change Of Name[/NH] "
+            "[NH]Change of Name[/NH] "
             "Department of War designated Department of the Army by act July 26, 1947. "
             "[NH]Savings Provision[/NH] "
             "Pub. L. 99–495, § 17(a), Oct. 16, 1986, 100 Stat. 1259, provided that "
@@ -1928,12 +1928,12 @@ class TestFlatNotesParser:
         assert len(notes.notes) == 3
         headers = [n.header for n in notes.notes]
         assert "Amendments" in headers
-        assert "Change Of Name" in headers
+        assert "Change of Name" in headers
         assert "Savings Provision" in headers
 
         editorial = [n for n in notes.notes if n.category.value == "editorial"]
         statutory = [n for n in notes.notes if n.category.value == "statutory"]
-        assert len(editorial) == 2  # Amendments + Change Of Name
+        assert len(editorial) == 2  # Amendments + Change of Name
         assert len(statutory) == 1  # Savings Provision
 
     def test_flat_notes_fallback_in_parse_notes_structure(self) -> None:
@@ -1987,15 +1987,15 @@ class TestFlatNotesParser:
         )
 
         raw_notes = (
-            "[NH]Historical And Revision Notes[/NH] "
+            "[NH]Historical and Revision Notes[/NH] "
             "Based on title 13, U.S.C., 1952 ed., § 201 (part). "
             "[NH]Amendments[/NH] "
             "1957—Pub. L. 85–207, § 9, substituted heading; added housing census. "
             "1975—Pub. L. 94–171, §§ 1, 2(a), inserted apportionment tabulation. "
             "1976—Pub. L. 94–521, § 7(a), updated heading and subsections. "
-            "[NH]Effective Date Of 1976 Amendment[/NH] "
+            "[NH]Effective Date of 1976 Amendment[/NH] "
             "Amendment by Pub. L. 94–521 effective Oct. 1, 1976. "
-            "[NH]Statistical Sampling Or Adjustment In Decennial Enumeration[/NH] "
+            "[NH]Statistical Sampling or Adjustment in Decennial Enumeration[/NH] "
             "Pub. L. 105–119, title II, § 209(a), Nov. 26, 1997, 111 Stat. 2482, provided."
         )
         notes = SectionNotes()
@@ -2005,8 +2005,8 @@ class TestFlatNotesParser:
         # _parse_historical_notes hardcodes "Historical and Revision Notes" (lowercase "and")
         assert "Historical and Revision Notes" in headers
         assert "Amendments" in headers
-        assert "Effective Date Of 1976 Amendment" in headers
-        assert "Statistical Sampling Or Adjustment In Decennial Enumeration" in headers
+        assert "Effective Date of 1976 Amendment" in headers
+        assert "Statistical Sampling or Adjustment in Decennial Enumeration" in headers
         assert len(notes.notes) >= 4
 
     def test_amendments_populated_from_flat_notes_issue_284(self) -> None:
@@ -2022,7 +2022,7 @@ class TestFlatNotesParser:
         )
 
         raw_notes = (
-            "[NH]Historical And Revision Notes[/NH] "
+            "[NH]Historical and Revision Notes[/NH] "
             "Based on title 13, U.S.C., 1952 ed., § 201 (part). "
             "[NH]Amendments[/NH] "
             "1957—Pub. L. 85–207, § 9, substituted the heading for prior heading. "
@@ -2160,10 +2160,10 @@ class TestNoteTopicAmendmentParsing:
         assert len(notes.notes) == 4
 
         headers = [n.header for n in notes.notes]
-        assert "References In Text" in headers
+        assert "References in Text" in headers
         assert "Amendments" in headers
-        assert "Effective Date Of 1996 Amendment" in headers
-        assert "No Requirement Of Reimbursement" in headers
+        assert "Effective Date of 1996 Amendment" in headers
+        assert "No Requirement of Reimbursement" in headers
 
         editorial = [n for n in notes.notes if n.category.value == "editorial"]
         statutory = [n for n in notes.notes if n.category.value == "statutory"]

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -636,9 +636,7 @@ class TestNoteHeadingTitleCase:
 
     def test_references_in_text(self) -> None:
         """'in' stays lowercase in 'References in Text'."""
-        assert (
-            _note_heading_title_case("References in Text") == "References in Text"
-        )
+        assert _note_heading_title_case("References in Text") == "References in Text"
 
     def test_change_of_name(self) -> None:
         """'of' stays lowercase in 'Change of Name'."""

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -9,6 +9,7 @@ from pipeline.olrc.parser import (
     NoteRef,
     USLMParser,
     _clean_bracket_heading,
+    _note_heading_title_case,
     compute_text_hash,
     title_case_heading,
     to_title_case,
@@ -582,6 +583,73 @@ class TestCleanBracketHeading:
     def test_empty_string(self) -> None:
         """Test empty string returns empty string."""
         assert _clean_bracket_heading("") == ""
+
+
+class TestNoteHeadingTitleCase:
+    """Tests for _note_heading_title_case function.
+
+    This function is used when emitting [NH] markers for note headings.
+    Unlike title_case_heading (which only converts ALL-CAPS text), this
+    function always applies proper title-case rules regardless of the
+    input casing — critical for OLRC XML headings that arrive already
+    mixed-case (e.g. "Effective Date of 1981 Amendment").
+    """
+
+    def test_of_stays_lowercase(self) -> None:
+        """'of' must remain lowercase in the middle of a heading (Issue #468)."""
+        assert (
+            _note_heading_title_case("Effective Date of 1981 Amendment")
+            == "Effective Date of 1981 Amendment"
+        )
+
+    def test_of_not_overcapitalized_by_naive_title(self) -> None:
+        """Regression: str.title() would produce 'Of', which is incorrect."""
+        result = _note_heading_title_case("Effective Date of 1981 Amendment")
+        assert result != "Effective Date Of 1981 Amendment"
+        assert result == "Effective Date of 1981 Amendment"
+
+    def test_lowercase_topic_capitalized(self) -> None:
+        """A lowercase topic attribute value like 'amendments' is capitalized."""
+        assert _note_heading_title_case("amendments") == "Amendments"
+
+    def test_first_word_always_capitalized(self) -> None:
+        """First word is capitalized even if it is a minor preposition."""
+        assert _note_heading_title_case("of mice and men") == "Of Mice and Men"
+
+    def test_and_stays_lowercase(self) -> None:
+        """'and' in the middle of a heading stays lowercase."""
+        assert (
+            _note_heading_title_case("Historical and Revision Notes")
+            == "Historical and Revision Notes"
+        )
+
+    def test_allcaps_heading_converted(self) -> None:
+        """ALL-CAPS note heading is converted to proper title case."""
+        assert (
+            _note_heading_title_case("EFFECTIVE DATE OF 1981 AMENDMENT")
+            == "Effective Date of 1981 Amendment"
+        )
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty string."""
+        assert _note_heading_title_case("") == ""
+
+    def test_references_in_text(self) -> None:
+        """'in' stays lowercase in 'References in Text'."""
+        assert (
+            _note_heading_title_case("References in Text") == "References in Text"
+        )
+
+    def test_change_of_name(self) -> None:
+        """'of' stays lowercase in 'Change of Name'."""
+        assert _note_heading_title_case("Change of Name") == "Change of Name"
+
+    def test_effective_date_of_amendment(self) -> None:
+        """'of' stays lowercase in effective date headings (the exact bug case)."""
+        assert (
+            _note_heading_title_case("Effective Date of 1986 Amendment")
+            == "Effective Date of 1986 Amendment"
+        )
 
 
 class TestChapterGroups:


### PR DESCRIPTION
## Bug

Note headings were transformed with a naive `str.title()` call that capitalizes every word, including short prepositions like "of". This caused the CWLB response to return `"Effective Date Of 1981 Amendment"` instead of the OLRC-authoritative `"Effective Date of 1981 Amendment"`.

**Before (buggy):**
```
[NH]Effective Date Of 1981 Amendment[/NH]
```
**After (fixed):**
```
[NH]Effective Date of 1981 Amendment[/NH]
```

## Fix

Replaced the two `str.title()` calls in `_get_notes_text_content` (for both `<heading>` elements and `<note topic="...">` attributes) with a new `_note_heading_title_case()` function that applies standard English title-case rules:

- First and last words are always capitalized.
- Short prepositions and conjunctions ("of", "in", "and", "the", "to", "for", "a", "an", "or", "nor", "but", "at", "by", "with", "from", "on", etc.) stay lowercase when they appear mid-heading.
- Hyphenated compounds are capitalized on each part.

Also updated `EDITORIAL_HEADERS` in `normalized_section.py` (which contained `"Change Of Name"`, `"References In Text"`, `"Effective Date Of Repeal"`) to use correct lowercase prepositions so category assignment continues to work correctly.

A regression test class (`TestNoteHeadingTitleCase`) is added to `test_parser.py` to verify the fix and guard against future regressions.

Closes #468