### PR TITLE
fix: preserve inline footnoteRef markers in section text instead of dropping them

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -878,8 +878,14 @@ class USLMParser:
         # Build full citation
         full_citation = f"{title_number} U.S.C. § {section_number}"
 
-        # Extract text content (flattened for backwards compatibility)
+        # Extract text content (flattened for backwards compatibility).
+        # Inline footnote markers (e.g. "[1]") are included by
+        # _itertext_skip_footnotes; footnote body texts are collected separately
+        # and appended so they are accessible without requiring a schema change.
         text_content = self._extract_section_text(section_elem)
+        footnote_texts = self._collect_footnote_texts(section_elem)
+        if footnote_texts:
+            text_content = text_content + " " + " ".join(footnote_texts)
 
         # Extract structured subsections from XML
         subsections = self._extract_subsections(section_elem)
@@ -1044,7 +1050,11 @@ class USLMParser:
         ) -> Generator[str, None, None]:
             tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
             if strip_footnotes:
+                # Include inline footnote marker as [N] rather than skipping.
                 if tag == "ref" and el.get("class", "") == "footnoteRef":
+                    ref_num = (el.text or "").strip()
+                    if ref_num:
+                        yield f"[{ref_num}]"
                     return
                 if tag == "note" and el.get("type", "") == "footnote":
                     return
@@ -1068,11 +1078,22 @@ class USLMParser:
 
     @staticmethod
     def _itertext_skip_footnotes(elem: etree._Element) -> Generator[str, None, None]:
-        """Like elem.itertext() but skips footnote refs and notes."""
+        """Like elem.itertext() but preserves inline footnote markers and skips note bodies.
+
+        For ``<ref class="footnoteRef">`` elements, yields a bracketed marker like
+        ``[1]`` so the footnote reference number appears in the extracted text.
+        For ``<note type="footnote">`` elements, the body text is skipped inline
+        (callers that need the full footnote text should call
+        ``_collect_footnote_texts()`` separately).
+        """
         tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
-        # Skip footnote reference links and footnote note bodies
+        # Footnote reference link: include the marker number as [N].
         if tag == "ref" and elem.get("class", "") == "footnoteRef":
+            ref_num = (elem.text or "").strip()
+            if ref_num:
+                yield f"[{ref_num}]"
             return
+        # Footnote note body: skip entirely (avoid injecting note prose inline).
         if tag == "note" and elem.get("type", "") == "footnote":
             return
         if elem.text:
@@ -1081,6 +1102,26 @@ class USLMParser:
             yield from USLMParser._itertext_skip_footnotes(child)
             if child.tail:
                 yield child.tail
+
+    @staticmethod
+    def _collect_footnote_texts(section_elem: etree._Element) -> list[str]:
+        """Return a list of footnote body texts from ``<note type="footnote">`` elements.
+
+        These elements are typically siblings of ``<ref class="footnoteRef">``
+        inside a subsection.  Their prose is excluded from inline text extraction
+        by ``_itertext_skip_footnotes``; this method gathers them so callers can
+        append the footnote bodies to ``text_content`` or surface them separately.
+        """
+        footnote_texts: list[str] = []
+        for note_elem in section_elem.iter():
+            note_tag = (
+                note_elem.tag.split("}")[-1] if "}" in note_elem.tag else note_elem.tag
+            )
+            if note_tag == "note" and note_elem.get("type", "") == "footnote":
+                text = "".join(note_elem.itertext()).strip()
+                if text:
+                    footnote_texts.append(text)
+        return footnote_texts
 
     def _extract_section_text(self, section_elem: etree._Element) -> str:
         """Extract the full text content of a section."""

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -623,9 +623,7 @@ class TestUSLMParser:
             "<p> inside <content> must be promoted to section-level continuation"
         )
 
