### PR TITLE
fix: capture clauses nested directly in paragraph elements that skip the subparagraph level

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1144,22 +1144,44 @@ class USLMParser:
 
         content = " ".join(content_parts).strip()
 
-        # Parse nested children
+        # Parse nested children.
+        #
+        # The standard USLM hierarchy is:
+        #     subsection > paragraph > subparagraph > clause > subclause > item
+        #
+        # Normally each level's children use the immediate-next tag (e.g. a
+        # <paragraph> contains <subparagraph> children). However, some sources
+        # (e.g. 38 U.S.C. § 3702(a)(1)) skip a level — a <paragraph> may
+        # directly contain <clause> elements with no intervening
+        # <subparagraph>. If we only ever look for the immediate-next tag, we
+        # silently drop these deeper-nested children and lose their content.
+        #
+        # To handle this, we search for whichever of the structurally-valid
+        # descendant tags (in hierarchy order, from shallowest to deepest)
+        # actually appears as a direct child, and use that tag both to find
+        # the children AND to determine the correct `level` to assign so they
+        # render with the appropriate marker/indentation (e.g. clauses render
+        # as "(i)", "(ii)" regardless of whether they are reached via
+        # <subparagraph> or directly).
         children = []
-        child_levels = {
-            "subsection": ("paragraph", "paragraph"),
-            "paragraph": ("subparagraph", "subparagraph"),
-            "subparagraph": ("clause", "clause"),
-            "clause": ("subclause", "subclause"),
-            "subclause": ("item", "item"),
-        }
-
-        if level in child_levels:
-            child_tag, child_level = child_levels[level]
-            for child_elem in elem.findall(f"{{*}}{child_tag}") or elem.findall(
-                child_tag
-            ):
-                children.append(self._parse_subsection(child_elem, child_level))
+        hierarchy = [
+            "subsection",
+            "paragraph",
+            "subparagraph",
+            "clause",
+            "subclause",
+            "item",
+        ]
+        if level in hierarchy:
+            level_index = hierarchy.index(level)
+            for child_level in hierarchy[level_index + 1 :]:
+                child_elems = elem.findall(f"{{*}}{child_level}") or elem.findall(
+                    child_level
+                )
+                if child_elems:
+                    for child_elem in child_elems:
+                        children.append(self._parse_subsection(child_elem, child_level))
+                    break
 
         # Collect continuation elements (closing text that follows a numbered list,
         # e.g. the penalty clause in 18 U.S.C. § 1001(a)).

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -298,6 +298,58 @@ class TestUSLMParser:
 
         assert result.continuation == []
 
+    def test_parse_subsection_clause_skipping_subparagraph_level(
+        self, parser: USLMParser
+    ) -> None:
+        """_parse_subsection captures <clause> children nested directly in a
+        <paragraph>, skipping the <subparagraph> level.
+
+        Regression test for Issue #506: 38 U.S.C. § 3702(a)(1) encodes its
+        paragraph as a <chapeau> followed directly by two <clause> elements
+        (no intervening <subparagraph>). The parser previously only searched
+        for the immediate-next level in the standard hierarchy
+        (paragraph -> subparagraph), so it found nothing and silently dropped
+        clauses (i) and (ii) along with their text.
+        """
+        xml = """<paragraph xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t38/s3702/a/1">
+          <num value="1">(1)</num>
+          <chapeau>The veterans described in paragraph (2) of this subsection are
+          eligible for the housing loan benefits of this chapter. Entitlement
+          derived from service during the most recent such period shall be
+          reduced by the amount by which entitlement from service during any
+          earlier such period has been used to obtain a direct, guaranteed, or
+          insured housing loan&#8212;</chapeau>
+          <clause identifier="/us/usc/t38/s3702/a/1/i">
+            <num value="i">(i)</num>
+            <content>on real property which the veteran owns at the time of
+            application; or</content>
+          </clause>
+          <clause identifier="/us/usc/t38/s3702/a/1/ii">
+            <num value="ii">(ii)</num>
+            <content>as to which the Secretary has incurred actual liability or
+            loss, unless in the event of loss or the incurrence and payment of
+            such liability by the Secretary the resulting indebtedness of the
+            veteran to the United States has been paid in full.</content>
+          </clause>
+        </paragraph>"""
+        elem = etree.fromstring(xml)
+        result = parser._parse_subsection(elem, "paragraph")
+
+        assert result.marker == "(1)"
+        assert "housing loan" in result.content
+
+        assert len(result.children) == 2
+        clause_i, clause_ii = result.children
+
+        assert clause_i.marker == "(i)"
+        assert clause_i.level == "clause"
+        assert "on real property which the veteran owns" in clause_i.content
+
+        assert clause_ii.marker == "(ii)"
+        assert clause_ii.level == "clause"
+        assert "incurred actual liability or loss" in clause_ii.content
+
     def test_extract_subsections_continuation_in_subsection(
         self, parser: USLMParser
     ) -> None:


