### PR TITLE
chore: record clean test status for 25 USC 349 (113-21)

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,0 +1,9 @@
+# Test Status
+
+This file tracks daily spot-checks comparing CWLB's ingested data against the
+authoritative OLRC source. Each entry records a section that was tested and
+confirmed clean (no parsing or fidelity discrepancies found).
+
+| Date | Title | Section | Release Point | Notes |
+| --- | --- | --- | --- | --- |
+| 2026.06.15 | 25 (Indians) | § 349 | 113-21 (effective 2013-01-01) | Heading, text, source credit citations, and editorial notes (References in Text, Codification) match OLRC XML exactly. |


### PR DESCRIPTION
## Summary
- Daily spot-check comparing CWLB's ingested data against the authoritative OLRC source for a randomly selected section.
- Selected: Title 25 (Indians), § 349 "Patents in fee to allottees", release point 113-21 (effective 2013-01-01).
- Compared heading, full text content, source credit citations, enacted date, positive-law/repeal status, and editorial notes (References in Text, Codification) against the OLRC bulk XML (`usc25@113-21.xml`).
- No discrepancies found — adds a `docs/test-status.md` entry recording the clean result.

## Test plan
- [x] Fetched `/api/v1/sections/25/349` from CWLB backend and compared against `https://uscode.house.gov/download/releasepoints/us/pl/113/21/xml_usc25@113-21.xml`
- [x] Verified text content matches exactly (modulo `<i>` italics tags for "Provided"/"Provided further"/"And provided further")
- [x] Verified both editorial notes (References in Text, Codification) match
- [x] Verified source credit citations (Act of Feb. 8, 1887, ch. 119, 24 Stat. 390; Act of May 8, 1906, ch. 2348, 34 Stat. 182) match


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUnrPKQSb9fFMgSEE7QLLM)_