### PR TITLE
fix: split enumerated quoted text into separate note lines

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1318,11 +1318,15 @@ class USLMParser:
         quoted content and formats them with [QC:level] markers the normalizer
         uses to create properly indented lines.
 
-        Two patterns handled:
+        Patterns handled:
         - Anonymous inline: <section class="inline"> with chapeau + paragraphs
           + continuation (no section header emitted for empty <num>)
         - Full named sections: <section> with real <num> and <heading>
         - Subsection-only: <subsection> children at top level (legacy pattern)
+        - Paragraph-only: <paragraph> children directly under quotedContent
+          with no enclosing <section>/<subsection> wrapper, optionally
+          preceded by a bare <inline> intro line (e.g. the 21 U.S.C. 822
+          "Findings" note; see issue #536)
         """
         parts = []
 
@@ -1408,6 +1412,25 @@ class USLMParser:
                 format_item(subsection, 1)
             for subsection in elem.findall("subsection"):
                 format_item(subsection, 1)
+
+        # Process top-level paragraphs when neither sections nor subsections
+        # wrap them directly under quotedContent (e.g. a flat enumeration
+        # like "(1)", "(2)" with "(A)", "(B)" sub-items but no enclosing
+        # <section>/<subsection>). A bare <inline> intro line, if present,
+        # is emitted first at the same level so it precedes the enumeration.
+        if not parts:
+            inline_elem = elem.find("{*}inline")
+            if inline_elem is None:
+                inline_elem = elem.find("inline")
+            if inline_elem is not None:
+                inline_text = self._get_text_content(inline_elem).strip()
+                if inline_text:
+                    parts.append(f"[QC:1]{inline_text}[/QC]")
+
+            for paragraph in elem.findall("{*}paragraph"):
+                format_item(paragraph, 1)
+            for paragraph in elem.findall("paragraph"):
+                format_item(paragraph, 1)
 
         # Fallback: extract plain text for simple inline quotedContent
         if not parts:

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1,5 +1,7 @@
 """Tests for legal text line normalization."""
 
+import re
+
 from app.models.enums import NoteRefType
 from app.schemas import NoteReferenceSchema
 from pipeline.olrc.normalized_section import (
@@ -1628,6 +1630,69 @@ class TestParserNotesContent:
         assert '"SEC. 2."' in content
         assert "[QC:1]" in content
         assert "[QC:2]" in content
+
+    def test_paragraphs_direct_children_of_quoted_content(self) -> None:
+        """quotedContent whose direct children are <paragraph> (no enclosing
+        <section>/<subsection>), optionally preceded by a bare <inline> intro.
+
+        This mirrors the real OLRC structure for the 21 U.S.C. 822 "Findings"
+        statutory note (Pub. L. 111-273, Sec. 2), where <quotedContent> wraps
+        an <inline> intro line followed directly by sibling <paragraph>
+        elements -- some of which have nested <subparagraph> children -- with
+        no <section> or <subsection> wrapper at the top level (issue #536).
+        """
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        xml = """<notes>
+            <quotedContent>
+                <inline>"Congress finds the following:</inline>
+                <paragraph>
+                    <num value="1">"(1)"</num>
+                    <content>The nonmedical use of prescription drugs is a growing problem.</content>
+                </paragraph>
+                <paragraph>
+                    <num value="2">"(2)"</num>
+                    <chapeau>According to the Department of Justice&#8212;</chapeau>
+                    <subparagraph>
+                        <num value="A">"(A)"</num>
+                        <content>the number of deaths has increased significantly; and</content>
+                    </subparagraph>
+                    <subparagraph>
+                        <num value="B">"(B)"</num>
+                        <content>treatment admissions increased.</content>
+                    </subparagraph>
+                </paragraph>
+            </quotedContent>
+        </notes>"""
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # The bare intro line and each enumerated paragraph/subparagraph
+        # must become its own [QC:level] marker rather than being flattened
+        # into a single block of concatenated text.
+        assert "Congress finds the following" in content
+        assert '"(1)"' in content
+        assert '"(2)"' in content
+        assert '"(A)"' in content
+        assert '"(B)"' in content
+        assert "[QC:1]" in content
+        assert "[QC:2]" in content
+
+        # The intro and each paragraph/subparagraph must be distinct QC
+        # blocks -- not one giant block containing all of the text below.
+        qc_blocks = re.findall(r"\[QC:\d+\](.*?)\[/QC\]", content, flags=re.DOTALL)
+        assert len(qc_blocks) >= 5
+        assert not any('"(1)"' in block and '"(2)"' in block for block in qc_blocks), (
+            "paragraphs (1) and (2) must not be merged into a single QC block"
+        )
+        assert not any('"(A)"' in block and '"(B)"' in block for block in qc_blocks), (
+            "subparagraphs (A) and (B) must not be merged into a single QC block"
+        )
 
     def test_is_quoted_flag_set_on_qc_lines(self) -> None:
         """Lines derived from quotedContent blocks have is_quoted=True."""


### PR DESCRIPTION
## Context

For 21 U.S.C. § 822, the statutory note titled "Findings" (Pub. L. 111–273, § 2) had its enumerated structure — paragraphs (1)–(6), with lettered sub-items (A)–(D) under (2), (3), and (4) — collapsed into a single `lines[]` entry instead of one entry per paragraph/subparagraph, as in the OLRC source.

## Root cause

I downloaded the real OLRC XML (`usc21@113-21.xml` from release point `113-21`) and compared the "Findings" note against the sibling "Provisional Registration" note (which parses correctly):

**"Findings" (broken)** — `<quotedContent>`'s direct children are a bare `<inline>` intro followed by sibling `<paragraph>` elements, with **no enclosing `<section>`/`<subsection>` wrapper**:

```xml
<quotedContent origin="/us/pl/111/273/s2">
<inline>"Congress finds the following:</inline>
<paragraph class="indent1"><num value="1">"(1)</num><content> The nonmedical use of prescription drugs is a growing problem...</content>
</paragraph>
<paragraph class="indent1"><num value="2">"(2)</num><chapeau> According to the Department of Justice's 2009 National Prescription Drug Threat Assessment—</chapeau><subparagraph class="indent2"><num value="A">"(A)</num><content> the number of deaths and treatment admissions for controlled prescription drugs (CPDs) has increased significantly in recent years;</content>
</subparagraph>
...
</paragraph>
...
</quotedContent>
```

**"Provisional Registration" (works)** — `<quotedContent>`'s direct children are `<subsection>` elements, which wrap `<paragraph>`/`<subparagraph>`:

```xml
<quotedContent origin="/us/pl/99/514/s2">
<subsection class="indent0"><num value="a">"(a)</num><paragraph class="indent0"><num value="1">(1)</num><chapeau> Any person who—</chapeau><subparagraph class="indent1">...</subparagraph>
...
</paragraph>
</subsection>
...
</quotedContent>
```

`_format_quoted_content` (`backend/pipeline/olrc/parser.py`) only checked for `<section>` and `<subsection>` as direct children of `<quotedContent>`. When neither was found (the "Findings" case), it fell through to a fallback that calls `_get_text_content(elem)`, which uses `elem.itertext()` to flatten **every** descendant's text — across all six paragraphs and all lettered sub-items — into one string wrapped in a single `[QC:1]...[/QC]` marker. Downstream, `normalize_note_content` turns each `[QC:n]...[/QC]` marker into exactly one `ParsedLine`, so one marker means one line.

## Fix

Added a third dispatch branch in `_format_quoted_content` that runs when no `<section>`/`<subsection>` children are found: it emits a leading `<inline>` intro (if present) as its own `[QC:1]` line, then processes top-level `<paragraph>` children using the same recursive `format_item()` logic already used for `<section>`/`<subsection>` (which already knows how to recurse into `<paragraph>`/`<subparagraph>`/`<chapeau>`/`<continuation>`). No changes were needed to the recursion itself — only to the top-level dispatch that decides which container tag to start recursing from.

## Before / after (21 U.S.C. § 822 "Findings")

**Before:** 2 `lines[]` entries — the second one ~2,800 characters containing all of (1)–(6) and (A)–(D) concatenated with no breaks.

**After:** each paragraph and sub-item is its own line, with correct `indent_level` (1 for top-level (1)-(6) and the intro, 2 for lettered sub-items):

```
[indent=1] "Congress finds the following:
[indent=1] "(1) The nonmedical use of prescription drugs is a growing problem in the United...
[indent=1] "(2)
[indent=2] According to the Department of Justice's 2009 National Prescription Drug Threat ...
[indent=2] "(A) the number of deaths and treatment admissions for controlled prescription d...
[indent=2] "(B) unintentional overdose deaths involving prescription opioids, for example, ...
[indent=2] "(C) violent crime and property crime associated with abuse and diversion of CPD...
[indent=1] "(3)
[indent=2] According to the Office of National Drug Control Policy's 2008 Report 'Prescript...
[indent=2] "(A) one-third of all new abusers of prescription drugs in 2006 were 12- to 17-y...
[indent=2] "(B) teens abuse prescription drugs more than any illicit drug except marijuana—...
[indent=2] "(C) responsible adults are in a unique position to reduce teen access to prescr...
[indent=1] "(4)
[indent=2] (A) Many State and local law enforcement agencies have established drug disposal...
[indent=2] "(B) However, take-back programs often cannot dispose of the most dangerous phar...
[indent=2] "(C) Individuals seeking to reduce the amount of unwanted controlled substances ...
[indent=2] "(D) Long-term care facilities face a distinct set of obstacles to the safe disp...
[indent=1] "(5) This Act [see Short Title of 2010 Amendment note set out under section 801 ...
[indent=1] "(6) The goal of this Act is to encourage the Attorney General to set controlled...
```

19 distinct lines (intro + 6 numbered paragraphs + 12 lettered sub-items under (2)/(3)/(4)) instead of 1 flattened block — consistent with how "Provisional Registration" already renders.

## Testing

- Added `test_paragraphs_direct_children_of_quoted_content` in `backend/tests/pipeline/test_normalized_section.py` (`TestParserNotesContent`), using a structure mirroring the real Findings note (bare `<inline>` intro + sibling `<paragraph>` with nested `<subparagraph>`, no `<section>`/`<subsection>` wrapper). Verified it fails against the old code (single merged QC block) and passes with the fix.
- Verified against the real downloaded `usc21@113-21.xml` OLRC source that the fix produces the expected per-paragraph/sub-item line breakdown shown above.
- Confirmed existing tests covering `<section>`/`<subsection>`-based quoted content (including the "Provisional Registration"-style nested case) still pass — no regression to the working path.
- `uv run mypy app --ignore-missing-imports` — no issues.
- `uv run pytest` — 798 passed, 21 skipped (pre-existing/unrelated).

Closes #536


---
_Generated by [Claude Code](https://claude.ai/code/session_01RerrpQxTBJgNizJdzHSDoa)_