### PR TITLE
fix: attribute date to adding law in as-added source credits

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1563,86 +1563,91 @@ class USLMParser:
         if source_credit is None:
             return pl_refs, act_refs
 
-        # Find all ref elements within sourceCredit
-        ref_elems = source_credit.findall(".//{*}ref")
-        if not ref_elems:
-            ref_elems = source_credit.findall(".//ref")
+        # Process all significant elements within sourceCredit in document order.
+        # We traverse the element tree once, handling <ref> and <date> elements
+        # together so that each <date> is attributed to the most recently seen
+        # PL ref rather than the positionally-matching one.
+        #
+        # This correctly handles "as added" credits, e.g.:
+        #   (Pub. L. 87–195, ..., as added Pub. L. 104–132, ..., Apr. 24, 1996, ...)
+        # where the single <date> belongs to PL 104-132 (the adding law), not
+        # to PL 87-195 (the framework law that has no date in the credit).
+        #
+        # We use iter() to visit all descendants in document order, which gives
+        # the correct interleaving of <ref> and <date> elements.
 
-        # Track current stat volume/page for associating with refs
-        current_stat_volume: int | None = None
-        current_stat_page: int | None = None
-        # Track the most recent ref (either PL or Act) for stat association
+        # Track the most recent ref (either PL or Act) for stat/date association
         last_ref_type: str | None = None
 
-        for ref_elem in ref_elems:
-            href = ref_elem.get("href", "")
-            text = "".join(ref_elem.itertext()).strip()
+        for elem in source_credit.iter():
+            local_tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
 
