### PR TITLE
fix: capture intro paragraphs and separate continuation elements in statutory body parser

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1116,27 +1116,40 @@ class USLMParser:
         # appears as <continuation> inside <content> inside the last <paragraph>.
         # We strip them from the content text and collect them separately so
         # callers can promote them to the correct indent level.
+        #
+        # <p> elements inside <content> represent separate paragraphs in USLM
+        # (e.g. 9 U.S.C. § 13 where a trailing sentence follows the (c) item).
+        # They are also excluded from content text and emitted as continuations
+        # so they render as separate provisions (Issue #479).
         content_continuations: list[str] = []
         if chapeau_elem is not None:
             content_parts.append(
                 self._get_text_content(chapeau_elem, strip_footnotes=True)
             )
         if content_elem is not None:
-            # Check for <continuation> children inside <content>.
+            # Collect child elements inside <content> that should be separated out:
+            # <continuation> and <p> elements each represent distinct paragraphs.
             cont_in_content = content_elem.findall(
                 "{*}continuation"
             ) or content_elem.findall("continuation")
-            if cont_in_content:
-                # Get content text excluding the <continuation> children.
+            p_in_content = content_elem.findall("{*}p") or content_elem.findall("p")
+            excluded_in_content = cont_in_content + p_in_content
+            if excluded_in_content:
+                # Get content text excluding the separated child elements.
                 content_text = self._get_text_content_excluding(
-                    content_elem, cont_in_content, strip_footnotes=True
+                    content_elem, excluded_in_content, strip_footnotes=True
                 )
                 if content_text:
                     content_parts.append(content_text)
