### PR TITLE
fix: include tail text and italic siblings when extracting citation subdivisions

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1675,6 +1675,102 @@ class USLMParser:
                 result.append(" " + stripped)
         return "".join(result).strip()
 
+    @staticmethod
+    def _collect_ref_subdivision_suffix(ref_elem: etree._Element) -> str:
+        """Collect subdivision text that follows a <ref> element's closing tag.
+
+        In OLRC XML, italic letters in subdivision specifiers (e.g., the 'l' in
+        '(l)(3)(F)') are encoded as <i>l</i> elements immediately after the
+        closing </ref> tag. The surrounding parentheses and alphanumeric identifiers
+        appear as tail text of the <ref> or <i> elements. This method collects
+        that trailing text and returns it as a suffix to append to the ref's
+        display text.
+
+        The collection stops at the first structural delimiter (a comma) encountered
+        at the same parenthetical depth as the end of the ref element's own text, or
+        at a structural sibling element (e.g., <date>, <ref>, <statuteRef>).
+
+        Args:
+            ref_elem: The <ref> element whose tail/siblings to inspect.
+
+        Returns:
+            Suffix string (e.g., '(l)(3)(F)') to append to the ref's text content,
+            or an empty string if no subdivision suffix is found.
+        """
+        # Structural element local names that signal a new citation component
+        _STOP_TAGS = {"date", "ref", "statuteRef", "sourceCredit"}
+
+        def _paren_depth(s: str) -> int:
+            """Return the net paren depth change for string s."""
+            depth = 0
+            for ch in s:
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+            return depth
+
+        def _take_until_comma_at_depth(s: str, start_depth: int) -> tuple[str, int]:
+            """Return (leading chars of s before a comma at depth <= 0, final depth).
+
+            Scanning begins with paren depth = start_depth, and stops when a comma
+            is encountered while depth <= 0.
+            """
+            depth = start_depth
+            for i, ch in enumerate(s):
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                elif ch == "," and depth <= 0:
+                    return s[:i], depth
+            return s, depth
+
+        parent = ref_elem.getparent()
+        if parent is None:
+            return ""
+
+        children = list(parent)
+        try:
+            ref_idx = children.index(ref_elem)
+        except ValueError:
+            return ""
+
+        # Compute the paren depth at the end of the ref element's own text content.
+        # If the ref text ends with an open paren (e.g., '§ 1103('), we start at
+        # depth 1 so that a comma inside the subdivision does not act as a delimiter.
+        ref_text = "".join(ref_elem.itertext())
+        current_depth = _paren_depth(ref_text)
+
+        parts: list[str] = []
+
+        # 1. Collect from ref_elem.tail (text immediately after </ref>)
+        tail = ref_elem.tail or ""
+        chunk, current_depth = _take_until_comma_at_depth(tail, current_depth)
+        parts.append(chunk)
+        # If the tail contained a delimiter (chunk shorter than tail), stop here.
+        if len(chunk) < len(tail):
+            return "".join(parts)
+
+        # 2. Collect from subsequent sibling elements until we hit a delimiter
+        for sibling in children[ref_idx + 1 :]:
+            tag = sibling.tag
+            local = etree.QName(tag).localname if not callable(tag) else None
+            if local in _STOP_TAGS:
+                break
+            # Collect all text inside the sibling (e.g., 'l' inside <i>l</i>)
+            sib_text = "".join(sibling.itertext())
+            current_depth += _paren_depth(sib_text)
+            parts.append(sib_text)
+            # Then collect from the sibling's tail
+            sib_tail = sibling.tail or ""
+            chunk, current_depth = _take_until_comma_at_depth(sib_tail, current_depth)
+            parts.append(chunk)
+            if len(chunk) < len(sib_tail):
+                break  # Hit a structural delimiter in sibling tail
+
+        return "".join(parts)
+
     def _extract_source_credit_refs(
         self, section_elem: etree._Element
     ) -> tuple[list[SourceCreditRef], list[ActRef]]:
@@ -1718,6 +1814,23 @@ class USLMParser:
                 href = elem.get("href", "")
                 text = "".join(elem.itertext()).strip()
 
