### PR TITLE
fix: preserve subsection specifiers in citation path_display

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -2059,7 +2059,9 @@ class USLMParser:
                         # embedding it inline in the /s segment (e.g. "/s12(a)").
                         href_subsection_tail = match.group(6)
                         if href_section and href_subsection_tail:
-                            sub_parts = [p for p in href_subsection_tail.split("/") if p]
+                            sub_parts = [
+                                p for p in href_subsection_tail.split("/") if p
+                            ]
                             href_section = href_section + "".join(
                                 f"({p})" for p in sub_parts
                             )
@@ -2094,7 +2096,9 @@ class USLMParser:
                         # segments, mirroring the PL href handling above.
                         href_subsection_tail = match.group(5)
                         if href_section and href_subsection_tail:
-                            sub_parts = [p for p in href_subsection_tail.split("/") if p]
+                            sub_parts = [
+                                p for p in href_subsection_tail.split("/") if p
+                            ]
                             href_section = href_section + "".join(
                                 f"({p})" for p in sub_parts
                             )

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -2047,11 +2047,22 @@ class USLMParser:
                         r"/us/pl/(\d+)/(\d+)"  # Congress and law number
                         r"(?:/d([A-Z]+))?"  # Optional division (can be multi-letter: LL, FF)
                         r"(?:/t([IVXLCDM]+))?"  # Optional title
-                        r"(?:/s([\w()]+))?",  # Optional section
+                        r"(?:/s([\w()]+))?"  # Optional section
+                        r"((?:/[a-z0-9]+)*)?",  # Optional subsection path segments (e.g. /a, /a/1)
                         href,
                     )
                     if match:
                         href_section = match.group(5)