-            # Parse /us/pl/CONGRESS/LAW/... hrefs (Public Laws, post-1957)
-            if "/us/pl/" in href:
-                match = re.match(
-                    r"/us/pl/(\d+)/(\d+)"  # Congress and law number
-                    r"(?:/d([A-Z]+))?"  # Optional division (can be multi-letter: LL, FF)
-                    r"(?:/t([IVXLCDM]+))?"  # Optional title
-                    r"(?:/s([\w()]+))?",  # Optional section
-                    href,
-                )
-                if match:
-                    ref = SourceCreditRef(
-                        congress=int(match.group(1)),
-                        law_number=int(match.group(2)),
-                        division=match.group(3),
-                        title=match.group(4),
-                        section=match.group(5),
-                        raw_text=text,
+            if local_tag == "ref":
+                href = elem.get("href", "")
+                text = "".join(elem.itertext()).strip()
+
+                # Parse /us/pl/CONGRESS/LAW/... hrefs (Public Laws, post-1957)
+                if "/us/pl/" in href:
+                    match = re.match(
+                        r"/us/pl/(\d+)/(\d+)"  # Congress and law number
+                        r"(?:/d([A-Z]+))?"  # Optional division (can be multi-letter: LL, FF)
+                        r"(?:/t([IVXLCDM]+))?"  # Optional title
+                        r"(?:/s([\w()]+))?",  # Optional section
+                        href,
                     )
-                    pl_refs.append(ref)
-                    last_ref_type = "pl"
+                    if match:
+                        ref = SourceCreditRef(
+                            congress=int(match.group(1)),
+                            law_number=int(match.group(2)),
+                            division=match.group(3),
+                            title=match.group(4),
+                            section=match.group(5),
+                            raw_text=text,
+                        )
+                        pl_refs.append(ref)
+                        last_ref_type = "pl"
 
-            # Parse /us/act/YYYY-MM-DD/chNNN/... hrefs (Acts, pre-1957)
-            elif "/us/act/" in href:
-                match = re.match(
-                    r"/us/act/(\d{4}-\d{2}-\d{2})/ch(\d+)"  # Date and chapter
-                    r"(?:/t([IVXLCDM]+))?"  # Optional title
-                    r"(?:/s([\w()]+))?",  # Optional section
-                    href,
-                )
-                if match:
-                    act_ref = ActRef(
-                        date=match.group(1),  # e.g., "1935-08-14"
-                        chapter=int(match.group(2)),
-                        title=match.group(3),
-                        section=match.group(4),
-                        raw_text=text,
+                # Parse /us/act/YYYY-MM-DD/chNNN/... hrefs (Acts, pre-1957)
+                elif "/us/act/" in href:
+                    match = re.match(
+                        r"/us/act/(\d{4}-\d{2}-\d{2})/ch(\d+)"  # Date and chapter
+                        r"(?:/t([IVXLCDM]+))?"  # Optional title
+                        r"(?:/s([\w()]+))?",  # Optional section
+                        href,
                     )
-                    act_refs.append(act_ref)
-                    last_ref_type = "act"
+                    if match:
+                        act_ref = ActRef(
+                            date=match.group(1),  # e.g., "1935-08-14"
+                            chapter=int(match.group(2)),
+                            title=match.group(3),
+                            section=match.group(4),
+                            raw_text=text,
+                        )
+                        act_refs.append(act_ref)
+                        last_ref_type = "act"
 
-            # Parse /us/stat/VOLUME/PAGE hrefs to capture Stat references
-            elif "/us/stat/" in href:
-                match = re.match(r"/us/stat/(\d+)/(\d+)", href)
-                if match:
-                    current_stat_volume = int(match.group(1))
-                    current_stat_page = int(match.group(2))
-                    # Apply to the most recent ref
-                    if last_ref_type == "pl" and pl_refs:
-                        pl_refs[-1].stat_volume = current_stat_volume
-                        pl_refs[-1].stat_page = current_stat_page
-                    elif last_ref_type == "act" and act_refs:
-                        act_refs[-1].stat_volume = current_stat_volume
-                        act_refs[-1].stat_page = current_stat_page
+                # Parse /us/stat/VOLUME/PAGE hrefs to capture Stat references
+                elif "/us/stat/" in href:
+                    match = re.match(r"/us/stat/(\d+)/(\d+)", href)
+                    if match:
+                        stat_volume = int(match.group(1))
+                        stat_page = int(match.group(2))
+                        # Apply to the most recent ref
+                        if last_ref_type == "pl" and pl_refs:
+                            pl_refs[-1].stat_volume = stat_volume
+                            pl_refs[-1].stat_page = stat_page
+                        elif last_ref_type == "act" and act_refs:
+                            act_refs[-1].stat_volume = stat_volume
+                            act_refs[-1].stat_page = stat_page
 
-        # Extract dates from <date> elements and associate with PL refs
-        # Act refs already have dates in the href, so all <date> elements belong to PL refs
-        date_elems = source_credit.findall(".//{*}date")
-        if not date_elems:
-            date_elems = source_credit.findall(".//date")
-
-        # Simple heuristic: dates appear after their associated PL ref, in order
-        for i, date_elem in enumerate(date_elems):
-            date_text = "".join(date_elem.itertext()).strip()
-            if i < len(pl_refs):
-                pl_refs[i].date = date_text
+            elif local_tag == "date":
+                # Act refs already have dates in the href; <date> elements belong to
+                # PL refs only. Attribute each date to the most recently seen PL ref
+                # so that "as added" credits assign the date to the adding law, not
+                # the framework law that precedes the "as added" clause.
+                date_text = "".join(elem.itertext()).strip()
+                if last_ref_type == "pl" and pl_refs:
+                    pl_refs[-1].date = date_text
 
         return pl_refs, act_refs
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -6,9 +6,7 @@ import pytest
 from lxml import etree
 
 from pipeline.olrc.parser import (
-    ActRef,
     NoteRef,
-    SourceCreditRef,
     USLMParser,
     _clean_bracket_heading,
     compute_text_hash,

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -6,7 +6,9 @@ import pytest
 from lxml import etree
 
 from pipeline.olrc.parser import (
+    ActRef,
     NoteRef,
+    SourceCreditRef,
     USLMParser,
     _clean_bracket_heading,
     compute_text_hash,
@@ -1112,3 +1114,108 @@ class TestNoteRefDataclass:
         assert ref.ref_type == "act"
         assert ref.act_date == "1935-08-14"
         assert ref.act_chapter == 531
+
+
+class TestExtractSourceCreditRefs:
+    """Tests for _extract_source_credit_refs — specifically the as-added date bug (Issue #480)."""
+
+    @pytest.fixture
+    def parser(self) -> USLMParser:
+        """Create a parser instance."""
+        return USLMParser()
+
+    def test_as_added_date_attributed_to_adding_law_not_framework(
+        self, parser: USLMParser, tmp_path: Path
+    ) -> None:
+        """Date after an 'as added' clause must go to the adding law, not the framework law.
+
+        Regression test for Issue #480:
+            (Pub. L. 87–195, pt. III, § 620G, as added Pub. L. 104–132,
+             title III, § 325, Apr. 24, 1996, 110 Stat. 1256.)
+
+        PL 87-195 has no date in this credit; the date belongs to PL 104-132.
+        """
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<usc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <meta><identifier>usc/22</identifier></meta>
+  <main>
+    <title identifier="/us/usc/t22" number="22">
+      <heading>FOREIGN RELATIONS AND INTERCOURSE</heading>
+      <chapter identifier="/us/usc/t22/ch32" number="32">
+        <heading>FOREIGN ASSISTANCE</heading>
+        <section identifier="/us/usc/t22/s2377" number="2377">
+          <heading>Prohibition on assistance to countries that aid terrorist states</heading>
+          <content><p>Test content.</p></content>
+          <sourceCredit>(<ref href="/us/pl/87/195/tIII/s620G">Pub. L. 87–195</ref>, pt. III, § 620G, as added <ref href="/us/pl/104/132/tIII/s325">Pub. L. 104–132</ref>, title III, § 325, <date>Apr. 24, 1996</date>, <ref href="/us/stat/110/1256">110 Stat. 1256</ref>.)</sourceCredit>
+        </section>
+      </chapter>
+    </title>
+  </main>
+</usc>
+"""
+        xml_path = tmp_path / "test_as_added.xml"
+        xml_path.write_text(xml_content)
+        result = parser.parse_file(xml_path)
+
+        assert len(result.sections) == 1
+        section = result.sections[0]
+
+        pl_refs = section.source_credit_refs
+        assert len(pl_refs) == 2, f"Expected 2 PL refs, got {len(pl_refs)}"
+
+        # PL 87-195 is the framework law — no date should be attributed to it
+        framework = pl_refs[0]
+        assert framework.congress == 87
+        assert framework.law_number == 195
+        assert framework.date is None, (
+            f"Framework law PL 87-195 should have date=None, got {framework.date!r}"
+        )
+
+        # PL 104-132 is the adding law — it gets the date "Apr. 24, 1996"
+        adding = pl_refs[1]
+        assert adding.congress == 104
+        assert adding.law_number == 132
+        assert adding.date == "Apr. 24, 1996", (
+            f"Adding law PL 104-132 should have date='Apr. 24, 1996', got {adding.date!r}"
+        )
+        assert adding.stat_volume == 110
+        assert adding.stat_page == 1256
+
+    def test_simple_single_law_date_attributed_correctly(
+        self, parser: USLMParser, tmp_path: Path
+    ) -> None:
+        """A single PL ref should still get its date when there is no 'as added' clause."""
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<usc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <meta><identifier>usc/17</identifier></meta>
+  <main>
+    <title identifier="/us/usc/t17" number="17">
+      <heading>COPYRIGHTS</heading>
+      <chapter identifier="/us/usc/t17/ch1" number="1">
+        <heading>SUBJECT MATTER</heading>
+        <section identifier="/us/usc/t17/s101" number="101">
+          <heading>Definitions</heading>
+          <content><p>Test content.</p></content>
+          <sourceCredit>(<ref href="/us/pl/94/553">Pub. L. 94–553</ref>, <date>Oct. 19, 1976</date>, <ref href="/us/stat/90/2541">90 Stat. 2541</ref>.)</sourceCredit>
+        </section>
+      </chapter>
+    </title>
+  </main>
+</usc>
+"""
+        xml_path = tmp_path / "test_simple_credit.xml"
+        xml_path.write_text(xml_content)
+        result = parser.parse_file(xml_path)
+
+        assert len(result.sections) == 1
+        section = result.sections[0]
+
+        pl_refs = section.source_credit_refs
+        assert len(pl_refs) == 1
+
+        ref = pl_refs[0]
+        assert ref.congress == 94
+        assert ref.law_number == 553
+        assert ref.date == "Oct. 19, 1976"
+        assert ref.stat_volume == 90
+        assert ref.stat_page == 2541


### PR DESCRIPTION
## What

When a source credit contains an "as added" clause — e.g. `(Pub. L. 87–195, pt. III, § 620G, as added Pub. L. 104–132, title III, § 325, Apr. 24, 1996, 110 Stat. 1256.)` — the citation parser was incorrectly attributing the adding law's date (Apr. 24, 1996) to the framework law (PL 87-195). The framework law had no date in the source credit; only the adding law did.

## Fix

The old implementation collected all `<ref>` elements first, then matched dates to refs positionally (`dates[i]` → `pl_refs[i]`). This broke for "as added" credits because a single `<date>` appears after the *second* law ref (the adding law), but the positional match assigned it to the *first* ref (the framework law).

The new implementation uses a single `source_credit.iter()` traversal that processes `<ref>` and `<date>` elements in document order. Each `<date>` is attributed to the **most recently seen PL ref** at the time of traversal. Since the `<date>` physically follows PL 104-132's `<ref>` in the XML, it is correctly assigned to PL 104-132. PL 87-195, which has no `<date>` after its `<ref>`, keeps `date=None`.

**Before (22 U.S.C. § 2377, PL 87-195):**
```json
{ "congress": 87, "law_number": 195, "date": "Apr. 24, 1996" }
```

**After:**
```json
{ "congress": 87, "law_number": 195, "date": null }
```

**PL 104-132 (adding law) — unchanged correct behaviour:**
```json
{ "congress": 104, "law_number": 132, "date": "Apr. 24, 1996" }
```

## Tests

Added `TestExtractSourceCreditRefs` in `backend/tests/pipeline/test_parser.py`:
- `test_as_added_date_attributed_to_adding_law_not_framework` — reproduces the exact bug from issue #480 and verifies the fix
- `test_simple_single_law_date_attributed_correctly` — regression guard that a single-PL credit without "as added" still works

Closes #480