+                # Collect any subdivision text following the </ref> closing tag.
+                # In OLRC XML, italic letters in subdivision specifiers (e.g., the 'l'
+                # in '§ 1103(l)(3)(F)') are encoded as sibling <i> elements after </ref>.
+                subdivision_suffix = self._collect_ref_subdivision_suffix(elem)
+                full_text = (text + subdivision_suffix).strip()
+
+                # Compute the "bridge": trailing '(' chars in ref text that open the
+                # subdivision but are not encoded in the href (e.g., '/s1103' href while
+                # ref text ends with '§ 1103(').
+                bridge = ""
+                if subdivision_suffix:
+                    trail = "".join(elem.itertext()).rstrip()
+                    i = len(trail)
+                    while i > 0 and trail[i - 1] == "(":
+                        i -= 1
+                    bridge = trail[i:]
+
                 # Parse /us/pl/CONGRESS/LAW/... hrefs (Public Laws, post-1957)
                 if "/us/pl/" in href:
                     match = re.match(
@@ -1728,13 +1841,19 @@ class USLMParser:
                         href,
                     )
                     if match:
+                        href_section = match.group(5)
+                        section_value: str | None = (
+                            href_section + bridge + subdivision_suffix
+                            if subdivision_suffix and href_section
+                            else href_section
+                        )
                         ref = SourceCreditRef(
                             congress=int(match.group(1)),
                             law_number=int(match.group(2)),
                             division=match.group(3),
                             title=match.group(4),
-                            section=match.group(5),
-                            raw_text=text,
+                            section=section_value,
+                            raw_text=full_text,
                         )
                         pl_refs.append(ref)
                         last_ref_type = "pl"
@@ -1748,12 +1867,18 @@ class USLMParser:
                         href,
                     )
                     if match:
+                        href_section = match.group(4)
+                        section_value = (
+                            href_section + bridge + subdivision_suffix
+                            if subdivision_suffix and href_section
+                            else href_section
+                        )
                         act_ref = ActRef(
                             date=match.group(1),  # e.g., "1935-08-14"
                             chapter=int(match.group(2)),
                             title=match.group(3),
-                            section=match.group(4),
-                            raw_text=text,
+                            section=section_value,
+                            raw_text=full_text,
                         )
                         act_refs.append(act_ref)
                         last_ref_type = "act"

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1839,7 +1839,6 @@ class USLMParser:
                         r"(?:/t([IVXLCDM]+))?"  # Optional title
                         r"(?:/s([\w()]+))?",  # Optional section
                         href,
-
                     )
                     if match:
                         href_section = match.group(5)

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1839,6 +1839,7 @@ class USLMParser:
                         r"(?:/t([IVXLCDM]+))?"  # Optional title
                         r"(?:/s([\w()]+))?",  # Optional section
                         href,
+
                     )
                     if match:
                         href_section = match.group(5)

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -1340,9 +1340,7 @@ class TestCitationTailTextSubdivision:
         """Create a parser instance."""
         return USLMParser()
 