+                        # Reconstruct subsection specifiers encoded as extra href path
+                        # segments (e.g. "/s12/a" -> "12(a)"). OLRC sometimes splits the
+                        # subsection out into its own slash-delimited segment instead of
+                        # embedding it inline in the /s segment (e.g. "/s12(a)").
+                        href_subsection_tail = match.group(6)
+                        if href_section and href_subsection_tail:
+                            sub_parts = [p for p in href_subsection_tail.split("/") if p]
+                            href_section = href_section + "".join(
+                                f"({p})" for p in sub_parts
+                            )
                         section_value: str | None = (
                             href_section + bridge + subdivision_suffix
                             if subdivision_suffix and href_section
@@ -2073,11 +2084,20 @@ class USLMParser:
                     match = re.match(
                         r"/us/act/(\d{4}-\d{2}-\d{2})/ch(\d+)"  # Date and chapter
                         r"(?:/t([IVXLCDM]+))?"  # Optional title
-                        r"(?:/s([\w()]+))?",  # Optional section
+                        r"(?:/s([\w()]+))?"  # Optional section
+                        r"((?:/[a-z0-9]+)*)?",  # Optional subsection path segments (e.g. /a, /a/1)
                         href,
                     )
                     if match:
                         href_section = match.group(4)
+                        # Reconstruct subsection specifiers encoded as extra href path
+                        # segments, mirroring the PL href handling above.
+                        href_subsection_tail = match.group(5)
+                        if href_section and href_subsection_tail:
+                            sub_parts = [p for p in href_subsection_tail.split("/") if p]
+                            href_section = href_section + "".join(
+                                f"({p})" for p in sub_parts
+                            )
                         section_value = (
                             href_section + bridge + subdivision_suffix
                             if subdivision_suffix and href_section

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -586,6 +586,40 @@ class TestCitationParsing:
         assert citations[1].congress == 101
         assert citations[2].congress == 106  # Newest
 
+    def test_path_display_preserves_subsection_specifier(self) -> None:
+        """path_display must include subsection specifiers like (a) and (c).
+
+        Regression test for Issue #490: citations to sections like §12(a)
+        were displayed as §12, dropping the subsection specifier. The
+        section value in the path must include the full specifier so that
+        path_display shows "§12(a)" rather than "§12".
+        """
+        from app.models.enums import LawLevel
+        from app.schemas import LawPathComponent
+
+        law = ParsedPublicLaw(congress=94, law_number=521)
+
+        # Simulate what the fixed parser produces: section="12(a)"
+        citation = SourceLaw(
+            law=law,
+            path=[LawPathComponent(level=LawLevel.SECTION, value="12(a)")],
+            raw_text="Pub. L. 94–521, §12(a), Oct. 17, 1976, 90 Stat. 2464",
+        )
+        assert citation.section == "12(a)"
+        assert citation.path_display == "§12(a)", (
+            f"Expected '§12(a)' but got {citation.path_display!r}; "
+            "subsection specifier (a) must be included in path_display"
+        )
+
+        # Also verify a multi-level subsection specifier like §2(c)
+        citation2 = SourceLaw(
+            law=ParsedPublicLaw(congress=103, law_number=430),
+            path=[LawPathComponent(level=LawLevel.SECTION, value="2(c)")],
+            raw_text="Pub. L. 103–430, §2(c), Oct. 31, 1994, 108 Stat. 4394",
+        )
+        assert citation2.section == "2(c)"
+        assert citation2.path_display == "§2(c)"
+
 
 class TestNormalizeParsedSection:
     """Tests for normalizing ParsedSection with structured subsections."""

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -277,6 +277,54 @@ class TestUSLMParser:
         assert "Pub. L." not in text
         assert "endowment" in text
 
+    def test_extract_source_credit_refs_preserves_subsection_specifiers(
+        self, parser: USLMParser
+    ) -> None:
+        """Subsection specifiers in source credit hrefs must be preserved.
+
+        OLRC encodes section references with subsections as separate path
+        segments: /us/pl/94/521/s12/a → section "12(a)". Previously the
+        parser dropped the /a segment, producing section="12" and
+        path_display="§12" instead of "§12(a)".
+
+        Regression test for Issue #490 (13 U.S.C. § 214).
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t13/s214">
+          <num value="214">§ 214.</num>
+          <heading>Obsolete information</heading>
+          <content>Some content here.</content>
+          <sourceCredit>(Aug. 31, 1954, ch. 1158, <ref href="/us/stat/68/1023">68 Stat. 1023</ref>;
+          <ref href="/us/pl/94/521/s12/a">Pub. L. 94–521, §12(a)</ref>,
+          <date date="1976-10-17">Oct. 17, 1976</date>,
+          <ref href="/us/stat/90/2464">90 Stat. 2464</ref>;
+          <ref href="/us/pl/103/430/s2/c">Pub. L. 103–430, §2(c)</ref>,
+          <date date="1994-10-31">Oct. 31, 1994</date>,
+          <ref href="/us/stat/108/4394">108 Stat. 4394</ref>.)</sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml)
+        pl_refs, _act_refs = parser._extract_source_credit_refs(elem)
+
+        assert len(pl_refs) == 2
+
+        # Pub. L. 94–521, §12(a) — subsection (a) must be preserved
+        ref1 = pl_refs[0]
+        assert ref1.congress == 94
+        assert ref1.law_number == 521
+        assert ref1.section == "12(a)", (
+            f"Expected '12(a)' but got {ref1.section!r}; "
+            "subsection specifier (a) was dropped from the path"
+        )
+
+        # Pub. L. 103–430, §2(c) — subsection (c) must be preserved
+        ref2 = pl_refs[1]
+        assert ref2.congress == 103
+        assert ref2.law_number == 430
+        assert ref2.section == "2(c)", (
+            f"Expected '2(c)' but got {ref2.section!r}; "
+            "subsection specifier (c) was dropped from the path"
+        )
+
     def test_extract_subsections_with_direct_paragraphs(
         self, parser: USLMParser
     ) -> None:


### PR DESCRIPTION
## Bug

The citation path builder was stripping subsection specifiers like `(a)` and `(c)` from section references. For example, "§ 12(a)" in a source credit produced `path_display: "§12"` instead of `"§12(a)"`. The `raw_text` field correctly contained the subsection specifier, confirming it was present at parse time — the loss occurred in the path object construction step.

**Root cause:** OLRC XML encodes section references with subsections as separate slash-delimited path segments in the `href` attribute (e.g., `/us/pl/94/521/s12/a` rather than `/us/pl/94/521/s12(a)`). The `_extract_source_credit_refs` parser regex `(?:/s([\w()]+))?` captured only the section number (`12`) and silently discarded the trailing `/a` segment, so `SourceCreditRef.section` was set to `"12"` instead of `"12(a)"`.

**Before (broken):**
```
href="/us/pl/94/521/s12/a" → section="12" → path_display="§12"
href="/us/pl/103/430/s2/c" → section="2"  → path_display="§2"
```

**After (fixed):**
```
href="/us/pl/94/521/s12/a" → section="12(a)" → path_display="§12(a)"
href="/us/pl/103/430/s2/c" → section="2(c)"  → path_display="§2(c)"
```

## Fix

Extended the href regex for both PL (`/us/pl/…`) and Act (`/us/act/…`) refs to capture trailing lowercase slash-separated path segments (e.g., `/a`, `/a/1`) and reconstruct them as parenthesised specifiers appended to the section value. The same pattern used by the USC href parser in `xml_parser.py` (converting `/c` → `(c)`) is now applied consistently.

Two regression tests added:
- `test_parser.py`: end-to-end via `_extract_source_credit_refs` with XML mimicking 13 U.S.C. § 214's source credit
- `test_normalized_section.py`: `path_display` roundtrip asserting `§12(a)` and `§2(c)` are produced correctly

Closes #490