### PR TITLE
docs: record clean spot-check for 6 USC 231 (PL 113-21)

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -6,10 +6,11 @@ parsed representation against the authoritative OLRC source XML.
 Each row represents one tested section. "Clean" means no discrepancies were found between
 CWLB and the OLRC XML at the stated release point.
 
-| Date       | Title | Section | Heading                                          | Release Point | Status |
-|------------|-------|---------|--------------------------------------------------|---------------|--------|
-| 2026.05.24 | 17    | 204     | Execution of transfers of copyright ownership    | 113-21        | ✅ Clean |
-| 2026.06.20 | 28    | 2514    | Forfeiture of fraudulent claims                  | 113-21        | ✅ Clean (known issue applies — see notes) |
+| Date       | Title | Section | Heading                                                                                | Release Point | Status |
+|------------|-------|---------|----------------------------------------------------------------------------------------|---------------|--------|
+| 2026.05.24 | 17    | 204     | Execution of transfers of copyright ownership                                          | 113-21        | ✅ Clean |
+| 2026.06.11 | 6     | 231     | Transfer of certain agricultural inspection functions of the Department of Agriculture | 113-21        | ✅ Clean |
+| 2026.06.20 | 28    | 2514    | Forfeiture of fraudulent claims                                                        | 113-21        | ✅ Clean (known issue applies — see notes) |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Daily automated spot-check compared CWLB's parsed representation of 6 U.S.C. § 231 (Title 6, Domestic Security) against the OLRC XML bulk download for release point PL 113-21 (effective 2013-01-01).
- No discrepancies found in heading, body text (subsections (a)-(g)), citations, "References In Text" note, "Codification" note, group ancestors (ch. 1, subch. IV, part C), or enactment metadata.
- Adds `docs/test-status.md` to record the result.

## Test plan
- [x] Compared `GET /api/v1/sections/6/231` output against `usc06@113-21.xml` from https://uscode.house.gov/download/download.shtml


---
_Generated by [Claude Code](https://claude.ai/code/session_01CaiSeokbTZfEf7byRrsG8D)_