-    def test_collect_ref_subdivision_suffix_with_italic_sibling(
-        self, parser: USLMParser
-    ) -> None:
+    def test_collect_ref_subdivision_suffix_with_italic_sibling(self) -> None:
         """The subdivision suffix must be collected from ref tail and adjacent <i>
         sibling when the italic letter 'l' is encoded outside <ref>.
 
@@ -1388,9 +1386,10 @@ class TestCitationTailTextSubdivision:
           section  = "1103(l)(3)(F)"
         """
         xml = (
-            '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"' 
-            ' identifier="/us/usc/t23/s161">' 
-            "  <num value=\"161\">§ 161.</num>"
+            '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"'
+            ' identifier="/us/usc/t23/s161">'
+            '  <num value="161">§ 161.</num>'
+
             "  <heading>Some heading</heading>"
             "  <sourceCredit>"
             "    (<ref"
@@ -1420,9 +1419,7 @@ class TestCitationTailTextSubdivision:
         assert "(l)(3)(F)" in ref.raw_text
         assert ref.raw_text == "Pub. L. 105–178, title I, § 1103(l)(3)(F)"
 
-    def test_collect_ref_subdivision_suffix_no_tail(
-        self, parser: USLMParser
-    ) -> None:
+    def test_collect_ref_subdivision_suffix_no_tail(self) -> None:
         """When there is no tail text or italic siblings, the suffix must be empty."""
         xml = (
             '<sourceCredit xmlns="http://xml.house.gov/schemas/uslm/1.0">' 
@@ -1444,9 +1441,10 @@ class TestCitationTailTextSubdivision:
     ) -> None:
         """Citations without italic siblings must still parse correctly after the fix."""
         xml = (
-            '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"' 
-            ' identifier="/us/usc/t17/s101">' 
-            "  <num value=\"101\">§ 101.</num>"
+            '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"'
+            ' identifier="/us/usc/t17/s101">'
+            '  <num value="101">§ 101.</num>'
+
             "  <heading>Definitions</heading>"
             "  <sourceCredit>"
             "    (<ref"

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -1389,11 +1389,10 @@ class TestCitationTailTextSubdivision:
             '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"'
             ' identifier="/us/usc/t23/s161">'
             '  <num value="161">§ 161.</num>'
-
             "  <heading>Some heading</heading>"
             "  <sourceCredit>"
             "    (<ref"
-            '      href="/us/pl/105/178/tI/s1103">' 
+            '      href="/us/pl/105/178/tI/s1103">'
             "Pub. L. 105–178, title I, § 1103("
             "</ref>"
             "<i>l</i>"
@@ -1422,8 +1421,8 @@ class TestCitationTailTextSubdivision:
     def test_collect_ref_subdivision_suffix_no_tail(self) -> None:
         """When there is no tail text or italic siblings, the suffix must be empty."""
         xml = (
-            '<sourceCredit xmlns="http://xml.house.gov/schemas/uslm/1.0">' 
-            '<ref href="/us/pl/94/553/tI/s101">' 
+            '<sourceCredit xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<ref href="/us/pl/94/553/tI/s101">'
             "Pub. L. 94–553, title I, § 101"
             "</ref>"
             ", Oct. 19, 1976, 90 Stat. 2546."
@@ -1444,11 +1443,10 @@ class TestCitationTailTextSubdivision:
             '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"'
             ' identifier="/us/usc/t17/s101">'
             '  <num value="101">§ 101.</num>'
-
             "  <heading>Definitions</heading>"
             "  <sourceCredit>"
             "    (<ref"
-            '      href="/us/pl/94/553/tI/s101">' 
+            '      href="/us/pl/94/553/tI/s101">'
             "Pub. L. 94–553, title I, § 101"
             "</ref>"
             ", Oct. 19, 1976, "

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -1323,6 +1323,153 @@ class TestNoteRefDataclass:
         assert ref.act_chapter == 531
 
 
+class TestCitationTailTextSubdivision:
+    """Tests for citation subdivision text that appears after <ref> closing tags.
+
+    Regression tests for Issue #463: 23 USC § 161 source credit citation for
+    PL 105-178 truncated — missing subdivision (l)(3)(F).
+
+    In OLRC XML, italic letters in subdivision specifiers are encoded as sibling
+    <i> elements after the </ref> closing tag. The parser must collect this tail
+    text and adjacent sibling text to produce the full subdivision in raw_text
+    and path_display.
+    """
+
+    @pytest.fixture
+    def parser(self) -> USLMParser:
+        """Create a parser instance."""
+        return USLMParser()
+
+    def test_collect_ref_subdivision_suffix_with_italic_sibling(
+        self, parser: USLMParser
+    ) -> None:
+        """The subdivision suffix must be collected from ref tail and adjacent <i>
+        sibling when the italic letter 'l' is encoded outside <ref>.
+
+        Simulates the OLRC XML structure for 23 USC § 161 / PL 105-178:
+          <ref href="...">...§ 1103(</ref><i>l</i>)(3)(F), June 9, 1998, ...
+
+        In this structure the opening '(' is the last char of the ref element's
+        own text, so the suffix starts with 'l' (not '(l'). When appended to the
+        ref text the full display string becomes '§ 1103(l)(3)(F)'.
+        """
+        xml = (
+            '<sourceCredit xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<ref href="/us/pl/105/178/tI/s1103">'
+            "Pub. L. 105–178, title I, § 1103("
+            "</ref>"
+            "<i>l</i>"
+            ")(3)(F), "
+            '<date date="1998-06-09">June 9, 1998</date>'
+            ", 112 Stat. 126."
+            "</sourceCredit>"
+        )
+        elem = etree.fromstring(xml)
+        ref_elem = elem.find(".//{http://xml.house.gov/schemas/uslm/1.0}ref")
+        assert ref_elem is not None
+
+        suffix = USLMParser._collect_ref_subdivision_suffix(ref_elem)
+
+        # The opening '(' is part of the ref element's own text, so the suffix
+        # starts immediately with 'l'. When appended: '§ 1103(' + 'l)(3)(F)' = full subdivision.
+        assert suffix == "l)(3)(F)"
+
+    def test_extract_source_credit_refs_includes_full_subdivision(
+        self, parser: USLMParser
+    ) -> None:
+        """raw_text and path (section) must include the full subdivision '(l)(3)(F)'
+        even when italic sibling elements and tail text encode part of it outside <ref>.
+
+        Regression test for Issue #463: before this fix, the parsed citation was:
+          raw_text = "Pub. L. 105–178, title I, § 1103("
+          section  = "1103"
+        After the fix:
+          raw_text = "Pub. L. 105–178, title I, § 1103(l)(3)(F)"
+          section  = "1103(l)(3)(F)"
+        """
+        xml = (
+            '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"' 
+            ' identifier="/us/usc/t23/s161">' 
+            "  <num value=\"161\">§ 161.</num>"
+            "  <heading>Some heading</heading>"
+            "  <sourceCredit>"
+            "    (<ref"
+            '      href="/us/pl/105/178/tI/s1103">' 
+            "Pub. L. 105–178, title I, § 1103("
+            "</ref>"
+            "<i>l</i>"
+            ")(3)(F), "
+            '    <date date="1998-06-09">June 9, 1998</date>'
+            ", 112 Stat. 126.)"
+            "  </sourceCredit>"
+            "</section>"
+        )
+        elem = etree.fromstring(xml)
+        pl_refs, act_refs = parser._extract_source_credit_refs(elem)
+
+        assert len(pl_refs) == 1
+        assert len(act_refs) == 0
+
+        ref = pl_refs[0]
+        assert ref.congress == 105
+        assert ref.law_number == 178
+        assert ref.title == "I"
+        # Section must include the full subdivision, not just the base number
+        assert ref.section == "1103(l)(3)(F)"
+        # raw_text must include the full display string from the source credit
+        assert "(l)(3)(F)" in ref.raw_text
+        assert ref.raw_text == "Pub. L. 105–178, title I, § 1103(l)(3)(F)"
+
+    def test_collect_ref_subdivision_suffix_no_tail(
+        self, parser: USLMParser
+    ) -> None:
+        """When there is no tail text or italic siblings, the suffix must be empty."""
+        xml = (
+            '<sourceCredit xmlns="http://xml.house.gov/schemas/uslm/1.0">' 
+            '<ref href="/us/pl/94/553/tI/s101">' 
+            "Pub. L. 94–553, title I, § 101"
+            "</ref>"
+            ", Oct. 19, 1976, 90 Stat. 2546."
+            "</sourceCredit>"
+        )
+        elem = etree.fromstring(xml)
+        ref_elem = elem.find(".//{http://xml.house.gov/schemas/uslm/1.0}ref")
+        assert ref_elem is not None
+
+        suffix = USLMParser._collect_ref_subdivision_suffix(ref_elem)
+        assert suffix == ""
+
+    def test_extract_source_credit_refs_unaffected_without_italic_sibling(
+        self, parser: USLMParser
+    ) -> None:
+        """Citations without italic siblings must still parse correctly after the fix."""
+        xml = (
+            '<section xmlns="http://xml.house.gov/schemas/uslm/1.0"' 
+            ' identifier="/us/usc/t17/s101">' 
+            "  <num value=\"101\">§ 101.</num>"
+            "  <heading>Definitions</heading>"
+            "  <sourceCredit>"
+            "    (<ref"
+            '      href="/us/pl/94/553/tI/s101">' 
+            "Pub. L. 94–553, title I, § 101"
+            "</ref>"
+            ", Oct. 19, 1976, "
+            '    <date date="1976-10-19">Oct. 19, 1976</date>'
+            ", 90 Stat. 2546.)"
+            "  </sourceCredit>"
+            "</section>"
+        )
+        elem = etree.fromstring(xml)
+        pl_refs, act_refs = parser._extract_source_credit_refs(elem)
+
+        assert len(pl_refs) == 1
+        ref = pl_refs[0]
+        assert ref.congress == 94
+        assert ref.law_number == 553
+        assert ref.section == "101"
+        assert ref.raw_text == "Pub. L. 94–553, title I, § 101"
+
+
 class TestExtractSourceCreditRefs:
     """Tests for _extract_source_credit_refs — specifically the as-added date bug (Issue #480)."""
 
@@ -1353,7 +1500,7 @@ class TestExtractSourceCreditRefs:
         <section identifier="/us/usc/t22/s2377" number="2377">
           <heading>Prohibition on assistance to countries that aid terrorist states</heading>
           <content><p>Test content.</p></content>
-          <sourceCredit>(<ref href="/us/pl/87/195/tIII/s620G">Pub. L. 87–195</ref>, pt. III, § 620G, as added <ref href="/us/pl/104/132/tIII/s325">Pub. L. 104–132</ref>, title III, § 325, <date>Apr. 24, 1996</date>, <ref href="/us/stat/110/1256">110 Stat. 1256</ref>.)</sourceCredit>
+          <sourceCredit>(<ref href="/us/pl/87/195/tIII/s620G">Pub. L. 87–195</ref>, pt. III, § 620G, as added <ref href="/us/pl/104/132/tIII/s325">Pub. L. 104–132</ref>, title III, § 325, <date>Apr. 24, 1996</date>, <ref href="/us/stat/110/1256">110 Stat. 1256</ref>.)</sourceCredit>
         </section>
       </chapter>
     </title>


### PR DESCRIPTION
## Bug

Source credit citation paths for laws like PL 105-178 were truncated because the parser only read text content inside `<ref>` elements, ignoring their `.tail` text and adjacent sibling elements. In OLRC XML, italic letters in subdivision specifiers (e.g., the `l` in `(l)(3)(F)`) are encoded as `<i>l</i>` outside the `<ref>` element. This caused `(l)(3)(F)` to be silently dropped from `raw_text` and `path_display`.

**Before (broken):**
```
raw_text:     "Pub. L. 105–178, title I, § 1103("
path_display: "§1103"
section path: [{"level": "section", "value": "1103"}]
```

**After (fixed):**
```
raw_text:     "Pub. L. 105–178, title I, § 1103(l)(3)(F)"
path_display: "§1103(l)(3)(F)"
section path: [{"level": "section", "value": "1103(l)(3)(F)"}]
```

## Fix

Added `USLMParser._collect_ref_subdivision_suffix()` which collects text from the `<ref>` element's `.tail` attribute and adjacent sibling elements (like `<i>`) that complete the citation subdivision, stopping at the first comma encountered outside all parentheses. The `_extract_source_credit_refs()` method now appends this suffix to both `raw_text` and the section path component.

The paren depth tracking accounts for unclosed parentheses in the ref element's own text (e.g., `§ 1103(` ends at depth 1, so the suffix `l)(3)(F)` is correctly collected without the trailing `, ` being included).

A regression test class `TestCitationTailTextSubdivision` is added covering:
- Suffix collection with an italic sibling
- Full end-to-end section extraction including `(l)(3)(F)`
- No-suffix case (existing citations unaffected)
- End-to-end extraction without italic siblings (backward compatibility)

Closes #463