### PR TITLE
fix: don't split notes on inline cross-references to header strings

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1661,6 +1661,34 @@ def _strip_note_markers(text: str) -> str:
     return text.strip()
 
 
+def _find_wrapper_heading(pattern: str, raw_notes: str) -> re.Match[str] | None:
+    """Find a top-level wrapper heading match, rejecting inline cross-references.
+
+    Wrapper headings like "Historical and Revision Notes", "Editorial Notes",
+    and "Statutory Notes and Related Subsidiaries" mark the start of a whole
+    category of notes within raw_notes. But the same phrases can also appear
+    as inline cross-references buried inside a note's body prose — e.g. "See
+    Historical and Revision Notes and 2006 Amendment note under section 303
+    of Title 40." A naive unanchored search matches that prose too, splitting
+    one note into a real note plus a fabricated one from the trailing
+    fragment (issue #529).
+
+    A real wrapper heading only ever begins raw_notes, or follows immediately
+    after [NH]/[H1] marker spans with nothing but whitespace in between —
+    never mid-sentence prose. We scan all candidate matches and accept the
+    first one whose preceding text, once marker spans are stripped, is
+    empty/whitespace-only.
+    """
+    for match in re.finditer(pattern, raw_notes, re.DOTALL | re.IGNORECASE):
+        prefix = raw_notes[: match.start()]
+        prefix = re.sub(r"\[NH\].*?\[/NH\]", "", prefix, flags=re.DOTALL)
+        prefix = re.sub(r"\[H1\].*?\[/H1\]", "", prefix, flags=re.DOTALL)
+        prefix = re.sub(r"\[/?NH\]|\[/?H1\]", "", prefix)
+        if not prefix.strip():
+            return match
+    return None
+
+
 def _parse_historical_notes(raw_notes: str, notes: SectionNotes) -> None:
     """Parse Historical and Revision Notes section."""
     # Match until next major section (with optional [H1] prefix) or the
@@ -1669,10 +1697,12 @@ def _parse_historical_notes(raw_notes: str, notes: SectionNotes) -> None:
     # wrapper in the OLRC XML.  Without the [NH] lookahead the regex
     # greedily consumed sibling note content (e.g. "References in Text")
     # into the Historical note — Issue #504.
