### PR TITLE
fix: don't split note paragraphs mid-sentence on inline element boundaries

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -101,6 +101,10 @@ LEGAL_ABBREVIATIONS = {
     "cl.",
     "Para.",
     "para.",
+    "Subsec.",  # Subsection (e.g., "referred to in subsec. (c)(3)")
+    "subsec.",
+    "Subsecs.",  # Plural subsection (e.g., "referred to in subsecs. (b), (c)")
+    "subsecs.",
     "Subch.",
     "subch.",
     "Pt.",
@@ -1126,12 +1130,29 @@ def _indent_block_quotes(
     return result
 
 
-def _amendment_lines(raw_content: str) -> list[ParsedLine]:
-    """Fast path for Amendments notes: split on newlines, skip sentence detection.
+# Note headers whose paragraphs are already complete, self-contained statements
+# (citation/cross-reference prose, year-prefixed amendment entries) and so should
+# bypass sentence-boundary splitting in favor of a straight one-paragraph-per-line
+# mapping. See _paragraph_lines() docstring for why the general-purpose
+# normalize_note_content() codepath mis-renders these headers.
+PARAGRAPH_LINE_HEADERS = {
+    "Amendments",
+    "References In Text",
+}
 
-    Amendment text consists of year-prefixed entries ("1988—Pub. L. 100–568 …"),
-    one per line, so sentence-boundary detection in normalize_note_content adds
-    no value while costing ~98× more than a plain newline split.
+
+def _paragraph_lines(raw_content: str) -> list[ParsedLine]:
+    """One line per source <p>: split on paragraph breaks, skip sentence detection.
+
+    Used for note categories whose paragraphs are already complete, self-contained
+    statements — e.g. "Amendments" entries ("1988—Pub. L. 100–568 …") and
+    "References in Text" entries (citation/cross-reference prose). Running these
+    through normalize_note_content's sentence-boundary detector would (a) fragment
+    a paragraph mid-sentence whenever it contains an abbreviation outside
+    LEGAL_ABBREVIATIONS (e.g. "subsecs."), and (b) insert a spurious blank
+    ParsedLine for the paragraph break itself, since that codepath always renders
+    [PARA] markers as a separating blank line. Splitting on paragraph boundaries
+    directly avoids both problems and is ~98x cheaper than sentence splitting.
     """
     cleaned = re.sub(r"\[NH\].*?\[/NH\]", "", raw_content, flags=re.DOTALL)
     cleaned = re.sub(r"\[/NH\]", "", cleaned)
@@ -1458,8 +1479,8 @@ def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
         notes.notes.append(
             SectionNote(
                 header=header,
-                lines=_amendment_lines(raw_content)
-                if header == "Amendments"
+                lines=_paragraph_lines(raw_content)
+                if header in PARAGRAPH_LINE_HEADERS
                 else normalize_note_content(raw_content),
                 category=category,
             )
@@ -1590,8 +1611,8 @@ def _parse_editorial_notes(raw_notes: str, notes: SectionNotes) -> None:
             notes.notes.append(
                 SectionNote(
                     header=header,
-                    lines=_amendment_lines(raw_content)
-                    if header == "Amendments"
+                    lines=_paragraph_lines(raw_content)
+                    if header in PARAGRAPH_LINE_HEADERS
                     else normalize_note_content(raw_content),
                     category=NoteCategory.EDITORIAL,
                 )

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1502,16 +1502,29 @@ class USLMParser:
                     header_text = text.rstrip(".")
                     parts.append(f"[H1]{header_text}[/H1]")
                 elif tag == "i":
-                    # Italic text might be a sub-header if followed by ".—"
-                    # But NOT if it's a case citation (contains " v. ")
-                    # or other inline emphasis (Latin terms, etc.)
+                    # Italic text is a sub-header only when it is followed
+                    # immediately by ".—" (an em-dash introducer), e.g.:
+                    #   <i>Reproduction</i>.—The right to reproduce.
+                    # If the tail does NOT start with ".—" the element is
+                    # inline formatting (case name, date, emphasis) and must
+                    # be kept as plain text so the surrounding sentence is
+                    # not fragmented. Also exclude known case-citation
+                    # patterns (" v. ") and common Latin phrases.
                     inline_latin = {"et seq", "et al", "supra", "infra", "id"}
                     stripped_text = text.strip().rstrip(".")
-                    if " v. " in text or stripped_text.lower() in inline_latin:
-                        # Case citation or Latin phrase - keep as inline text
+                    tail = el.tail or ""
+                    is_subheader_tail = bool(re.match(r"^\s*\.?\s*—", tail))
+                    if (
+                        " v. " in text
+                        or stripped_text.lower() in inline_latin
+                        or not is_subheader_tail
+                    ):
+                        # Inline text (case citation, date, Latin phrase, or
+                        # mid-sentence emphasis) — keep as plain text
                         parts.append(text)
                     else:
-                        # Mark as potential sub-header for normalizer
+                        # Standalone italic introducer followed by ".—":
+                        # mark as sub-header for the normalizer
                         parts.append(f"[H2]{text}[/H2]")
                 else:
                     parts.append(text)

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2176,6 +2176,142 @@ class TestNoteTopicAmendmentParsing:
         assert 2007 in years
 
 
+class TestReferencesInTextParagraphMapping:
+    """Regression tests for issue #537: 21 U.S.C. § 822 'References in Text'.
+
+    The OLRC source XML has exactly 2 <p> elements in this note. The parser
+    previously broke the first <p> into 3 fragment lines — cutting it off
+    mid-sentence right after the abbreviation "subsecs." — and inserted a
+    spurious empty line between the two source paragraphs. Each source <p>
+    must map to exactly one lines[] entry, matching the "Amendments" note's
+    existing 1:1 paragraph-to-line behavior.
+    """
+
+    def _parse_xml_notes(self, xml_snippet: str) -> object:
+        from lxml import etree
+
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+        from pipeline.olrc.parser import USLMParser
+
+        notes_elem = etree.fromstring(xml_snippet)
+        raw = USLMParser()._get_notes_text_content(notes_elem)
+        notes = SectionNotes()
+        _parse_notes_structure(raw, notes)
+        return notes
+
+    def test_21_usc_822_references_in_text_two_paragraphs_two_lines(self) -> None:
+        """21 U.S.C. § 822 References in Text note: 2 source <p> -> 2 lines[].
+
+        XML reproduced verbatim from usc21@113-21.xml (OLRC release point
+        113-21), including the <ref> and <date> inline children that
+        previously triggered the mid-sentence split.
+        """
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0" type="uscNote">'
+            '<note class="editorial">'
+            '<heading class="smallCaps">Editorial Notes</heading>'
+            '<note topic="referencesInText">'
+            "<heading>References in Text</heading>"
+            '<p style="-uslm-lc:I21" class="indent0">This subchapter, referred to '
+            "in subsecs. (b), (c), and (g)(1), was in the original “this "
+            'title”, meaning title II of <ref href="/us/pl/91/513">Pub. L. '
+            '91–513</ref>, <date date="1970-10-27">Oct. 27, 1970</date>, '
+            '<ref href="/us/stat/84/1242">84 Stat. 1242</ref>, and is popularly '
+            "known as the “Controlled Substances Act”. For complete "
+            "classification of title II to the Code, see second paragraph of "
+            'Short Title note set out under <ref href="/us/usc/t21/s801">section '
+            "801 of this title</ref> and Tables.</p>"
+            '<p style="-uslm-lc:I21" class="indent0">'
+            '<ref href="/us/usc/t21/s802/25">Section 802(25) of this title</ref>, '
+            "referred to in subsec. (c)(3), was redesignated "
+            '<ref href="/us/usc/t21/s802/26">section 802(26) of this title</ref> '
+            'by <ref href="/us/pl/98/473/s507/a">Pub. L. 98–473, title II, '
+            '§ 507(a)</ref>, <date date="1984-10-12">Oct. 12, 1984</date>, '
+            '<ref href="/us/stat/98/2071">98 Stat. 2071</ref>, and was further '
+            'redesignated <ref href="/us/usc/t21/s802/27">section 802(27) of '
+            'this title</ref> by <ref href="/us/pl/99/570/s1003/b/2">Pub. L. '
+            "99–570, title I, § 1003(b)(2)</ref>, "
+            '<date date="1986-10-27">Oct. 27, 1986</date>, '
+            '<ref href="/us/stat/100/3207-6">100 Stat. 3207–6</ref>.</p>'
+            "</note>"
+            '<note topic="amendments"><heading>Amendments</heading>'
+            '<p style="-uslm-lc:I21" class="indent0">2010—Subsec. (g). '
+            '<ref href="/us/pl/111/273">Pub. L. 111–273</ref> added '
+            "subsec. (g).</p>"
+            "</note>"
+            "</note>"
+            "</notes>"
+        )
+
+        notes = self._parse_xml_notes(xml)
+
+        ref_notes = [n for n in notes.notes if n.header == "References In Text"]
+        assert len(ref_notes) == 1
+        lines = ref_notes[0].lines
+
+        # Exactly 2 lines — one per source <p> — with no spurious blank line.
+        assert len(lines) == 2
+        assert all(line.content != "" for line in lines)
+
+        # First line must NOT be cut off mid-sentence after "subsecs." and
+        # must contain the full first source paragraph, including its
+        # second sentence ("For complete classification...").
+        first = lines[0].content
+        assert first.startswith(
+            "This subchapter, referred to in subsecs. (b), (c), and (g)(1)"
+        )
+        assert "84 Stat. 1242" in first
+        assert "Controlled Substances Act" in first
+        assert "For complete classification of title II to the Code" in first
+        assert first.endswith("and Tables.")
+
+        # Second line is the second source paragraph, reproduced in full.
+        second = lines[1].content
+        assert second.startswith("Section 802(25) of this title")
+        assert second.endswith("100 Stat. 3207–6.")
+
+    def test_subsecs_abbreviation_not_split_in_general_path(self) -> None:
+        """normalize_note_content must not treat 'subsecs.' as a sentence end.
+
+        Direct unit test of the abbreviation-list gap, independent of the
+        Amendments/References-in-Text fast path, so other note categories
+        that still use normalize_note_content (e.g. statutory notes) also
+        benefit from the fix.
+        """
+        text = (
+            "This subchapter, referred to in subsecs. (b), (c), and (g)(1), "
+            "was in the original this title."
+        )
+        lines = normalize_note_content(text)
+
+        assert len(lines) == 1
+        assert lines[0].content == text
+
+    def test_italic_date_not_split_mid_sentence(self) -> None:
+        """An <i> element not followed by '.—' stays inline (Issue #460-style).
+
+        Some OLRC releases wrap dates or other inline content in <i> without
+        an em-dash introducer; that must not be misread as a [H2] sub-header,
+        which would otherwise fragment the surrounding sentence onto its own
+        line (e.g. the issue's hypothesis about <i> + <ref> together).
+        """
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+        xml = "<notes><p>enacted on <i>Oct. 27, 1970</i>, and is binding.</p></notes>"
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        assert "[H2]" not in content
+        assert "Oct. 27, 1970" in content
+
+
 class TestCleanHeading:
     """Tests for _clean_heading function."""
 


### PR DESCRIPTION
## Context

For 21 U.S.C. § 822, the "References in Text" statutory note has its first source paragraph (a single `<p>` element in the OLRC XML) incorrectly broken into three separate `lines[]` entries — with the first break landing mid-sentence right after the abbreviation "subsecs." — plus a spurious empty-string line inserted between the two source paragraphs.

### Root cause

Two independent bugs in `backend/pipeline/olrc/`:

1. **Missing abbreviation** (`normalized_section.py`): `subsec.` / `subsecs.` were not in `LEGAL_ABBREVIATIONS`, so `_is_sentence_boundary()` treated the period in `"...subsecs. (b), (c)..."` as a true sentence end (period followed by whitespace + `(`), splitting the paragraph mid-sentence.

2. **Spurious blank line** (`normalized_section.py`): `normalize_note_content()` always renders a `[PARA]` paragraph break (inserted by the parser for every `<p>` boundary) as a blank `ParsedLine`. That's correct behavior for some notes (covered by the existing `test_paragraph_breaks` test — e.g. separating distinct quoted documents), but spurious for citation-style notes like "References in Text" whose paragraphs are already complete, self-contained statements that should map 1:1 to `lines[]`, exactly like the existing "Amendments" note behavior.

3. **Related latent bug** (`parser.py`): any `<i>` element's text was unconditionally wrapped in `[H2]...[/H2]` (treated as a sub-header) unless it matched a narrow set of exceptions (case citations, Latin terms) — regardless of whether `.—` actually followed. This mirrors the precedent fix for issue #460 and is fixed defensively here since the issue's report specifically flagged `<i>` + `<ref>` inline mixing as a suspect (the real 21 USC 822 source actually uses `<date>`, not `<i>`, so this wasn't the proximate cause for #537, but it's the same class of bug and worth closing).

### Fix

- Added `Subsec.` / `subsec.` / `Subsecs.` / `subsecs.` to `LEGAL_ABBREVIATIONS`.
- Generalized the existing "Amendments"-only fast path (`_amendment_lines`, renamed `_paragraph_lines`) to also apply to "References In Text" headers via a new `PARAGRAPH_LINE_HEADERS` set, used at both dispatch sites (`_parse_flat_notes` and `_parse_editorial_notes`). This splits on paragraph breaks instead of sentence boundaries, so each source `<p>` maps to exactly one `lines[]` entry with no blank separator — matching the issue's expected behavior and the "Amendments" note's existing 1:1 mapping.
- Fixed the `<i>` handling in `parser.py` to only emit `[H2]` when the element's tail actually starts with `.—` (an em-dash introducer), keeping all other inline italics (dates, mid-sentence emphasis) as plain text.

### Before / after (21 U.S.C. § 822, "References In Text")

**Before:**
```
'This subchapter, referred to in subsecs.'
'(b), (c), and (g)(1), was in the original "this title", meaning title II of Pub. L. 91–513, Oct. 27, 1970, 84 Stat. 1242, and is popularly known as the "Controlled Substances Act".'
'For complete classification of title II to the Code, see second paragraph of Short Title note set out under section 801 of this title and Tables.'
''
'Section 802(25) of this title, referred to in subsec. (c)(3), was redesignated section 802(26) of this title by Pub. L. 98–473, title II, § 507(a), Oct. 12, 1984, 98 Stat. 2071, and was further redesignated section 802(27) of this title by Pub. L. 99–570, title I, § 1003(b)(2), Oct. 27, 1986, 100 Stat. 3207–6.'
```

**After:**
```
'This subchapter, referred to in subsecs. (b), (c), and (g)(1), was in the original "this title", meaning title II of Pub. L. 91–513, Oct. 27, 1970, 84 Stat. 1242, and is popularly known as the "Controlled Substances Act". For complete classification of title II to the Code, see second paragraph of Short Title note set out under section 801 of this title and Tables.'
'Section 802(25) of this title, referred to in subsec. (c)(3), was redesignated section 802(26) of this title by Pub. L. 98–473, title II, § 507(a), Oct. 12, 1984, 98 Stat. 2071, and was further redesignated section 802(27) of this title by Pub. L. 99–570, title I, § 1003(b)(2), Oct. 27, 1986, 100 Stat. 3207–6.'
```

Exactly 2 `lines[]` entries, each matching one source `<p>` in full, no mid-sentence cuts, no blank line.

This output was reproduced and verified using the real `usc21@113-21.xml` OLRC release point file (fetched directly from `uscode.house.gov`), not a hand-written approximation.

## Test plan

- [x] Added `TestReferencesInTextParagraphMapping` in `backend/tests/pipeline/test_normalized_section.py` with the exact 21 U.S.C. § 822 XML fixture (verbatim from the real OLRC source), asserting 2 lines / no blank line / no mid-sentence cut.
- [x] Added a focused unit test confirming `subsecs.` is no longer treated as a sentence boundary in the general `normalize_note_content()` path (benefits other note categories too).
- [x] Added a regression test for the `<i>` tail-check fix.
- [x] `uv run mypy app --ignore-missing-imports` — clean.
- [x] `uv run pytest` — 800 passed, 21 skipped (pre-existing), 0 failed.
- [x] `uv run ruff check .` and `uv run ruff format .` — clean.

Closes #537


---
_Generated by [Claude Code](https://claude.ai/code/session_01RerrpQxTBJgNizJdzHSDoa)_