### PR TITLE
chore: gitignore .claude/worktrees/ runtime directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ Thumbs.db
 
 # Downloaded data
 backend/data/
+
+# Claude Code runtime worktrees
+.claude/worktrees/


### PR DESCRIPTION
Adds `.claude/worktrees/` to `.gitignore` to suppress the runtime worktree directories created by the Claude Code agent isolation feature.

Supersedes #488 (same change, needed a clean branch).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qx4U7sSGyHPpxfa6RBeXh7)_