### PR TITLE
docs: add test-status.md with clean spot-check for 28 USC 2514 (2026.06.20)

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -9,6 +9,18 @@ CWLB and the OLRC XML at the stated release point.
 | Date       | Title | Section | Heading                                          | Release Point | Status |
 |------------|-------|---------|--------------------------------------------------|---------------|--------|
 | 2026.05.24 | 17    | 204     | Execution of transfers of copyright ownership    | 113-21        | ✅ Clean |
+| 2026.06.20 | 28    | 2514    | Forfeiture of fraudulent claims                  | 113-21        | ✅ Clean (known issue applies — see notes) |
+
+## Notes
+
+### 2026.06.20 — 28 U.S.C. § 2514
+
+All fields matched: heading, body text (2 paragraphs), source credit/citations, Historical and
+Revision Notes, Amendments note, Effective Date notes, and all 15 in-note cross-references.
+
+`last_modified_date` is returned as `1992-01-01` instead of the actual amendment date
+`1992-10-29` (Pub. L. 102-572 effective date). This is the systemic Jan-1-placeholder bug
+already tracked in #466, #483, #491, and #510 — not re-filed here.
 
 ## Test methodology
 


### PR DESCRIPTION
## Summary

- Daily spot-check comparing CWLB's ingested data against the authoritative OLRC source for a randomly selected section.
- Selected: Title 28 (Judiciary and Judicial Procedure), § 2514 "Forfeiture of fraudulent claims", release point 113-21 (effective 2013-01-01).
- Compared heading, full body text, source credit/citations, all notes (Historical and Revision Notes, Amendments, Effective Date of 1992/1982 Amendment), and all 15 in-note cross-references against the OLRC bulk XML (`usc28@119-99.xml` — section text unchanged since 1992, so identical to 113-21).
- No new discrepancies found. One known, already-tracked issue applies (see below) and was **not** re-filed to avoid duplication.

## Known issue observed (not re-filed)

`last_modified_date` for this section is `1992-01-01` instead of the actual amendment date `1992-10-29`. This is the same systemic "January 1 placeholder" bug already filed in issues #466, #483, #491, and #510 — confirmed here as another instance, but a 5th duplicate issue was not created.

## Test plan

- [x] Fetched `/api/v1/sections/28/2514` from CWLB backend
- [x] Downloaded and parsed `xml_usc28@119-99.zip` from OLRC, located `<section identifier="/us/usc/t28/s2514">`
- [x] Verified body text matches exactly
- [x] Verified source credit citations and all amendment/effective-date notes match exactly
- [x] Verified all 15 in-note references (usc_section, public_law, statute, act) match exactly in order and text

https://claude.ai/code/session_01BBGsScvHiARiThKCYjt1DG


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBGsScvHiARiThKCYjt1DG)_