### PR TITLE
fix: do not split note paragraphs on inline (number) cross-references

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -101,6 +101,8 @@ LEGAL_ABBREVIATIONS = {
     "cl.",
     "Para.",
     "para.",
+    "Par.",  # Paragraph (e.g., "Par. (11). Pub. L. ...")
+    "par.",  # Paragraph (e.g., "inserted two pars. relating to par. (11)")
     "Subsec.",  # Subsection (e.g., "referred to in subsec. (c)(3)")
     "subsec.",
     "Subsecs.",  # Plural subsection (e.g., "referred to in subsecs. (b), (c)")

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1702,9 +1702,9 @@ class TestNormalizeNoteContent:
         text = "Par. (11). Pub. L. 109–9, § 202(a)(1)–(3), added par. (11)."
         lines = normalize_note_content(text)
 
-        non_blank = [l for l in lines if l.content]
+        non_blank = [ln for ln in lines if ln.content]
         assert len(non_blank) == 1, (
-            f"Expected 1 line, got {len(non_blank)}: {[l.content for l in non_blank]}"
+            f"Expected 1 line, got {len(non_blank)}: {[ln.content for ln in non_blank]}"
         )
         assert "Par. (11)" in non_blank[0].content
 
@@ -1738,10 +1738,10 @@ class TestNormalizeNoteContent:
         _parse_notes_structure(raw, notes)
 
         amendment_note = next(n for n in notes.notes if n.header == "Amendments")
-        non_blank = [l for l in amendment_note.lines if l.content]
+        non_blank = [ln for ln in amendment_note.lines if ln.content]
         assert len(non_blank) == 2, (
             f"Expected 2 lines (one per <p>), got {len(non_blank)}: "
-            f"{[l.content for l in non_blank]}"
+            f"{[ln.content for ln in non_blank]}"
         )
         assert "par. (11)" in non_blank[0].content
         assert "Par. (11)" in non_blank[1].content

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1686,9 +1686,9 @@ class TestNormalizeNoteContent:
         text = "2005—Pub. L. 109–9, § 202(a)(4), inserted two pars. relating to par. (11) at end of concluding provisions."
         lines = normalize_note_content(text)
 
-        non_blank = [l for l in lines if l.content]
+        non_blank = [ln for ln in lines if ln.content]
         assert len(non_blank) == 1, (
-            f"Expected 1 line, got {len(non_blank)}: {[l.content for l in non_blank]}"
+            f"Expected 1 line, got {len(non_blank)}: {[ln.content for ln in non_blank]}"
         )
         assert "par. (11)" in non_blank[0].content
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1675,6 +1675,77 @@ class TestNormalizeNoteContent:
         # The actual note text must still be present
         assert "qualified to become a member of that panel." in last_line.content
 
+    def test_par_number_cross_reference_not_split(self) -> None:
+        """Note paragraphs with 'par. (N)' inline refs must not be fragmented.
+
+        Regression test for Issue #461: 17 USC § 110 amendment notes were split
+        at 'par. (11)' because the period triggered a false sentence boundary.
+        Each <p> element in notes must map to exactly one content line.
+        """
+        # Single paragraph with inline par. (N) reference — must stay as one line.
+        text = "2005—Pub. L. 109–9, § 202(a)(4), inserted two pars. relating to par. (11) at end of concluding provisions."
+        lines = normalize_note_content(text)
+
+        non_blank = [l for l in lines if l.content]
+        assert len(non_blank) == 1, (
+            f"Expected 1 line, got {len(non_blank)}: {[l.content for l in non_blank]}"
+        )
+        assert "par. (11)" in non_blank[0].content
+
+    def test_par_uppercase_number_cross_reference_not_split(self) -> None:
+        """'Par. (N). Pub. L.' at the start of a note line must not be split.
+
+        Regression test for Issue #461: 'Par. (11). Pub. L.' was incorrectly
+        split into ['Par.', '(11). Pub. L. ...', '(11).'] because the period
+        after 'Par' was treated as a sentence boundary before '(11)'.
+        """
+        text = "Par. (11). Pub. L. 109–9, § 202(a)(1)–(3), added par. (11)."
+        lines = normalize_note_content(text)
+
+        non_blank = [l for l in lines if l.content]
+        assert len(non_blank) == 1, (
+            f"Expected 1 line, got {len(non_blank)}: {[l.content for l in non_blank]}"
+        )
+        assert "Par. (11)" in non_blank[0].content
+
+    def test_two_para_note_each_p_yields_one_line(self) -> None:
+        """Two <p> elements in a note must each produce exactly one content line.
+
+        Regression test for Issue #461: verifies end-to-end that the XML parser
+        + note normalizer together preserve paragraph boundaries from the OLRC XML.
+        """
+        from lxml import etree
+
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+        from pipeline.olrc.parser import USLMParser
+
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<note topic="amendments">'
+            "<heading>Amendments</heading>"
+            "<p>2005—Pub. L. 109–9, § 202(a)(4), inserted two pars. relating"
+            " to par. (11) at end of concluding provisions.</p>"
+            "<p>Par. (11). Pub. L. 109–9, § 202(a)(1)–(3), added par. (11).</p>"
+            "</note>"
+            "</notes>"
+        )
+        notes_elem = etree.fromstring(xml)
+        raw = USLMParser()._get_notes_text_content(notes_elem)
+        notes = SectionNotes()
+        _parse_notes_structure(raw, notes)
+
+        amendment_note = next(n for n in notes.notes if n.header == "Amendments")
+        non_blank = [l for l in amendment_note.lines if l.content]
+        assert len(non_blank) == 2, (
+            f"Expected 2 lines (one per <p>), got {len(non_blank)}: "
+            f"{[l.content for l in non_blank]}"
+        )
+        assert "par. (11)" in non_blank[0].content
+        assert "Par. (11)" in non_blank[1].content
+
 
 class TestSentenceSplittingWithParagraphs:
     """Tests for sentence splitting with paragraph break detection."""


