### PR TITLE
fix: capture title/section sub-path after chapter in source credit citations

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -2091,27 +2091,53 @@ class USLMParser:
                         href,
                     )
                     if match:
+                        href_title = match.group(3)
                         href_section = match.group(4)
-                        # Reconstruct subsection specifiers encoded as extra href path
-                        # segments, mirroring the PL href handling above.
-                        href_subsection_tail = match.group(5)
-                        if href_section and href_subsection_tail:
-                            sub_parts = [
-                                p for p in href_subsection_tail.split("/") if p
-                            ]
-                            href_section = href_section + "".join(
-                                f"({p})" for p in sub_parts
+                        # If href lacks both title and section, parse them from the
+                        # tail text. OLRC XML sometimes encodes only the chapter in
+                        # the href and writes the sub-path (e.g. ", title I, § 1,")
+                        # as tail text after the closing </ref> tag.
+                        tail_title: str | None = href_title
+                        act_section_value: str | None
+                        if href_title is None and href_section is None:
+                            tail_section: str | None = href_section
+                            tail = (elem.tail or "").strip()
+                            if tail:
+                                title_match = re.match(
+                                    r",?\s*title\s+([IVXLCDM]+)",
+                                    tail,
+                                    re.IGNORECASE,
+                                )
+                                if title_match:
+                                    tail_title = title_match.group(1).upper()
+                                sec_match = re.search(
+                                    r"§\s*([\w()]+)",
+                                    tail,
+                                )
+                                if sec_match:
+                                    tail_section = sec_match.group(1)
+                            act_section_value = tail_section
+                        else:
+                            # Reconstruct subsection specifiers encoded as extra href
+                            # path segments, mirroring the PL href handling above.
+                            href_subsection_tail = match.group(5)
+                            if href_section and href_subsection_tail:
+                                sub_parts = [
+                                    p for p in href_subsection_tail.split("/") if p
+                                ]
+                                href_section = href_section + "".join(
+                                    f"({p})" for p in sub_parts
+                                )
+                            act_section_value = (
+                                href_section + bridge + subdivision_suffix
+                                if subdivision_suffix and href_section
+                                else href_section
                             )
-                        section_value = (
-                            href_section + bridge + subdivision_suffix
-                            if subdivision_suffix and href_section
-                            else href_section
-                        )
                         act_ref = ActRef(
                             date=match.group(1),  # e.g., "1935-08-14"
                             chapter=int(match.group(2)),
-                            title=match.group(3),
-                            section=section_value,
+                            title=tail_title,
+                            section=act_section_value,
                             raw_text=full_text,
                         )
                         act_refs.append(act_ref)

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -1943,3 +1943,111 @@ class TestExtractSourceCreditRefs:
         assert ref.date == "Oct. 19, 1976"
         assert ref.stat_volume == 90
         assert ref.stat_page == 2541
+
+
+class TestExtractSourceCreditActRefs:
+    """Tests for _extract_source_credit_refs with pre-1957 Act citations.
+
+    Covers issue #467: sub-path levels (title, section) after the chapter
+    number must be captured even when they live outside the <ref> element.
+    """
+
+    @pytest.fixture
+    def parser(self) -> USLMParser:
+        """Create a parser instance."""
+        return USLMParser()
+
+    def _make_xml(self, source_credit_inner: str, tmp_path: Path) -> Path:
+        """Wrap source credit text in a minimal USLM document."""
+        xml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<usc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <meta><identifier>usc/2</identifier></meta>
+  <main>
+    <title identifier="/us/usc/t2" number="2">
+      <heading>THE CONGRESS</heading>
+      <chapter identifier="/us/usc/t2/ch1" number="1">
+        <heading>ELECTION OF SENATORS AND REPRESENTATIVES</heading>
+        <section identifier="/us/usc/t2/s33" number="33">
+          <heading>Senators' salaries</heading>
+          <content><p>Each Senator shall receive...</p></content>
+          <sourceCredit>({source_credit_inner})</sourceCredit>
+        </section>
+      </chapter>
+    </title>
+  </main>
+</usc>
+"""
+        xml_path = tmp_path / "test_act_source_credit.xml"
+        xml_path.write_text(xml_content)
+        return xml_path
+
+    def test_act_ref_chapter_only_href_captures_tail_title_and_section(
+        self, parser: USLMParser, tmp_path: Path
+    ) -> None:
+        """Act ref where href only has chapter; title and section are in tail text.
+
+        Reproduces 2 U.S.C. § 33 (RP 113-21):
+          June 19, 1934, ch. 648, title I, § 1, 48 Stat. 1022
+        The <ref> wraps only the date+chapter; title/section follow as tail.
+        """
+        # Simulate the OLRC XML structure: <ref> covers date+chapter only;
+        # ", title I, § 1," is tail text between the act ref and stat ref.
+        source_credit = (
+            '<ref href="/us/act/1934-06-19/ch648">June 19, 1934, ch. 648</ref>'
+            ", title I, § 1, "
+            '<ref href="/us/stat/48/1022">48 Stat. 1022</ref>'
+        )
+        xml_path = self._make_xml(source_credit, tmp_path)
+        result = parser.parse_file(xml_path)
+
+        assert len(result.sections) == 1
+        section = result.sections[0]
+
+        assert len(section.act_refs) == 1
+        act_ref = section.act_refs[0]
+
+        assert act_ref.chapter == 648
+        assert act_ref.title == "I", "title sub-path must be captured from tail text"
+        assert act_ref.section == "1", (
+            "section sub-path must be captured from tail text"
+        )
+        assert act_ref.stat_volume == 48
+        assert act_ref.stat_page == 1022
+
+    def test_act_ref_href_with_title_and_section_unchanged(
+        self, parser: USLMParser, tmp_path: Path
+    ) -> None:
+        """When href already encodes title and section, those values are used."""
+        source_credit = (
+            '<ref href="/us/act/1935-08-14/ch531/tI/s3">Aug. 14, 1935, ch. 531</ref>'
+            ', <ref href="/us/stat/49/620">49 Stat. 620</ref>'
+        )
+        xml_path = self._make_xml(source_credit, tmp_path)
+        result = parser.parse_file(xml_path)
+
+        section = result.sections[0]
+        assert len(section.act_refs) == 1
+        act_ref = section.act_refs[0]
+
+        assert act_ref.chapter == 531
+        assert act_ref.title == "I"
+        assert act_ref.section == "3"
+
+    def test_act_ref_chapter_only_no_sub_path(
+        self, parser: USLMParser, tmp_path: Path
+    ) -> None:
+        """Act ref with no title/section in href or tail leaves them as None."""
+        source_credit = (
+            '<ref href="/us/act/1935-08-14/ch531">Aug. 14, 1935, ch. 531</ref>'
+            ', <ref href="/us/stat/49/620">49 Stat. 620</ref>'
+        )
+        xml_path = self._make_xml(source_credit, tmp_path)
+        result = parser.parse_file(xml_path)
+
+        section = result.sections[0]
+        assert len(section.act_refs) == 1
+        act_ref = section.act_refs[0]
+
+        assert act_ref.chapter == 531
+        assert act_ref.title is None
+        assert act_ref.section is None


### PR DESCRIPTION
## What

Source credit citations with chapter acts (e.g. `June 19, 1934, ch. 648, title I, § 1, 48 Stat. 1022`) were only capturing the chapter number in the `path` array, silently dropping the `title I, § 1` sub-path.

## Root cause

The OLRC XML structure for pre-1957 Act citations puts only the date+chapter number inside the `<ref href="/us/act/1934-06-19/ch648">` element. The sub-path components (`title I, § 1`) appear as **tail text** after the closing `</ref>` tag — they are not part of the element's href or text content.

The parser only called `ref_elem.itertext()` (inner text) and extracted title/section from the href path, which was bare (`/ch648` with no `/t.../s...` segments). The tail text was never examined.

## Fix

In `_extract_source_credit_refs` (`pipeline/olrc/parser.py`): when an act `<ref>` href contains no title or section path segments, the code now reads `ref_elem.tail` and applies two small regexes:

- `,?\s*title\s+([IVXLCDM]+)` → `ActRef.title`
- `§\s*([\w()]+)` → `ActRef.section`

This populates the same fields that `citations_from_source_credit_refs` and `_build_law_path` already use to build the `path` array.

## Before / after (representative example: 2 U.S.C. § 33, RP 113-21)

**Before:**
```json
"path": [{"level": "chapter", "value": "648"}],
"path_display": "ch. 648"
```

**After:**
```json
"path": [
  {"level": "chapter", "value": "648"},
  {"level": "title", "value": "I"},
  {"level": "section", "value": "1"}
],
"path_display": "ch. 648, tit. I, §1"
```

## Tests added

`TestExtractSourceCreditActRefs` in `tests/pipeline/test_parser.py` (3 cases):

1. **`test_act_ref_chapter_only_href_captures_tail_title_and_section`** — exact structure from the bug report (`ch648` href with `, title I, § 1,` tail text); verifies title=`"I"`, section=`"1"`, stat=48/1022.
2. **`test_act_ref_href_with_title_and_section_unchanged`** — href already encodes `/tI/s3`; verifies those values come through unchanged.
3. **`test_act_ref_chapter_only_no_sub_path`** — bare chapter href with no tail sub-path; verifies title/section remain `None`.

Closes #467