### PR TITLE
docs: record clean daily OLRC spot-check for 44 USC 910 (2026.06.29)

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,0 +1,39 @@
+# Daily OLRC Spot-Check Status
+
+Records of the daily routine that compares a randomly selected US Code section ingested by CWLB against the authoritative OLRC source at the same release point.
+
+## 2026.06.29 — 44 U.S.C. § 910
+
+- **Title:** 44 (Public Printing and Documents)
+- **Section:** 910 ("Congressional Record: subscriptions; sale of current, individual numbers, and bound sets; postage rate")
+- **Release point:** OLRC 113-21 (effective 2013-01-01), per `GET /api/v1/revisions/latest?title=44`
+- **OLRC source:** `https://uscode.house.gov/download/releasepoints/us/pl/113/21/xml_usc44@113-21.zip` → `usc44@113-21.xml`
+
+### Result: clean
+
+Compared CWLB's `GET /api/v1/sections/44/910` response against the OLRC USLM XML for release point 113-21:
+
+- Heading and full body text (subsections (a)–(c)) match verbatim, including "Public Printer" terminology — correct for this release point, since the 2014 rename to "Director of the Government Publishing Office" (Pub. L. 113–235) postdates 113-21.
+- Enactment + amendment citations match the `sourceCredit` exactly: Pub. L. 90–620 (Oct. 22, 1968, 82 Stat. 1260) and Pub. L. 93–314, § 1(a) (June 8, 1974, 88 Stat. 239).
+- "Historical and Revision Notes" and "Amendments" notes match the OLRC XML's `<notes>` block exactly, including the reference to 44 U.S. Code 1964 ed. § 188 and the 1974 amendment description.
+- `enacted_date` (1968-10-22) matches the enactment citation exactly.
+
+### Known issue observed (not re-filed)
+
+`last_modified_date` is returned as `1974-01-01` instead of the actual amendment date `1974-06-08` (visible in the same response's `notes.citations[1].law.date`). This is the same systemic "year-only / Jan-1 placeholder" bug already filed in issues #466, #483, #491, #510, #538, and #546 (most recently #548), and already has a correct, reviewed fix sitting unmerged in PR #469 since 2026-05-27. No new issue was filed to avoid further duplication.
+
+## 2026.06.26 — 3 U.S.C. § 456
+
+See PR #545.
+
+## 2026.06.24 — 33 U.S.C. § 2284b
+
+See PR #541.
+
+## 2026.06.22 — 5 U.S.C. § 569
+
+See PR #535.
+
+## 2026.06.20 — 28 U.S.C. § 2514
+
+See PR #532.


### PR DESCRIPTION
## Summary

Daily ingestion spot-check: randomly selected Title 44 ("Public Printing and Documents"), Section 910 ("Congressional Record: subscriptions; sale of current, individual numbers, and bound sets; postage rate") and compared CWLB's parsed representation against the OLRC XML bulk download for release point 113-21 (effective 2013-01-01), which is the release point CWLB has ingested for this title.

## Findings

No new discrepancies. Verified:
- Heading and full text of subsections (a)-(c) match verbatim, including the "Public Printer" terminology, which is correct for release point 113-21 (the rename to "Director of the Government Publishing Office" via Pub. L. 113-235 postdates this release point).
- Enactment + amendment citations match the OLRC `sourceCredit` exactly (Pub. L. 90-620 and Pub. L. 93-314, § 1(a)).
- "Historical and Revision Notes" and "Amendments" notes match the OLRC XML's `<notes>` block exactly.
- `enacted_date` (1968-10-22) matches the enactment citation exactly.

One already-known issue was observed: `last_modified_date` returns `1974-01-01` instead of the actual amendment date `1974-06-08`. This is the same systemic bug already filed in issues #466, #483, #491, #510, #538, and #548 — **not re-filed** to avoid further duplication. Notably, a correct fix for this already exists in PR #469 (opened 2026-05-27) but has not been merged, which is why this keeps recurring.

## Test plan

- [x] Fetched `/api/v1/revisions/latest`, `/api/v1/titles`, `/api/v1/titles/44/structure`, `/api/v1/sections/44/910` from the CWLB backend
- [x] Downloaded and diffed against `xml_usc44@113-21.zip` from uscode.house.gov for the matching release point
- [x] Checked existing GitHub issues/PRs for duplicates before deciding not to file a new issue
- [x] No new bug filed — recording result in `docs/test-status.md` per routine instructions


---
_Generated by [Claude Code](https://claude.ai/code/session_014xxgyuWR7yQjnWKr1DqhZG)_