### PR TITLE
fix: don't split note paragraphs mid-sentence at legal abbreviation periods

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1150,7 +1150,7 @@ def _indent_block_quotes(
 # normalize_note_content() codepath mis-renders these headers.
 PARAGRAPH_LINE_HEADERS = {
     "Amendments",
-    "References In Text",
+    "References in Text",
 }
 
 

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -101,6 +101,10 @@ LEGAL_ABBREVIATIONS = {
     "cl.",
     "Para.",
     "para.",
+    "Subsec.",  # Subsection (e.g., "referred to in subsec. (c)(3)")
+    "subsec.",
+    "Subsecs.",  # Plural subsection (e.g., "referred to in subsecs. (b), (c)")
+    "subsecs.",
     "Subch.",
     "subch.",
     "Pt.",
@@ -1139,12 +1143,29 @@ def _indent_block_quotes(
     return result
 
 
-def _amendment_lines(raw_content: str) -> list[ParsedLine]:
-    """Fast path for Amendments notes: split on newlines, skip sentence detection.
+# Note headers whose paragraphs are already complete, self-contained statements
+# (citation/cross-reference prose, year-prefixed amendment entries) and so should
+# bypass sentence-boundary splitting in favor of a straight one-paragraph-per-line
+# mapping. See _paragraph_lines() docstring for why the general-purpose
+# normalize_note_content() codepath mis-renders these headers.
+PARAGRAPH_LINE_HEADERS = {
+    "Amendments",
+    "References In Text",
+}
 
-    Amendment text consists of year-prefixed entries ("1988—Pub. L. 100–568 …"),
-    one per line, so sentence-boundary detection in normalize_note_content adds
-    no value while costing ~98× more than a plain newline split.
+
+def _paragraph_lines(raw_content: str) -> list[ParsedLine]:
+    """One line per source <p>: split on paragraph breaks, skip sentence detection.
+
+    Used for note categories whose paragraphs are already complete, self-contained
+    statements — e.g. "Amendments" entries ("1988—Pub. L. 100–568 …") and
+    "References in Text" entries (citation/cross-reference prose). Running these
+    through normalize_note_content's sentence-boundary detector would (a) fragment
+    a paragraph mid-sentence whenever it contains an abbreviation outside
+    LEGAL_ABBREVIATIONS (e.g. "subsecs."), and (b) insert a spurious blank
+    ParsedLine for the paragraph break itself, since that codepath always renders
+    [PARA] markers as a separating blank line. Splitting on paragraph boundaries
+    directly avoids both problems and is ~98x cheaper than sentence splitting.
     """
     cleaned = re.sub(r"\[NH\].*?\[/NH\]", "", raw_content, flags=re.DOTALL)
     cleaned = re.sub(r"\[/NH\]", "", cleaned)
@@ -1494,8 +1515,8 @@ def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
         notes.notes.append(
             SectionNote(
                 header=header,
-                lines=_amendment_lines(raw_content)
-                if header == "Amendments"
+                lines=_paragraph_lines(raw_content)
+                if header in PARAGRAPH_LINE_HEADERS
                 else normalize_note_content(raw_content),
                 category=category,
             )
@@ -1649,8 +1670,8 @@ def _parse_editorial_notes(raw_notes: str, notes: SectionNotes) -> None:
             notes.notes.append(
                 SectionNote(
                     header=header,
-                    lines=_amendment_lines(raw_content)
-                    if header == "Amendments"
+                    lines=_paragraph_lines(raw_content)
+                    if header in PARAGRAPH_LINE_HEADERS
                     else normalize_note_content(raw_content),
                     category=NoteCategory.EDITORIAL,
                 )

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1672,16 +1672,29 @@ class USLMParser:
                     header_text = text.rstrip(".")
                     parts.append(f"[H1]{header_text}[/H1]")
                 elif tag == "i":
-                    # Italic text might be a sub-header if followed by ".—"
-                    # But NOT if it's a case citation (contains " v. ")
-                    # or other inline emphasis (Latin terms, etc.)
+                    # Italic text is a sub-header only when it is followed
+                    # immediately by ".—" (an em-dash introducer), e.g.:
+                    #   <i>Reproduction</i>.—The right to reproduce.
+                    # If the tail does NOT start with ".—" the element is
+                    # inline formatting (case name, date, emphasis) and must
+                    # be kept as plain text so the surrounding sentence is
+                    # not fragmented. Also exclude known case-citation
+                    # patterns (" v. ") and common Latin phrases.
                     inline_latin = {"et seq", "et al", "supra", "infra", "id"}
                     stripped_text = text.strip().rstrip(".")
-                    if " v. " in text or stripped_text.lower() in inline_latin:
-                        # Case citation or Latin phrase - keep as inline text
+                    tail = el.tail or ""
+                    is_subheader_tail = bool(re.match(r"^\s*\.?\s*—", tail))
+                    if (
+                        " v. " in text
+                        or stripped_text.lower() in inline_latin
+                        or not is_subheader_tail
+                    ):
+                        # Inline text (case citation, date, Latin phrase, or
+                        # mid-sentence emphasis) — keep as plain text
                         parts.append(text)
                     else:
-                        # Mark as potential sub-header for normalizer
+                        # Standalone italic introducer followed by ".—":
+                        # mark as sub-header for the normalizer
                         parts.append(f"[H2]{text}[/H2]")
                 else:
                     parts.append(text)

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2894,15 +2894,15 @@ class TestAmendmentsIndentLevel:
     """
 
     def test_amendment_lines_indent_level_is_one(self) -> None:
-        """_amendment_lines returns lines with indent_level=1, matching peer notes."""
-        from pipeline.olrc.normalized_section import _amendment_lines
+        """_paragraph_lines returns lines with indent_level=1, matching peer notes."""
+        from pipeline.olrc.normalized_section import _paragraph_lines
 
         raw = (
             "[NH]Amendments[/NH] "
             "1954—Act Sept. 3, 1954, brought section into conformity with arbitration "
             "rules of the Federal Rules of Civil Procedure."
         )
-        lines = _amendment_lines(raw)
+        lines = _paragraph_lines(raw)
 
         assert len(lines) > 0
         for line in lines:
@@ -3917,3 +3917,118 @@ class TestAmendmentMidSentencePubLFix:
         # The fifth 1976 entry must have the Subsecs. plural prefix
         fifth_1976 = [a for a in amendments if a.year == 1976][4]
         assert "Subsecs. (d) to (g)." in fifth_1976.description
+
+
+class TestReferencesInTextAbbreviationPeriods:
+    """Regression tests for issue #551: 17 U.S.C. § 1201 note paragraphs split at 'subsecs.' period.
+
+    The OLRC source renders each "References in Text" note entry as a complete
+    paragraph, but the parser was splitting lines mid-sentence at "subsecs." because
+    that abbreviation was missing from LEGAL_ABBREVIATIONS and the sentence-boundary
+    detector treated the period in "subsecs. (a)(1)(A)" as a sentence end.
+    """
+
+    def _parse_editorial_notes_xml(self, xml_snippet: str) -> object:
+        from lxml import etree
+
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+        from pipeline.olrc.parser import USLMParser
+
+        notes_elem = etree.fromstring(xml_snippet)
+        raw = USLMParser()._get_notes_text_content(notes_elem)
+        notes = SectionNotes()
+        _parse_notes_structure(raw, notes)
+        return notes
+
+    def test_subsecs_abbreviation_not_split_via_normalize_note_content(self) -> None:
+        """normalize_note_content must not treat 'subsecs.' as a sentence boundary.
+
+        This is the root cause: 'subsecs.' was not in LEGAL_ABBREVIATIONS so
+        '_is_sentence_boundary' returned True for the period in 'subsecs. (a)(1)(A)',
+        cutting the paragraph mid-sentence.
+        """
+        text = (
+            "The date of the enactment of this chapter, referred to in subsecs. "
+            "(a)(1)(A), (g)(5), and (k)(1), (4)(E), is the date of enactment of "
+            "Pub. L. 105-304, which was approved Oct. 28, 1998."
+        )
+        lines = normalize_note_content(text)
+
+        assert len(lines) == 1, (
+            f"Expected 1 line but got {len(lines)}: {[line.content for line in lines]}"
+        )
+        assert lines[0].content == text
+
+    def test_subsec_singular_abbreviation_not_split(self) -> None:
+        """Singular 'subsec.' abbreviation also should not cause a split."""
+        text = (
+            "Section 802(25) of this title, referred to in subsec. (c)(3), "
+            "was redesignated section 802(26) of this title."
+        )
+        lines = normalize_note_content(text)
+
+        assert len(lines) == 1, (
+            f"Expected 1 line but got {len(lines)}: {[line.content for line in lines]}"
+        )
+        assert lines[0].content == text
+
+    def test_17_usc_1201_references_in_text_two_paragraphs_two_lines(self) -> None:
+        """17 U.S.C. § 1201 References in Text: each source <p> maps to exactly one line.
+
+        The OLRC source has two distinct note paragraphs. Before the fix these were
+        split into multiple fragments because 'subsecs.' caused mid-sentence cuts.
+        After the fix each source <p> must produce exactly one lines[] entry.
+        """
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0" type="uscNote">'
+            '<note class="editorial">'
+            "<heading>Editorial Notes</heading>"
+            '<note topic="referencesInText">'
+            "<heading>References in Text</heading>"
+            '<p class="indent0">The date of the enactment of this chapter, '
+            "referred to in subsecs. (a)(1)(A), (g)(5), and (k)(1), (4)(E), "
+            "is the date of enactment of "
+            '<ref href="/us/pl/105/304">Pub. L. 105–304</ref>, which was '
+            "approved Oct. 28, 1998.</p>"
+            '<p class="indent0">The Computer Fraud and Abuse Act of 1986, '
+            "referred to in subsecs. (g)(2)(D) and (j)(2), is "
+            '<ref href="/us/pl/99/474">Pub. L. 99–474</ref>, Oct. 16, 1986, '
+            "100 Stat. 1213, which is classified principally to chapter 47 "
+            "of Title 18.</p>"
+            "</note>"
+            "</note>"
+            "</notes>"
+        )
+
+        notes = self._parse_editorial_notes_xml(xml)
+
+        ref_notes = [n for n in notes.notes if n.header == "References in Text"]
+        assert len(ref_notes) == 1, (
+            f"Expected 1 References in Text note, got {len(ref_notes)}"
+        )
+        lines = ref_notes[0].lines
+
+        # Exactly 2 lines -- one per source <p> -- no spurious blank lines or splits.
+        non_empty = [line for line in lines if line.content]
+        assert len(non_empty) == 2, (
+            f"Expected 2 non-empty lines but got {len(non_empty)}: "
+            f"{[line.content for line in lines]}"
+        )
+
+        # First line must contain the full first paragraph, not be cut at "subsecs."
+        first = non_empty[0].content
+        assert "subsecs. (a)(1)(A), (g)(5), and (k)(1), (4)(E)" in first, (
+            f"First line was cut at 'subsecs.': {first!r}"
+        )
+        assert "Pub. L. 105" in first
+        assert first.endswith("1998.")
+
+        # Second line must contain the full second paragraph.
+        second = non_empty[1].content
+        assert "subsecs. (g)(2)(D) and (j)(2)" in second, (
+            f"Second line was cut at 'subsecs.': {second!r}"
+        )
+        assert "Computer Fraud and Abuse Act of 1986" in second


### PR DESCRIPTION
## Summary

**Bug**: Note paragraphs in "References In Text" notes (and potentially other note types) were being incorrectly split mid-sentence at the period in legal abbreviations like `subsecs.` and `subsec.`. For example, 17 U.S.C. § 1201's References In Text note was split:

- L1: `The date of the enactment of this chapter, referred to in subsecs.` ← cut off
- L2: `(a)(1)(A), (g)(5), and (k)(1), (4)(E), is the date of enactment of Pub. L. 105–304...`

when it should be a single paragraph.

**Root causes fixed:**

1. **`LEGAL_ABBREVIATIONS` missing subsection abbreviations** (`normalized_section.py`): `subsec.`, `subsecs.`, `Subsec.`, `Subsecs.` were not in the set, so sentence-boundary detection treated the trailing period as a sentence end. Added all four variants.

2. **"References In Text" notes ran through sentence splitter** (`normalized_section.py`): The fast-path that skips sentence detection (previously called `_amendment_lines`, now `_paragraph_lines`) only applied to `"Amendments"` notes. References In Text entries are also complete self-contained paragraphs per source `<p>` element. Extended the fast-path to cover `"References In Text"` as well via a `PARAGRAPH_LINE_HEADERS` set, preventing the sentence detector from fragmenting them.

3. **Inline italics promoted to sub-headers too aggressively** (`parser.py`): Italic elements were being marked as `[H2]` sub-headers even when they appeared mid-sentence. Fixed to only promote italics that are immediately followed by `.—` (an em-dash introducer), which is the reliable signal for a standalone sub-header. All other italic spans (case citations, dates, emphasis) are kept as plain inline text.

## Before / After (17 U.S.C. § 1201 — "References In Text")

**Before:**
```
L1: The date of the enactment of this chapter, referred to in subsecs.
L2: (a)(1)(A), (g)(5), and (k)(1), (4)(E), is the date of enactment of Pub. L. 105–304, which was approved Oct. 28, 1998.
```

**After:**
```
L1: The date of the enactment of this chapter, referred to in subsecs. (a)(1)(A), (g)(5), and (k)(1), (4)(E), is the date of enactment of Pub. L. 105–304, which was approved Oct. 28, 1998.
```

Closes #551

---
_Generated by [Claude Code](https://claude.ai/code/session_017L5AhcbwPbTLXfkAnUuf7a)_