### PR TITLE
fix: stop note content collection at note boundary

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1517,6 +1517,13 @@ def _parse_historical_notes(raw_notes: str, notes: SectionNotes) -> None:
         )
         return
 
+    # Pre-compute positions of all [NH] markers in hist_text so we can use them
+    # as note-boundary sentinels when no subsequent Report header exists.
+    # When hist_text absorbed sibling notes (because there is no "Editorial Notes"
+    # or "Statutory Notes" wrapper), the first [NH] marker *after* a Report's
+    # content start is the real boundary — not the end of hist_text.
+    _nh_positions = [m.start() for m in _NH_HEADER_PATTERN.finditer(hist_text)]
+
     # Extract unique report sections
     seen_headers: set[str] = set()
     for i, match in enumerate(matches):
@@ -1525,9 +1532,20 @@ def _parse_historical_notes(raw_notes: str, notes: SectionNotes) -> None:
             continue
         seen_headers.add(header)
 
-        # Content runs from end of this header to start of next header (or end)
+        # Content runs from end of this header to start of next header (or end).
+        # For the last report, also stop at the first [NH] marker that follows
+        # the report header — this prevents sibling flat notes (Amendments,
+        # Effective Date, etc.) from bleeding into the last report note.
         content_start = match.end()
-        content_end = matches[i + 1].start() if i + 1 < len(matches) else len(hist_text)
+        if i + 1 < len(matches):
+            content_end = matches[i + 1].start()
+        else:
+            # Find the first [NH] position strictly after content_start
+            next_nh = next(
+                (pos for pos in _nh_positions if pos > content_start),
+                len(hist_text),
+            )
+            content_end = next_nh
         raw_content = hist_text[content_start:content_end]
         content = _strip_note_markers(raw_content)
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2081,9 +2081,13 @@ class TestFlatNotesParser:
 
         # The House Report note must contain ONLY its own content —
         # no Amendments text and no Effective Date text.
-        house_report = next(n for n in notes.notes if n.header == "House Report No. 95-595")
+        house_report = next(
+            n for n in notes.notes if n.header == "House Report No. 95-595"
+        )
         house_text = " ".join(line.content for line in house_report.lines)
-        assert "independent trustee" in house_text, "House Report should contain its own text"
+        assert "independent trustee" in house_text, (
+            "House Report should contain its own text"
+        )
         assert "1986" not in house_text, (
             "House Report note must not contain Amendments year text"
         )
@@ -2097,7 +2101,9 @@ class TestFlatNotesParser:
         # Amendments note must have its own content
         amendments = next(n for n in notes.notes if n.header == "Amendments")
         amend_text = " ".join(line.content for line in amendments.lines)
