### PR TITLE
docs: record clean test status for 29 USC 521 (113-21)

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,0 +1,20 @@
+# Test Status
+
+This file records the results of the daily automated spot-check that compares
+CWLB's ingested representation of a randomly selected US Code section against
+the authoritative OLRC source (XML bulk download) for the same release point.
+
+Entries are appended in reverse chronological order. Only "clean" results
+(no discrepancies found) are recorded here — discrepancies are filed as GitHub
+issues with the `bug` label instead.
+
+## 2026.06.12
+
+- **Section**: 29 U.S.C. § 521 (Investigations by Secretary; applicability of other laws)
+- **Release point**: 113-21 (effective 2013-01-01)
+- **Result**: Clean. Heading, provision text, source credit/citation
+  (Pub. L. 86-257, 73 Stat. 539), and "References in Text" editorial note all
+  match the OLRC XML (`xml_usc29@113-21.zip`) exactly. The split of subsection
+  (a) into two provision lines (one per sentence, with the second indented at
+  level 1) matches the project's documented sentence-splitting convention in
+  `backend/pipeline/DISPLAY_CONVENTIONS.md`.


### PR DESCRIPTION
## Summary

Daily automated spot-check: compared CWLB's ingested representation of **29 U.S.C. § 521** ("Investigations by Secretary; applicability of other laws") against the authoritative OLRC XML for release point **113-21** (effective 2013-01-01).

## Findings

No discrepancies found. The heading, provision text, source credit/citation (Pub. L. 86-257, 73 Stat. 539), and "References in Text" editorial note all match the OLRC bulk XML (`xml_usc29@113-21.zip`) exactly.

The split of subsection (a) into two provision lines (one per sentence, with the second sentence indented at level 1) matches the project's documented sentence-splitting convention in `backend/pipeline/DISPLAY_CONVENTIONS.md` and corresponding tests in `backend/tests/pipeline/test_normalized_section.py`.

## Test plan

- [x] Fetched CWLB's parsed section via `GET /api/v1/sections/29/521`
- [x] Downloaded and compared against `https://uscode.house.gov/download/releasepoints/us/pl/113/21/xml_usc29@113-21.zip`
- [x] Verified text content, citations, and notes match


---
_Generated by [Claude Code](https://claude.ai/code/session_01168we6JbkY5SMwTGTwoArN)_