### PR TITLE
docs: record clean OLRC spot-check for 3 USC 456

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,0 +1,12 @@
+# Test Status
+
+This file records the results of the recurring spot-check that compares CWLB's
+ingested US Code sections against the authoritative OLRC source for the same
+release point. See the routine described in the repository's scheduled task
+for methodology.
+
+## Confirmed Clean
+
+| Date       | Title | Section | Release Point | Notes |
+|------------|-------|---------|----------------|-------|
+| 2026.06.26 | 3 (The President) | 456 (Confidentiality) | 113-21 (2013-01-01) | Text, heading, enactment citation (Pub. L. 104-331, § 2(a)), enacted date, and chapter/subchapter ancestry all match the OLRC XML bulk download for release point 113-21. Subsection heading punctuation (trailing ".—") is consistently stripped by the parser across sections, not a defect. |


### PR DESCRIPTION
## Summary

Daily ingestion spot-check: randomly selected Title 3 ("The President"), Section 456 ("Confidentiality") and compared CWLB's parsed representation against the OLRC XML bulk download for release point 113-21 (2013-01-01), which is the release point CWLB has ingested for this title.

## Findings

No discrepancies. Verified:
- Heading and full text of subsections (a) Counseling and (b) Mediation match verbatim
- Enactment citation (Pub. L. 104-331, § 2(a), Oct. 26, 1996, 110 Stat. 4068) matches the OLRC `sourceCredit` exactly
- `enacted_date` (1996-10-26) and absence of further amendments match
- Chapter/subchapter ancestry (ch. 5, subch. III) matches
- Confirmed as a non-issue: the parser consistently strips the trailing ".—" punctuation from subsection headings (e.g. "Counseling.—" → "Counseling") across sections — this is consistent normalization behavior, not a parsing defect

## Test plan

- [x] Compared CWLB `/api/v1/sections/3/456` output against OLRC `xml_usc03@113-21.zip` bulk download
- [x] No bugs filed — recording clean result in `docs/test-status.md` per routine instructions


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk9yXjLD8JkAGnn1pDShX8)_