-    def test_footnote_ref_marker_preserved_in_content(
-        self, parser: USLMParser
-    ) -> None:
+    def test_footnote_ref_marker_preserved_in_content(self, parser: USLMParser) -> None:
         """Inline footnoteRef markers appear as [N] in subsection content.
 
         Regression test for Issue #533: 21 U.S.C. § 1054 has a

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -623,6 +623,66 @@ class TestUSLMParser:
             "<p> inside <content> must be promoted to section-level continuation"
         )
 
+    def test_footnote_ref_marker_preserved_in_content(
+        self, parser: USLMParser
+    ) -> None:
+        """Inline footnoteRef markers appear as [N] in subsection content.
+
+        Regression test for Issue #533: 21 U.S.C. § 1054 has a
+        <ref class="footnoteRef"> immediately after the (a) num marker.
+        Previously the marker was silently dropped; now it appears as [1]
+        in the extracted content text.
+        """
+        xml = """<subsection xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t21/s1054/a">
+          <num value="a">(a)</num>
+          <content>
+            <ref class="footnoteRef" idref="fn001">1</ref>
+            <note type="footnote" id="fn001">1 So in original. No subsec. (b) has been enacted.</note>
+            Not later than March 1 of each year following December 29, 1970,
+            the Secretary shall submit to Congress a report.
+          </content>
+        </subsection>"""
+        elem = etree.fromstring(xml)
+        result = parser._parse_subsection(elem, "subsection")
+
+        # The footnote ref marker must appear in content as [1]
+        assert "[1]" in result.content, (
+            "Footnote ref marker [1] must be preserved in subsection content"
+        )
+        # The main provision text must also be present
+        assert "Not later than March 1" in result.content
+        # The footnote note body text must NOT appear inline in content
+        assert "So in original" not in result.content
+
+    def test_footnote_body_texts_collected_from_section(
+        self, parser: USLMParser
+    ) -> None:
+        """_collect_footnote_texts returns body text from <note type='footnote'> elements.
+
+        Regression test for Issue #533: footnote body text was silently dropped
+        from text_content; now it is accessible via _collect_footnote_texts.
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t21/s1054">
+          <num value="1054">§ 1054.</num>
+          <heading>Annual reports</heading>
+          <subsection identifier="/us/usc/t21/s1054/a">
+            <num value="a">(a)</num>
+            <content>
+              <ref class="footnoteRef" idref="fn001">1</ref>
+              <note type="footnote" id="fn001">1 So in original. No subsec. (b) has been enacted.</note>
+              Not later than March 1 of each year, the Secretary shall report.
+            </content>
+          </subsection>
+        </section>"""
+        elem = etree.fromstring(xml)
+        footnotes = parser._collect_footnote_texts(elem)
+
+        assert len(footnotes) == 1
+        assert "So in original" in footnotes[0]
+        assert "No subsec. (b) has been enacted" in footnotes[0]
+
 
 class TestToTitleCase:
     """Tests for to_title_case function."""


### PR DESCRIPTION
## Summary

**Bug**: `<ref class="footnoteRef">` elements were silently dropped by `_itertext_skip_footnotes`, causing inline footnote markers to disappear from provision text. For 21 U.S.C. § 1054, this meant `provisions[0].content` read `(a) Not later than March 1...` instead of `(a)[1] Not later than March 1...`. The footnote body text from `<note type="footnote">` was also silently dropped from `text_content`.

**Fix** (parser-only; no schema migrations required):

- **`_itertext_skip_footnotes`**: changed `<ref class="footnoteRef">` handling from a silent `return` to yielding `[N]` (e.g. `[1]`), so the footnote marker appears inline in provision content.  
- **`_get_text_content_excluding`**: applied the same `[N]` logic for consistency in the continuation-in-content extraction path.  
- **`_collect_footnote_texts`** (new static method): walks a section element and collects body text from all `<note type="footnote">` elements.  
- **`_parse_section`**: calls `_collect_footnote_texts` after building `text_content` and appends any footnote body texts to `text_content`, so the full footnote prose is accessible without a new DB column.

## Before / After

**Before:**
```
provisions[0].content = "(a) Not later than March 1 of each year following December 29, 1970, ..."
text_content = "(a) Not later than March 1 ..."   # footnote body lost
```

**After:**
```
provisions[0].content = "(a)[1] Not later than March 1 of each year following December 29, 1970, ..."
text_content = "(a)[1] Not later than March 1 ... 1 So in original. No subsec. (b) has been enacted."
```

## Tests added

Two new regression tests in `tests/pipeline/test_parser.py`:
- `test_footnote_ref_marker_preserved_in_content` — verifies `[1]` appears in subsection content and footnote body text does not appear inline.
- `test_footnote_body_texts_collected_from_section` — verifies `_collect_footnote_texts` returns the note body text.

Closes #533

---
_Generated by [Claude Code](https://claude.ai/code/session_017L5AhcbwPbTLXfkAnUuf7a)_