### PR TITLE
fix: strip [NH] internal markers from note line content

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -821,6 +821,12 @@ def normalize_note_content(text: str) -> list[ParsedLine]:
     # Clean up the text — strip note header markers and convert [PARA]
     text = re.sub(r"\[NH\].*?\[/NH\]", "", text, flags=re.DOTALL)
     text = re.sub(r"\[/NH\]", "", text)
+    # Strip orphaned opening [NH] markers (no matching [/NH]).  These arise when
+    # content is sliced at a section boundary: the lookahead in
+    # _parse_historical_notes stops at the plain text "Editorial Notes" but
+    # leaves the immediately-preceding "[NH]" inside the raw_content of the
+    # last note, producing a spurious "[NH]" with no closing tag.
+    text = re.sub(r"\[NH\]", "", text)
     text = re.sub(r"\[PARA\]", "\n\n", text)
     text = text.strip()
     if not text:

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1647,6 +1647,34 @@ class TestNormalizeNoteContent:
         assert sig_lines[0].content == "— By Irwin Karp,"
         assert sig_lines[1].content == "— Counsel"
 
+    def test_orphaned_nh_opening_tag_stripped(self) -> None:
+        """Orphaned [NH] opening tag (no closing [/NH]) must not appear in line content.
+
+        Regression test for issue #499: when _parse_historical_notes slices
+        content at a section boundary, the lookahead stops at the plain text of
+        the next section header (e.g. "Editorial Notes") but leaves the
+        immediately-preceding "[NH]" marker inside the last note's raw_content.
+        normalize_note_content must strip that orphaned opening tag so it does
+        not surface as "[NH]" at the end of the last line of note text.
+
+        Reproduces the spurious "[NH]" seen in 11 USC § 1163 Senate Report
+        No. 95-989 note at release point 113-21.
+        """
+        # Simulate raw_content where the content slice ends mid-marker:
+        # the "[NH]" for the next section header has no closing "[/NH]".
+        text = (
+            "This panel determines whether a trustee is qualified to become "
+            "a member of that panel. [NH]"
+        )
+        lines = normalize_note_content(text)
+
+        assert lines, "Expected at least one content line"
+        last_line = lines[-1]
+        assert "[NH]" not in last_line.content
+        assert "[/NH]" not in last_line.content
+        # The actual note text must still be present
+        assert "qualified to become a member of that panel." in last_line.content
+
 
 class TestSentenceSplittingWithParagraphs:
     """Tests for sentence splitting with paragraph break detection."""


### PR DESCRIPTION
## What

Strips spurious `[NH]` markers from note line content in `normalize_note_content`.

## Root cause

`normalize_note_content` correctly handled two cases:
1. Complete `[NH]...[/NH]` pairs — stripped with a paired regex
2. Orphaned `[/NH]` closing tags — stripped individually

But it did **not** handle orphaned **opening** `[NH]` tags (no matching `[/NH]`).

These arise at section boundaries in `_parse_historical_notes`. The function uses a lookahead like `(?=Editorial Notes|$)` to bound the historical notes block. When the raw notes contain `[NH]Editorial Notes[/NH]`, the lookahead matches at the plain-text "Editorial Notes" — but the preceding `[NH]` token remains inside the last note's `raw_content` slice without a corresponding `[/NH]`. That orphaned `[NH]` then passes through to the rendered `lines[].content` field.

**Before fix** — last line of the Senate Report No. 95-989 note for 11 USC § 1163:
```
"...qualified to become a member of that panel. [NH]"
```

**After fix:**
```
"...qualified to become a member of that panel."
```

## Fix

Added one additional `re.sub` pass in `normalize_note_content` (after the existing paired-tag and closing-tag passes) to strip any remaining bare `[NH]` opening markers:

```python
text = re.sub(r"\[NH\]", "", text)
```

This is a safe change: `[NH]` is an internal parser artifact that should never appear in rendered output, and the existing code already strips the closing `[/NH]` orphan.

## Test

Added `TestNormalizeNoteContent::test_orphaned_nh_opening_tag_stripped` — simulates the boundary-slice scenario (raw content ending with a bare `[NH]`) and asserts the marker does not appear in any line's `content` field.

Closes #499