### PR TITLE
docs: record clean daily OLRC check for 5 U.S.C. § 569 (RP 113-21)

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -9,6 +9,7 @@ CWLB and the OLRC XML at the stated release point.
 | Date       | Title | Section | Heading                                          | Release Point | Status |
 |------------|-------|---------|--------------------------------------------------|---------------|--------|
 | 2026.05.24 | 17    | 204     | Execution of transfers of copyright ownership    | 113-21        | ✅ Clean |
+| 2026.06.22 | 5     | 569     | Encouraging negotiated rulemaking                | 113-21        | ✅ Clean |
 
 ## Test methodology
 


### PR DESCRIPTION
## Summary

Daily routine check: compared CWLB's ingested representation of a randomly selected US Code section against the authoritative OLRC source at the same release point.

- **Section tested:** 5 U.S.C. § 569 ("Encouraging negotiated rulemaking")
- **Release point:** OLRC 113-21
- **Source:** `xml_usc05@113-21.zip` from `https://uscode.house.gov/download/releasepoints/us/pl/113/21/`

## Result

Clean. `text_content`, `provisions`, `notes.amendments`, and `notes.citations` all matched the OLRC USLM XML exactly.

One date discrepancy was observed (`last_modified_date: "1996-01-01"` vs. the actual amendment date `1996-10-19` from PL 104-320), but this is already covered by existing open issues #483, #491, #510, and #466 (systemic year-only truncation bug), so no new issue was filed to avoid duplication.

## Test plan

- [x] Fetched CWLB section detail via `GET /api/v1/sections/5/569`
- [x] Downloaded and parsed OLRC USLM XML for title 5 at release point 113-21
- [x] Diffed text content, amendment notes, and citation structure
- [x] Checked existing GitHub issues for duplicates before deciding not to file a new one


---
_Generated by [Claude Code](https://claude.ai/code/session_01E1iChKSeZqtFrdMVPohT9a)_