-                for cont_elem in cont_in_content:
-                    cont_text = self._get_text_content(cont_elem, strip_footnotes=True)
-                    if cont_text:
-                        content_continuations.append(cont_text)
+                # Emit separated children in document order as continuation entries.
+                excluded_set = {id(e) for e in excluded_in_content}
+                for child_elem in content_elem:
+                    if id(child_elem) in excluded_set:
+                        cont_text = self._get_text_content(
+                            child_elem, strip_footnotes=True
+                        )
+                        if cont_text:
+                            content_continuations.append(cont_text)
             else:
                 content_parts.append(
                     self._get_text_content(content_elem, strip_footnotes=True)
@@ -1210,17 +1223,34 @@ class USLMParser:
                 para_elems = section_elem.findall("paragraph")
 
             if para_elems:
-                # Check for section-level chapeau (introductory text before the list)
+                # Determine the document-order position of the first and last paragraph
+                # to classify sibling <p> elements as intro text or trailing text.
+                all_children = list(section_elem)
+                first_para_idx = all_children.index(para_elems[0])
+                last_para_idx = all_children.index(para_elems[-1])
+
+                # Collect introductory text: explicit <chapeau> OR <p> siblings that
+                # appear before the first <paragraph> in document order (Issue #478).
                 chapeau_elem = section_elem.find("{*}chapeau")
                 if chapeau_elem is None:
                     chapeau_elem = section_elem.find("chapeau")
-                chapeau_text = (
-                    self._get_text_content(chapeau_elem)
-                    if chapeau_elem is not None
-                    else ""
-                )
+                chapeau_parts: list[str] = []
+                if chapeau_elem is not None:
+                    text = self._get_text_content(chapeau_elem)
+                    if text:
+                        chapeau_parts.append(text)
+                for child in all_children[:first_para_idx]:
+                    child_tag = (
+                        child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                    )
+                    if child_tag == "p":
+                        text = self._get_text_content(child)
+                        if text:
+                            chapeau_parts.append(text)
+                chapeau_text = " ".join(chapeau_parts)
 
-                # Check for section-level continuation (closing text after the list)
+                # Collect trailing text: explicit <continuation> OR <p> siblings that
+                # appear after the last <paragraph> in document order (Issue #479).
                 section_continuation: list[str] = []
                 cont_elems = section_elem.findall(
                     "{*}continuation"
@@ -1229,6 +1259,14 @@ class USLMParser:
                     cont_text = self._get_text_content(cont_elem, strip_footnotes=True)
                     if cont_text:
                         section_continuation.append(cont_text)
+                for child in all_children[last_para_idx + 1 :]:
+                    child_tag = (
+                        child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                    )
+                    if child_tag == "p":
+                        text = self._get_text_content(child, strip_footnotes=True)
+                        if text:
+                            section_continuation.append(text)
 
                 # Parse each paragraph, then bubble up any <continuation> elements
                 # that were nested inside a paragraph's <content>.  In OLRC XML
@@ -1243,24 +1281,33 @@ class USLMParser:
                     parsed_para = self._parse_subsection(para_elem, "paragraph")
                     # Detect which continuation items originated inside <content>
                     # (captured by _parse_subsection via content_continuations).
+                    # This includes both <continuation> elements (17 U.S.C. § 107)
+                    # and <p> elements (9 U.S.C. § 13, Issue #479) — both represent
+                    # section-level paragraphs, not sub-clauses of the list item.
                     para_content_elem = para_elem.find("{*}content")
                     if para_content_elem is None:
                         para_content_elem = para_elem.find("content")
                     if para_content_elem is not None:
-                        in_content_cont_texts = {
+                        in_content_separated_texts = {
                             self._get_text_content(ce, strip_footnotes=True)
                             for ce in (
                                 para_content_elem.findall("{*}continuation")
                                 or para_content_elem.findall("continuation")
                             )
+                        } | {
+                            self._get_text_content(pe, strip_footnotes=True)
+                            for pe in (
+                                para_content_elem.findall("{*}p")
+                                or para_content_elem.findall("p")
+                            )
                         }
-                        if in_content_cont_texts:
+                        if in_content_separated_texts:
                             # Bubble these up to section level and remove from
                             # the paragraph so they don't render at indent_level=1.
                             promoted: list[str] = []
                             kept: list[str] = []
                             for ct in parsed_para.continuation:
-                                if ct in in_content_cont_texts:
+                                if ct in in_content_separated_texts:
                                     promoted.append(ct)
                                 else:
                                     kept.append(ct)

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1279,6 +1279,185 @@ class TestNormalizeParsedSectionContinuation:
         assert result.provisions[0].content == "(a) Single item."
 
 
+class TestNormalizeParsedSection9USC13:
+    """End-to-end normalization tests for 9 U.S.C. § 13.
+
+    Regression tests for Issues #478 and #479: the statutory body parser was
+    silently dropping the introductory <p> element that precedes the (a)/(b)/(c)
+    list, and merging a trailing <p> into the (c) item without a separator.
+    """
+
+    def test_intro_p_renders_as_first_provision(self) -> None:
+        """The introductory <p> before the first list item must appear as the
+        first provision at indent_level=0, not be dropped entirely.
+
+        Regression test for Issue #478.
+        """
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        # Simulate what the parser produces AFTER the fix: intro <p> captured
+        # as the synthetic wrapper's content (chapeau), trailing <p> in continuation.
+        section = ParsedSection(
+            section_number="13",
+            heading="Application for order confirming, modifying, or correcting award",
+            full_citation="9 U.S.C. § 13",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="",
+                    heading=None,
+                    content=(
+                        "The party moving for an order confirming, modifying, or"
+                        " correcting an award shall, at the time such order is filed"
+                        " with the clerk for the entry of judgment thereon, also file"
+                        " the following papers with the clerk:"
+                    ),
+                    children=[
+                        ParsedSubsection(
+                            marker="(a)",
+                            heading=None,
+                            content=(
+                                "The agreement; the selection or appointment, if any,"
+                                " of an additional arbitrator or umpire; and each"
+                                " written extension of the time, if any, within which"
+                                " to make the award."
+                            ),
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(b)",
+                            heading=None,
+                            content="The award.",
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(c)",
+                            heading=None,
+                            content=(
+                                "Each notice, affidavit, or other paper used upon an"
+                                " application to confirm, modify, or correct the award,"
+                                " and a copy of each order of the court upon such an"
+                                " application."
+                            ),
+                            level="paragraph",
+                        ),
+                    ],
+                    level="subsection",
+                    continuation=[
+                        "The judgment shall be docketed as if it was rendered in an action."
+                    ],
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+
+        # Must have 5 provisions: intro + (a) + (b) + (c) + docketing sentence
+        assert result.provision_count == 5, (
+            f"Expected 5 provisions (intro + 3 items + docketing), got"
+            f" {result.provision_count}: {[p.content for p in result.provisions]}"
+        )
+
+        # First provision: intro sentence at indent 0 (Issue #478)
+        intro = result.provisions[0]
+        assert "party moving" in intro.content, (
+            "Introductory sentence must appear as the first provision"
+        )
+        assert intro.indent_level == 0
+        assert intro.marker is None
+
+        # (a), (b), (c) at indent 1
+        assert "(a)" in result.provisions[1].content
+        assert result.provisions[1].indent_level == 1
+        assert "(b)" in result.provisions[2].content
+        assert result.provisions[2].indent_level == 1
+        assert "(c)" in result.provisions[3].content
+        assert result.provisions[3].indent_level == 1
+
+        # Docketing sentence as a separate provision at indent 0 (Issue #479)
+        docketing = result.provisions[4]
+        assert "docketed" in docketing.content, (
+            "Docketing sentence must appear as a distinct final provision"
+        )
+        assert docketing.indent_level == 0
+        assert docketing.marker is None
+
+    def test_docketing_sentence_not_merged_with_c_item(self) -> None:
+        """The docketing sentence must NOT be concatenated into the (c) content.
+
+        Regression test for Issue #479: the merged content was
+        '(c) ...application.The judgment shall be docketed...' (no space).
+        """
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import ParsedSection, ParsedSubsection
+
+        section = ParsedSection(
+            section_number="13",
+            heading="Application for order confirming, modifying, or correcting award",
+            full_citation="9 U.S.C. § 13",
+            text_content="",
+            subsections=[
+                ParsedSubsection(
+                    marker="",
+                    heading=None,
+                    content="The party moving for an order:",
+                    children=[
+                        ParsedSubsection(
+                            marker="(a)",
+                            heading=None,
+                            content="The agreement.",
+                            level="paragraph",
+                        ),
+                        ParsedSubsection(
+                            marker="(c)",
+                            heading=None,
+                            content=(
+                                "Each notice, affidavit, or other paper used upon an"
+                                " application to confirm, modify, or correct the award,"
+                                " and a copy of each order of the court upon such an"
+                                " application."
+                            ),
+                            level="paragraph",
+                        ),
+                    ],
+                    level="subsection",
+                    continuation=[
+                        "The judgment shall be docketed as if it was rendered in an action."
+                    ],
+                ),
+            ],
+        )
+
+        result = normalize_parsed_section(section)
+
+        # Find the (c) provision
+        c_provision = next(
+            (p for p in result.provisions if p.content.startswith("(c)")), None
+        )
+        assert c_provision is not None, "Provision (c) must be present"
+
+        # (c) content must NOT include the docketing sentence
+        assert "docketed" not in c_provision.content, (
+            "Docketing sentence must NOT be merged into provision (c)"
+        )
+        # The no-space artifact must not appear
+        assert "application.The" not in c_provision.content, (
+            "Sentences must not be concatenated without a space"
+        )
+
+        # The docketing sentence must be a separate provision
+        docketing = next(
+            (p for p in result.provisions if "docketed" in p.content), None
+        )
+        assert docketing is not None, (
+            "Docketing sentence must appear as a distinct provision"
+        )
+        assert docketing.line_number > c_provision.line_number, (
+            "Docketing sentence must appear after provision (c)"
+        )
+
+
 class TestNormalizeNoteContent:
     """Tests for normalize_note_content function (notes parsing)."""
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -414,6 +414,163 @@ class TestUSLMParser:
             "Continuation text must be promoted to the section-level wrapper"
         )
 
+    def test_intro_p_sibling_captured_as_chapeau(self, parser: USLMParser) -> None:
+        """A <p> element appearing before the first <paragraph> in a section is
+        captured as introductory (chapeau) text rather than silently dropped.
+
+        Regression test for Issue #478: 9 U.S.C. § 13 has an intro sentence
+        ("The party moving for an order confirming...") encoded as a <p> sibling
+        of the (a)/(b)/(c) <paragraph> elements.  The parser was previously
+        looking only for <chapeau>, so the intro was absent from text_content
+        and provisions.
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t9/s13">
+          <num value="13">§ 13.</num>
+          <heading>Application for order confirming, modifying, or correcting award</heading>
+          <p>The party moving for an order confirming, modifying, or correcting an
+          award shall, at the time such order is filed with the clerk for the entry of
+          judgment thereon, also file the following papers with the clerk:</p>
+          <paragraph identifier="/us/usc/t9/s13/a">
+            <num value="a">(a)</num>
+            <content>The agreement; the selection or appointment, if any, of an
+            additional arbitrator or umpire.</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t9/s13/b">
+            <num value="b">(b)</num>
+            <content>The award.</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t9/s13/c">
+            <num value="c">(c)</num>
+            <content>Each notice, affidavit, or other paper used upon an application
+            to confirm, modify, or correct the award.</content>
+          </paragraph>
+          <sourceCredit>(June 12, 1939, ch. 237.)</sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml)
+        subsections = parser._extract_subsections(elem)
+
+        assert len(subsections) == 1
+        wrapper = subsections[0]
+
+        # Intro sentence must appear as the wrapper's content (chapeau equivalent)
+        assert "party moving" in wrapper.content, (
+            "Introductory <p> before paragraphs must be captured as chapeau text"
+        )
+        assert len(wrapper.children) == 3
+        assert wrapper.children[0].marker == "(a)"
+        assert wrapper.children[1].marker == "(b)"
+        assert wrapper.children[2].marker == "(c)"
+
+    def test_trailing_p_sibling_captured_as_continuation(
+        self, parser: USLMParser
+    ) -> None:
+        """A <p> element appearing after the last <paragraph> in a section is
+        captured as a section-level continuation rather than silently dropped.
+
+        Regression test for Issue #479: 9 U.S.C. § 13 has a trailing sentence
+        ("The judgment shall be docketed...") encoded as a <p> sibling after the
+        (a)/(b)/(c) <paragraph> elements.  This sentence was either dropped or
+        merged into the (c) item — it must appear as a distinct provision.
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t9/s13">
+          <num value="13">§ 13.</num>
+          <heading>Application for order confirming, modifying, or correcting award</heading>
+          <p>The party moving for an order confirming, modifying, or correcting an
+          award shall, at the time such order is filed with the clerk for the entry of
+          judgment thereon, also file the following papers with the clerk:</p>
+          <paragraph identifier="/us/usc/t9/s13/a">
+            <num value="a">(a)</num>
+            <content>The agreement; the selection or appointment, if any, of an
+            additional arbitrator or umpire.</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t9/s13/b">
+            <num value="b">(b)</num>
+            <content>The award.</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t9/s13/c">
+            <num value="c">(c)</num>
+            <content>Each notice, affidavit, or other paper used upon an application
+            to confirm, modify, or correct the award.</content>
+          </paragraph>
+          <p>The judgment shall be docketed as if it was rendered in an action.</p>
+          <sourceCredit>(June 12, 1939, ch. 237.)</sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml)
+        subsections = parser._extract_subsections(elem)
+
+        assert len(subsections) == 1
+        wrapper = subsections[0]
+
+        # Trailing <p> must appear as a section-level continuation
+        assert len(wrapper.continuation) >= 1, (
+            "Trailing <p> after paragraphs must be captured as section continuation"
+        )
+        assert any("docketed" in ct for ct in wrapper.continuation), (
+            "Docketing sentence must appear in section-level continuation"
+        )
+
+        # (c) content must NOT include the docketing sentence
+        para_c = wrapper.children[2]
+        assert para_c.marker == "(c)"
+        assert "docketed" not in para_c.content, (
+            "Docketing sentence must not be merged into paragraph (c) content"
+        )
+
+    def test_p_inside_content_separated_as_continuation(
+        self, parser: USLMParser
+    ) -> None:
+        """A <p> element inside a <content> element is excluded from the content
+        text and emitted as a separate continuation entry.
+
+        Regression test for Issue #479 (merged-paragraph variant): when OLRC XML
+        encodes a trailing sentence as <p> inside <content> of the last paragraph,
+        the itertext() merge caused the two sentences to concatenate without a
+        space — e.g. '...application.The judgment shall be docketed...'
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t9/s13">
+          <num value="13">§ 13.</num>
+          <heading>Application for order confirming, modifying, or correcting award</heading>
+          <p>The party moving for an order confirming, modifying, or correcting an
+          award shall, at the time such order is filed with the clerk for the entry of
+          judgment thereon, also file the following papers with the clerk:</p>
+          <paragraph identifier="/us/usc/t9/s13/a">
+            <num value="a">(a)</num>
+            <content>The agreement.</content>
+          </paragraph>
+          <paragraph identifier="/us/usc/t9/s13/c">
+            <num value="c">(c)</num>
+            <content>Each notice, affidavit, or other paper used upon an application
+            to confirm, modify, or correct the award.<p>The judgment shall be docketed
+            as if it was rendered in an action.</p></content>
+          </paragraph>
+          <sourceCredit>(June 12, 1939, ch. 237.)</sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml)
+        subsections = parser._extract_subsections(elem)
+
+        assert len(subsections) == 1
+        wrapper = subsections[0]
+        para_c = wrapper.children[1]
+        assert para_c.marker == "(c)"
+
+        # The (c) content must NOT contain the docketing sentence
+        assert "docketed" not in para_c.content, (
+            "<p> inside <content> must not be merged into the list item text"
+        )
+        # The merged no-space artifact must not appear either
+        assert "application.The" not in para_c.content, (
+            "<p> inside <content> must not be concatenated without a space"
+        )
+
+        # The docketing sentence must appear separately at section level
+        all_continuation = wrapper.continuation
+        assert any("docketed" in ct for ct in all_continuation), (
+            "<p> inside <content> must be promoted to section-level continuation"
+        )
+
 
 class TestToTitleCase:
     """Tests for to_title_case function."""


### PR DESCRIPTION
## Bug

Two related parsing issues affected 9 U.S.C. § 13 and likely other sections with similar USLM XML structure:

1. **#478 — Missing introductory paragraph**: The statutory body parser skipped `<p>` elements appearing as siblings before the first `<paragraph>` element. For 9 U.S.C. § 13, the lead-in sentence "The party moving for an order confirming..." was entirely absent from `text_content` and `provisions`. The parser only looked for `<chapeau>` as intro text; sections that use `<p>` instead had their intro silently dropped.

2. **#479 — Merged paragraphs**: Two variants of this bug were fixed:
   - **Trailing `<p>` sibling**: A `<p>` element appearing after the last `<paragraph>` sibling was dropped or merged into the preceding list item. The standalone docketing sentence "The judgment shall be docketed as if it was rendered in an action." was absent as a distinct provision.
   - **`<p>` inside `<content>`**: When OLRC encodes a trailing sentence as a `<p>` inside a `<paragraph>`'s `<content>`, `itertext()` concatenated it directly to the content text without a space — producing the artifact `"...application.The judgment shall be docketed..."`.

## Fix

**`_extract_subsections` (`parser.py`):**
- When processing `<paragraph>` elements as direct children of a `<section>`, the method now inspects all siblings in document order.
- `<p>` siblings before the first `<paragraph>` are collected as introductory (chapeau) text.
- `<p>` siblings after the last `<paragraph>` are collected as section-level continuation entries.

**`_parse_subsection` (`parser.py`):**
- When extracting text from a `<content>` element, `<p>` child elements (in addition to existing `<continuation>` children) are now excluded from the content text via `_get_text_content_excluding()`.
- Their text is emitted as separate continuation entries in document order, preventing the no-space merge artifact.
- The bubble-up logic in `_extract_subsections` is updated to also promote `<p>`-sourced continuations from paragraph content to section level, matching the existing behaviour for `<continuation>` elements (17 U.S.C. § 107 pattern).

## Before / After (9 U.S.C. § 13 with sibling `<p>` structure)

**Before:**
```
(a) The agreement; the selection or appointment, if any, of an additional arbitrator or umpire; and each written extension of the time, if any, within which to make the award.
(b) The award.
(c) Each notice, affidavit, or other paper used upon an application to confirm, modify, or correct the award, and a copy of each order of the court upon such an application.
```
(intro sentence missing; docketing sentence missing)

**After:**
```
The party moving for an order confirming, modifying, or correcting an award shall, at the time such order is filed with the clerk for the entry of judgment thereon, also file the following papers with the clerk:
    (a) The agreement; the selection or appointment, if any, of an additional arbitrator or umpire; and each written extension of the time, if any, within which to make the award.
    (b) The award.
    (c) Each notice, affidavit, or other paper used upon an application to confirm, modify, or correct the award, and a copy of each order of the court upon such an application.
The judgment shall be docketed as if it was rendered in an action.
```

## Tests Added

- `TestUSLMParser::test_intro_p_sibling_captured_as_chapeau` — verifies intro `<p>` sibling → chapeau text (Issue #478)
- `TestUSLMParser::test_trailing_p_sibling_captured_as_continuation` — verifies trailing `<p>` sibling → section continuation (Issue #479)
- `TestUSLMParser::test_p_inside_content_separated_as_continuation` — verifies `<p>` inside `<content>` is excluded from content text and emitted as continuation (Issue #479 variant)
- `TestNormalizeParsedSection9USC13::test_intro_p_renders_as_first_provision` — end-to-end: intro appears as provision 1 at indent 0 (Issue #478)
- `TestNormalizeParsedSection9USC13::test_docketing_sentence_not_merged_with_c_item` — end-to-end: docketing sentence is a distinct provision after (c) (Issue #479)

Closes #478
Closes #479