### PR DESCRIPTION
## Context

38 U.S.C. § 3702(a)(1) (release point 113-21) is missing clauses (i) and (ii) — two entire operative clauses of statutory text — from CWLB's parsed `text_content`/`provisions`. The official OLRC XML encodes paragraph (a)(1) as a `<paragraph>` containing a `<chapeau>` followed directly by two `<clause>` elements, with no intervening `<subparagraph>`:

```xml
<paragraph identifier="/us/usc/t38/s3702/a/1">
  <num value="1">(1)</num>
  <chapeau>...obtain a direct, guaranteed, or insured housing loan—</chapeau>
  <clause identifier="/us/usc/t38/s3702/a/1/i">
    <num value="i">(i)</num>
    <content>on real property which the veteran owns at the time of application; or</content>
  </clause>
  <clause identifier="/us/usc/t38/s3702/a/1/ii">
    <num value="ii">(ii)</num>
    <content>as to which the Secretary has incurred actual liability or loss, ...</content>
  </clause>
</paragraph>
```

## Bug

`USLMParser._parse_subsection` discovered nested children by looking for **only the immediate-next tag** in the standard USLM hierarchy (`subsection > paragraph > subparagraph > clause > subclause > item`) via a rigid `child_levels` lookup table — e.g. for a `<paragraph>`, it searched only for `<subparagraph>` children. When source XML skips a level (a `<paragraph>` directly containing `<clause>` children, as in § 3702(a)(1)), the parser found nothing and **silently dropped** those children and their text.

## Fix

`_parse_subsection` now walks the remaining hierarchy levels in order — from shallowest to deepest — and uses **whichever tag actually appears as a direct child** to both find the children and determine the correct `level` to assign them, so they render with the appropriate marker/indentation (e.g. `(i)`, `(ii)`) regardless of how many levels were skipped to reach them. It stops at the first matching level found, so normal hierarchy traversal (`paragraph -> subparagraph -> clause`) is unaffected and there's no double-matching.

## Before / after (synthetic XML mirroring § 3702(a)(1), via `_parse_subsection`)

**Before:**
```
marker: (1)
content: ...obtain a direct, guaranteed, or insured housing loan—
num children: 0
```
Clauses (i) and (ii) are completely absent.

**After:**
```
marker: (1)
content: ...obtain a direct, guaranteed, or insured housing loan—
num children: 2
  - level=clause marker=(i)  content='on real property which the veteran owns at the time of application; or'
  - level=clause marker=(ii) content='as to which the Secretary has incurred actual liability or loss, unless in the e...'
```
Both clauses are now captured with the correct `level` (`clause`) and marker (`(i)`/`(ii)`), so they render with proper indentation downstream.

## Testing

- Added `test_parse_subsection_clause_skipping_subparagraph_level` to `backend/tests/pipeline/test_parser.py`, constructing a `<paragraph>` with a `<chapeau>` and two directly-nested `<clause>` children mirroring the § 3702(a)(1) XML, asserting both clauses' content (`"on real property which the veteran owns"` / `"incurred actual liability or loss"`) is captured with `level == "clause"`.
- `uv run mypy app --ignore-missing-imports` — no issues
- `uv run pytest` — 798 passed, 21 skipped

Closes #506