### PR TITLE
chore: ignore .claude/worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ Thumbs.db
 
 # Downloaded data
 backend/data/
+
+# Claude Code agent worktrees (ephemeral, managed by Claude Code)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore`

Claude Code creates temporary git worktrees under `.claude/worktrees/` when running isolated sub-agents. These directories are ephemeral and managed by the Claude Code harness — they should never be tracked in version control.

https://claude.ai/code/session_013PjpRH2GhBy8tBshNWUtjn

---
_Generated by [Claude Code](https://claude.ai/code/session_013PjpRH2GhBy8tBshNWUtjn)_