-    hist_match = re.search(
+    # Use _find_wrapper_heading so an inline cross-reference like "See
+    # Historical and Revision Notes ..." inside another note's body isn't
+    # mistaken for the start of this section (issue #529).
+    hist_match = _find_wrapper_heading(
         r"Historical and Revision Notes\s*(.*?)(?=\[H1\]Editorial Notes|\[H1\]Statutory Notes|Editorial Notes|Statutory Notes|\[NH\]|$)",
         raw_notes,
-        re.DOTALL | re.IGNORECASE,
     )
     if not hist_match:
         return
@@ -1747,11 +1777,12 @@ def _parse_historical_notes(raw_notes: str, notes: SectionNotes) -> None:
 
 def _parse_editorial_notes(raw_notes: str, notes: SectionNotes) -> None:
     """Parse Editorial Notes section."""
-    # Match "Editorial Notes" and capture until "Statutory Notes" (with optional [H1] prefix)
-    edit_match = re.search(
+    # Match "Editorial Notes" and capture until "Statutory Notes" (with optional
+    # [H1] prefix). Use _find_wrapper_heading to reject inline cross-references
+    # to "Editorial Notes" buried in other notes' body prose (issue #529).
+    edit_match = _find_wrapper_heading(
         r"Editorial Notes\s*(.*?)(?=\[H1\]Statutory Notes|\[NH\]Statutory Notes|Statutory Notes|$)",
         raw_notes,
-        re.DOTALL | re.IGNORECASE,
     )
     if not edit_match:
         return
@@ -1807,10 +1838,12 @@ def _parse_editorial_notes(raw_notes: str, notes: SectionNotes) -> None:
 
 def _parse_statutory_notes(raw_notes: str, notes: SectionNotes) -> None:
     """Parse Statutory Notes section."""
-    stat_match = re.search(
+    # Use _find_wrapper_heading to reject inline cross-references to
+    # "Statutory Notes and Related Subsidiaries" buried in other notes' body
+    # prose (issue #529).
+    stat_match = _find_wrapper_heading(
         r"Statutory Notes and Related Subsidiaries\s*(.*)",
         raw_notes,
-        re.DOTALL | re.IGNORECASE,
     )
     if not stat_match:
         return

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3302,6 +3302,65 @@ class TestFlatNotesParser:
         )
         assert agreement_note.lines == []
 
+    def test_inline_cross_reference_to_historical_notes_not_split_issue_529(
+        self,
+    ) -> None:
+        """Regression: an inline "See Historical and Revision Notes ..."
+        cross-reference inside a note's body must not be split into a second,
+        fabricated note.
+
+        16 U.S.C. § 16 has a single flat 'transferOfFunctions' note whose body
+        ends with "See Historical and Revision Notes and 2006 Amendment note
+        under section 303 of Title 40." Prior to the fix, _parse_historical_notes
+        did an unanchored search for "Historical and Revision Notes" and matched
+        this inline prose, fabricating a bogus second note ("Historical and
+        Revision Notes") containing only the truncated tail fragment, while also
+        mis-categorising the real note via the historical-notes code path.
+        Closes #529.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        raw_notes = (
+            "[NH]Transfer Of Functions[/NH] "
+            "Functions of procurement of supplies, services, stores, etc., "
+            "exercised by any other agency transferred to Procurement Division "
+            "in Department of the Treasury by Ex. Ord. No. 6166, "
+            "Section 1, June 10, 1933, set out as a note under section 901 of "
+            "Title 5, Government Organization and Employees. Bureau transferred "
+            "on July 1, 1949, to General Services Administration. Section 303(a) "
+            "of Title 40 was amended generally by Pub. L. 109-313, "
+            "Section 2(a)(1), Oct. 6, 2006, 120 Stat. 1734. "
+            "See Historical and Revision Notes and 2006 Amendment note under "
+            "section 303 of Title 40."
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        # Exactly one note must be produced — no fabricated split.
+        assert len(notes.notes) == 1
+
+        note = notes.notes[0]
+        assert note.header.lower() == "transfer of functions"
+
+        # The note must not be mis-categorised as historical.
+        assert note.category.value != "historical"
+
+        # The full body, including the trailing cross-reference sentence,
+        # must be present in the single note (nothing truncated away).
+        full_text = " ".join(line.content for line in note.lines)
+        assert "Functions of procurement of supplies" in full_text
+        assert (
+            "See Historical and Revision Notes and 2006 Amendment note "
+            "under section 303 of Title 40." in full_text
+        )
+
+        # No fabricated "Historical and Revision Notes" note should exist.
+        headers = [n.header.lower() for n in notes.notes]
+        assert "historical and revision notes" not in headers
+
 
 class TestNoteTopicAmendmentParsing:
     """Regression tests for issue #216: <note topic="amendments"> not parsed.


### PR DESCRIPTION
## Context

For 16 U.S.C. § 16, the OLRC source XML has exactly one `<note topic="transferOfFunctions">` element, but CWLB's parser split it into two notes in the API response. The bug: `_parse_historical_notes`, `_parse_editorial_notes`, and `_parse_statutory_notes` each locate their wrapper heading (e.g. "Historical and Revision Notes") with an **unanchored** `re.search` over the full notes text. This matches the same phrase wherever it appears — including as an inline cross-reference embedded in another note's body prose, e.g.:

> "... no longer relates to the Bureau of Federal Supply. **See Historical and Revision Notes** and 2006 Amendment note under section 303 of Title 40."

For 16 U.S.C. § 16 this fabricated a bogus "Historical and Revision Notes" note containing only the truncated tail fragment ("and 2006 Amendment note under section 303 of Title 40."), left a duplicate of that same sentence inside the real "Transfer of Functions" note, and mis-categorized the real note as `historical` via the `_parse_historical_notes` code path instead of the `statutory` category it should have received from `_parse_flat_notes`.

## Changes

- Added `_find_wrapper_heading()` in `backend/pipeline/olrc/normalized_section.py`, which scans **all** candidate regex matches for a wrapper heading and accepts only the first one whose preceding text — after stripping `[NH]...[/NH]` and `[H1]...[/H1]` marker spans — is empty/whitespace. This reflects how `raw_notes` is actually assembled: a real wrapper heading is always a structural section start (start of `raw_notes`, or right after a preceding note's marker-delimited content), never mid-sentence prose.
- Used this helper in `_parse_historical_notes`, `_parse_editorial_notes`, and `_parse_statutory_notes` in place of the previous unanchored `re.search` calls.
- With the fabricated note removed, the real "Transfer of Functions" note now falls through correctly to `_parse_flat_notes`, which already categorizes non-editorial flat notes as `STATUTORY` (fixing the category bug as a side effect, with no special-casing needed).
- Added a regression test (`test_inline_cross_reference_to_historical_notes_not_split_issue_529`) in `TestFlatNotesParser` covering a `transferOfFunctions`-style note body containing the exact "See Historical and Revision Notes ..." cross-reference, asserting a single note is produced with the full body intact and a non-`historical` category.

## Before / after (16 U.S.C. § 16 repro)

**Before:**
```
Number of notes: 2
HEADER: 'Historical and Revision Notes' CATEGORY: historical
    and 2006 Amendment note under section 303 of Title 40.
HEADER: 'Transfer Of Functions' CATEGORY: statutory
    Functions of procurement of supplies, services, stores, etc., ...
    Bureau transferred on July 1, 1949, to General Services Administration.
    Section 303(a) of Title 40 was amended generally by Pub. L. 109-313, ...
    See Historical and Revision Notes and 2006 Amendment note under section 303 of Title 40.
```

**After:**
```
Number of notes: 1
HEADER: 'Transfer Of Functions' CATEGORY: statutory
    Functions of procurement of supplies, services, stores, etc., ...
    Bureau transferred on July 1, 1949, to General Services Administration.
    Section 303(a) of Title 40 was amended generally by Pub. L. 109-313, ...
    See Historical and Revision Notes and 2006 Amendment note under section 303 of Title 40.
```

Note: the title-casing of the header ("Transfer Of Functions" vs. source casing "Transfer of Functions") is a separate, already-tracked issue being fixed by PR #493 and is intentionally left untouched here.

## Test plan

- [x] Added regression test reproducing the exact 16 U.S.C. § 16 cross-reference scenario
- [x] `uv run mypy app --ignore-missing-imports` passes
- [x] `uv run pytest` passes (798 passed, 21 skipped)
- [x] `uv run ruff check` / `uv run ruff format --check` clean

Closes #529
