### PR TITLE
fix: keep subsection prefix with its own paragraph in amendments split

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -365,13 +365,14 @@ _REPORT_PATTERN = re.compile(
 )
 _YEAR_PATTERN = re.compile(r"(\d{4})\s*[—–-]\s*", re.MULTILINE)
 _PUB_L_PATTERN = re.compile(
-    r"((?:Subsec\.?\s*"  # "Subsec." or "Subsec"
+    r"((?:Subsecs?\.?\s*"  # "Subsec." / "Subsec" or plural "Subsecs." / "Subsecs"
     r"(?:\([^)]+\))+"  # One or more parenthesized markers like (c)(1)
-    r"(?:\s*,\s*(?:\([^)]+\))+)*"  # Optional comma-separated markers like , (2)(A)
+    r"(?:\s+to\s+(?:\([^)]+\))+)?"  # Optional range suffix like " to (13)"
+    r"(?:\s*,\s*(?:\([^)]+\))+(?:\s+to\s+(?:\([^)]+\))+)?)*"  # Optional comma-separated markers, each optionally with a range
     r"\.?\s*)?)"  # Optional trailing period and whitespace
     r"(Pub\.\s*L\.\s*(\d+)[—–-](\d+))"  # Pub. L. reference
     r"(.*?)"  # Description (including any text after)
-    r"(?=Subsec\.?\s*(?:\([^)]+\))+|Pub\.\s*L\.\s*\d+[—–-]\d+|$)",  # Until next Subsec. or Pub. L. or end
+    r"(?=Subsecs?\.?\s*(?:\([^)]+\))+|Pub\.\s*L\.\s*\d+[—–-]\d+|$)",  # Until next Subsec(s). or Pub. L. or end
     re.DOTALL,
 )
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2274,7 +2274,7 @@ class TestAmendmentSubsectionPrefix:
         from pipeline.olrc.normalized_section import _parse_amendments
 
         text = (
-            '1998—Subsec. (b)(1). Pub. L. 105–244, § 301(c)(1), '
+            "1998—Subsec. (b)(1). Pub. L. 105–244, § 301(c)(1), "
             'substituted "section 1068h(a)(1)" for "section 1069f(a)(1)".\n'
             "Subsecs. (c), (d). Pub. L. 105–244, § 303(a), added subsecs. (c) and (d).\n"
         )

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2265,6 +2265,45 @@ class TestAmendmentSubsectionPrefix:
         assert amendments[0].description.startswith("Pub. L. 112–239")
         assert "Subsec." not in amendments[0].description
 
+    def test_plural_subsecs_prefix_stays_with_its_paragraph(self) -> None:
+        """Regression test for 20 USC § 1057 Case A (issue #473).
+
+        The plural prefix 'Subsecs. (c), (d).' must stay with the paragraph
+        it introduces, not be appended to the preceding entry's description.
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            '1998—Subsec. (b)(1). Pub. L. 105–244, § 301(c)(1), '
+            'substituted "section 1068h(a)(1)" for "section 1069f(a)(1)".\n'
+            "Subsecs. (c), (d). Pub. L. 105–244, § 303(a), added subsecs. (c) and (d).\n"
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 2
+        # First entry: only Subsec. (b)(1) prefix, no trailing Subsecs. (c), (d).
+        assert amendments[0].description.startswith("Subsec. (b)(1).")
+        assert "Subsecs. (c), (d)." not in amendments[0].description
+        # Second entry: must start with the Subsecs. (c), (d). prefix
+        assert amendments[1].description.startswith("Subsecs. (c), (d).")
+
+    def test_range_style_subsec_prefix_preserved(self) -> None:
+        """Regression test for 20 USC § 1057 Case B (issue #473).
+
+        A range-style prefix like 'Subsec. (c)(7) to (13).' must be included
+        in the description of the paragraph it introduces.
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "2008—Subsec. (c)(7) to (13). Pub. L. 110–315, "
+            "§ 301(2)(B)–(E), added par. (7), redesignated former pars.\n"
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].description.startswith("Subsec. (c)(7) to (13).")
+
 
 class TestAmendmentDateSpacing:
     """Tests for fixing whitespace inside quotes in amendments."""


### PR DESCRIPTION
## What

The amendments structured array parser (`_PUB_L_PATTERN` in `pipeline/olrc/normalized_section.py`) split paragraphs on subsection-reference patterns but had two defects:

1. **Case A (plural prefix misplaced):** The prefix pattern only matched `Subsec.` (singular). When a paragraph started with `Subsecs. (c), (d).`, the lookahead boundary also didn't recognize it as a stopping point. The `(.*?)` group from the *preceding* match greedily consumed `Subsecs. (c), (d).`, appending it to the wrong entry's description and leaving the new paragraph without its prefix.

2. **Case B (range prefix dropped):** The prefix pattern matched `Subsec. (c)(7)` but stopped there because ` to (13)` wasn't a comma-separated parenthetical. The overall regex then couldn't anchor to `Pub. L.` after ` to (13).`, so the optional-prefix group backtracked to an empty match and the entire prefix was silently discarded.

## Fix

Two changes to `_PUB_L_PATTERN`:

- Changed `Subsec\.?` → `Subsecs?\.?` in both the capture group and the lookahead so that plural `Subsecs.` is recognised as a prefix and as a paragraph boundary.
- Added `(?:\s+to\s+(?:\([^)]+\))+)?` after each parenthetical group to capture range-style suffixes like `(c)(7) to (13)`.

**Before:**
```python
r"((?:Subsec\.?\s*"
r"(?:\([^)]+\))+"
r"(?:\s*,\s*(?:\([^)]+\))+)*"
r"\.?\s*)?)"
...
r"(?=Subsec\.?\s*(?:\([^)]+\))+|Pub\.\s*L\.\s*\d+[—–-]\d+|$)"
```

**After:**
```python
r"((?:Subsecs?\.?\s*"
r"(?:\([^)]+\))+"
r"(?:\s+to\s+(?:\([^)]+\))+)?"
r"(?:\s*,\s*(?:\([^)]+\))+(?:\s+to\s+(?:\([^)]+\))+)?)*"
r"\.?\s*)?)"
...
r"(?=Subsecs?\.?\s*(?:\([^)]+\))+|Pub\.\s*L\.\s*\d+[—–-]\d+|$)"
```

## Parsing proof

**Case A — 1998 amendments (20 USC § 1057)**

Before fix:
```
entry 1: "Subsec. (b)(1). Pub. L. 105–244, § 301(c)(1), substituted … Subsecs. (c), (d)."
entry 2: "Pub. L. 105–244, § 303(a), added subsecs. (c) and (d)."
```

After fix:
```
entry 1: "Subsec. (b)(1). Pub. L. 105–244, § 301(c)(1), substituted …"
entry 2: "Subsecs. (c), (d). Pub. L. 105–244, § 303(a), added subsecs. (c) and (d)."
```

**Case B — 2008 amendments (20 USC § 1057)**

Before fix:
```
entry: "Pub. L. 110–315, § 301(2)(B)–(E), added par. (7), …"
```

After fix:
```
entry: "Subsec. (c)(7) to (13). Pub. L. 110–315, § 301(2)(B)–(E), added par. (7), …"
```

Closes #473