### PR DESCRIPTION
## Bug

Amendment note paragraphs were incorrectly fragmented whenever they contained inline statutory cross-references like "(11)" or "(2)". The note-text parser was applying the same `(number)` paragraph-detection logic used for statutory body text, splitting a single `<p>` note paragraph into multiple line entries.

For example, "inserted two pars. relating to par. (11) at end of concluding provisions." was split into two lines: one ending at "par." and a second starting with "(11)". Similarly, "Par. (11). Pub. L. 109–9 ..." was split into three fragments: "Par.", "(11). Pub. L. 109–9 ..., added par.", and "(11).".

## Root Cause

`_is_sentence_boundary` in `normalized_section.py` uses `_SENTENCE_FOLLOWS_RE = r'\s+[A-Z("\'...]'` to detect sentence starts, which includes `(`. So "par. (11)" was treated as a sentence boundary: period after `par` followed by ` (`. However `"par."` and `"Par."` were absent from `LEGAL_ABBREVIATIONS`, which is the set that prevents known abbreviations from being sentence-boundary candidates.

## Fix

Add `"par."` and `"Par."` to `LEGAL_ABBREVIATIONS`. These are genuine legal-drafting abbreviations for "paragraph" (the same set already contains `"para."` and `"Para."`). With them present, `_ABBREV_SUFFIX_RE` matches the period after `par`, and `_is_sentence_boundary` correctly returns `False` — keeping `par. (11)` inline.

**Before:**
```
Line 150: "2005— Pub. L. 109–9, § 202(a)(4), inserted two pars. relating to par."
Line 151: "(11) at end of concluding provisions."
Line 153: "Par."
Line 154: "(11). Pub. L. 109–9, § 202(a)(1) –(3), added par."
Line 155: "(11)."
```

**After:**
```
Line 150: "2005—Pub. L. 109–9, § 202(a)(4), inserted two pars. relating to par. (11) at end of concluding provisions."
Line 151: "Par. (11). Pub. L. 109–9, § 202(a)(1)–(3), added par. (11)."
```

Three regression tests added covering: inline `par. (N)` mid-sentence, `Par. (N).` at start of a note line, and end-to-end XML → parsed lines verifying each `<p>` maps to exactly one content line.

Closes #461