### PR TITLE
fix: don't truncate law text containing the word "regulations" as a notes header

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1682,8 +1682,15 @@ def _separate_notes_from_text(text: str) -> tuple[str, SectionNotes]:
     # Find the earliest notes section header
     earliest_notes_pos = len(text)
     for header in NOTES_SECTION_HEADERS:
-        # Look for the header, possibly with leading whitespace/newlines
-        pattern = re.compile(rf"[\s\n]+{re.escape(header)}", re.IGNORECASE)
+        # Look for the header at the start of a line (possibly with leading
+        # whitespace), since real notes headers always begin their own line.
+        # Requiring a line start avoids false positives when a header word
+        # (e.g. "Regulations") appears mid-sentence in ordinary law text,
+        # such as "...in accordance with the rules and regulations
+        # prescribed by..." in 24 U.S.C. § 17.
+        pattern = re.compile(
+            rf"(?:^|\n)[ \t]*{re.escape(header)}", re.IGNORECASE | re.MULTILINE
+        )
         match = pattern.search(text)
         if match and match.start() < earliest_notes_pos:
             earliest_notes_pos = match.start()

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -285,6 +285,48 @@ class TestNormalizeSectionRealExamples:
         full_text = " ".join(line.content for line in result.provisions)
         assert "U.S.C." in full_text
 
+    def test_naval_asylum_regulations_not_treated_as_notes_header_issue_522(
+        self,
+    ) -> None:
+        """Regression test for 24 U.S.C. § 17 (issue #522).
+
+        The word "regulations" appearing mid-sentence must not be mistaken
+        for the "Regulations" notes-section header, which would truncate the
+        law text right before it.
+        """
+        text = (
+            "The asylum for disabled and decrepit Navy officers, seamen, "
+            "and marines shall be governed in accordance with the rules "
+            "and regulations prescribed by the Secretary of the Navy."
+        )
+
+        result = normalize_section(text)
+
+        full_text = " ".join(line.content for line in result.provisions)
+        assert full_text == text
+        assert "regulations prescribed by the Secretary of the Navy" in full_text
+
+    def test_army_navy_hospital_regulations_not_truncated_issue_522(self) -> None:
+        """Regression test for 24 U.S.C. § 18 (issue #522).
+
+        Same pattern as § 17: "regulations" appears mid-sentence (after
+        "such rules,") and must not be treated as a notes header.
+        """
+        text = (
+            "The Army and Navy General Hospital at Hot Springs, Arkansas, "
+            "shall be subject to such rules, regulations, and restrictions "
+            "as shall be provided by the President of the United States "
+            "and shall remain under the jurisdiction and control of the "
+            "Department of the Army."
+        )
+
+        result = normalize_section(text)
+
+        full_text = " ".join(line.content for line in result.provisions)
+        assert full_text == text
+        assert "regulations, and restrictions" in full_text
+        assert "Department of the Army" in full_text
+
 
 class TestCharacterToLineMapping:
     """Tests for character position to line number mapping."""


### PR DESCRIPTION
## Root cause

`_separate_notes_from_text()` in `backend/pipeline/olrc/normalized_section.py` splits a section's text into "law text" and "notes" by searching for known notes-section headers (e.g. `Codification`, `Regulations`, `Editorial Notes`). The search pattern was:

```python
pattern = re.compile(rf"[\s\n]+{re.escape(header)}", re.IGNORECASE)
```

This matches the header text anywhere it's preceded by whitespace, case-insensitively — including the ordinary lowercase word "regulations" appearing mid-sentence in normal law text. For 24 U.S.C. SS 17 and 18, the phrase "...rules and regulations prescribed by..." / "...such rules, regulations, and restrictions..." was misdetected as the start of a "Regulations" notes section, so everything from "regulations" onward was discarded from `text_content`.

## Fix

Require the header to start a line (optionally indented), since real notes-section headers always begin their own line in both XML-derived text and plain-text fallback inputs:

```python
pattern = re.compile(
    rf"(?:^|\n)[ \t]*{re.escape(header)}", re.IGNORECASE | re.MULTILINE
)
```

This still matches legitimate headers like `\n        Editorial Notes` (covered by existing tests) while no longer matching "regulations" mid-sentence.

## Before / after - 24 U.S.C. SS 17

Before (122 chars, truncated):
```
The asylum for disabled and decrepit Navy officers, seamen, and marines shall be governed in accordance with the rules and
```

After (175 chars, matches OLRC):
```
The asylum for disabled and decrepit Navy officers, seamen, and marines shall be governed in accordance with the rules and regulations prescribed by the Secretary of the Navy.
```

## Before / after - 24 U.S.C. SS 18

Before (92 chars, truncated):
```
The Army and Navy General Hospital at Hot Springs, Arkansas, shall be subject to such rules,
```

After (264 chars, matches OLRC):
```
The Army and Navy General Hospital at Hot Springs, Arkansas, shall be subject to such rules, regulations, and restrictions as shall be provided by the President of the United States and shall remain under the jurisdiction and control of the Department of the Army.
```

## Testing

Added two regression tests in `backend/tests/pipeline/test_normalized_section.py` covering both SS 17 and SS 18's exact text patterns. Full suite passes: `uv run mypy app --ignore-missing-imports && uv run pytest` (799 passed, 21 skipped).

Note: this PR fixes the parser/normalization code. The already-ingested database rows for SS 17 and SS 18 will need re-ingestion (out of scope for this PR) to pick up the corrected text.

Closes #522