-        assert "Pub. L. 99–554" in amend_text, "Amendments note should contain Pub. L. ref"
+        assert "Pub. L. 99–554" in amend_text, (
+            "Amendments note should contain Pub. L. ref"
+        )
 
         # Effective Date note must have its own content
         eff_date = next(

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2037,6 +2037,77 @@ class TestFlatNotesParser:
         assert 1957 in years
         assert 1975 in years
 
+    def test_house_report_note_does_not_absorb_siblings_issue_498(self) -> None:
+        """Regression: House Report note must not bleed into Amendments/Effective Date.
+
+        11 U.S.C. § 1163 (release 113-21): the Historical and Revision Notes contain
+        a House Report No. 95-595 note, followed by flat [NH]-delimited sibling notes
+        for Amendments and Effective Date of 1986 Amendment.  Because there is no
+        'Editorial Notes' / 'Statutory Notes' wrapper, the hist_text regex captured
+        everything to end-of-string.  The House Report note's content_end was then set
+        to len(hist_text), absorbing the Amendments and Effective Date text.  Closes #498.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        # Minimal reproduction of the 11 USC § 1163 flat-notes structure:
+        # Historical notes header + House Report + sibling flat notes
+        raw_notes = (
+            "Historical and Revision Notes "
+            "[NH]House Report No. 95-595[/NH] "
+            "[Section 1162] This section [enacted as section 1163] requires the appointment "
+            "of an independent trustee in a railroad reorganization case. "
+            "The court may appoint one or more disinterested persons to serve as trustee "
+            "in the case. "
+            "[NH]Amendments[/NH] "
+            "1986— Pub. L. 99–554 amended section generally, substituting provisions "
+            "relating to appointment of trustee for provisions relating to qualification "
+            "of trustee. "
+            "[NH]Effective Date Of 1986 Amendment[/NH] "
+            "Effective date and applicability of amendment by Pub. L. 99–554 are "
+            "as provided in section 302(a) of Pub. L. 99–554."
+        )
+
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        # All four notes must be present
+        headers = [n.header for n in notes.notes]
+        assert "House Report No. 95-595" in headers, f"Notes: {headers}"
+        assert "Amendments" in headers, f"Notes: {headers}"
+        assert "Effective Date Of 1986 Amendment" in headers, f"Notes: {headers}"
+
+        # The House Report note must contain ONLY its own content —
+        # no Amendments text and no Effective Date text.
+        house_report = next(n for n in notes.notes if n.header == "House Report No. 95-595")
+        house_text = " ".join(line.content for line in house_report.lines)
+        assert "independent trustee" in house_text, "House Report should contain its own text"
+        assert "1986" not in house_text, (
+            "House Report note must not contain Amendments year text"
+        )
+        assert "Pub. L. 99–554" not in house_text, (
+            "House Report note must not contain Amendments Pub. L. reference"
+        )
+        assert "Effective date and applicability" not in house_text, (
+            "House Report note must not contain Effective Date text"
+        )
+
+        # Amendments note must have its own content
+        amendments = next(n for n in notes.notes if n.header == "Amendments")
+        amend_text = " ".join(line.content for line in amendments.lines)
+        assert "Pub. L. 99–554" in amend_text, "Amendments note should contain Pub. L. ref"
+
+        # Effective Date note must have its own content
+        eff_date = next(
+            n for n in notes.notes if n.header == "Effective Date Of 1986 Amendment"
+        )
+        eff_text = " ".join(line.content for line in eff_date.lines)
+        assert "Effective date and applicability" in eff_text, (
+            "Effective Date note should contain its own text"
+        )
+
 
 class TestNoteTopicAmendmentParsing:
     """Regression tests for issue #216: <note topic="amendments"> not parsed.


### PR DESCRIPTION
## What

For 11 U.S.C. § 1163, the House Report No. 95–595 note was absorbing lines from subsequent Amendments and Effective Date notes. The parser was not detecting the note boundary correctly, causing later note content to bleed into the preceding note.

## Fix

In `_parse_historical_notes`, when iterating report headers (`matches`), `content_end` for the last report was set to `len(hist_text)`. When the section has no "Editorial Notes" / "Statutory Notes" wrapper, `hist_text` runs all the way to the end of the notes string — absorbing all sibling flat `[NH]`-delimited notes (Amendments, Effective Date, etc.) that follow.

The fix pre-computes the positions of all `[NH]` markers in `hist_text`, then for the last report sets `content_end` to the first `[NH]` position strictly after `content_start` (falling back to `len(hist_text)` only if none exists). This cleanly stops at the next sibling note's boundary without affecting non-last reports or sections that have no sibling flat notes.

A regression test covering the exact structure of 11 U.S.C. § 1163 was added to `TestFlatNotesParser` to prevent recurrence.

## Before / After

**Before** – `notes.notes[1]` (House Report No. 95–595):
```
[Section 1162] This section [enacted as section 1163] requires the appointment of an
independent trustee in a railroad reorganization case. The court may appoint one or more
disinterested persons to serve as trustee in the case.

1986— Pub. L. 99–554 amended section generally, ...

Effective date and applicability of amendment by Pub. L. 99–554 ...
```

**After** – `notes.notes[1]` (House Report No. 95–595):
```
[Section 1162] This section [enacted as section 1163] requires the appointment of an
independent trustee in a railroad reorganization case. The court may appoint one or more
disinterested persons to serve as trustee in the case.
```

Closes #498