### PR TITLE
fix: capture lone statutory note when heading is encoded as a &lt;b&gt; element

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -359,6 +359,7 @@ CITATION_PARSE_PATTERN = re.compile(
 # (Previously compiled inside function bodies, causing ~1026 re._compile calls per
 # _parse_notes_structure invocation due to Python's 512-entry LRU cache churn.)
 _NH_HEADER_PATTERN = re.compile(r"\[NH\](.*?)\[/NH\]", re.DOTALL)
+_H1_HEADER_PATTERN = re.compile(r"\[H1\](.*?)\[/H1\]", re.DOTALL)
 _REPORT_PATTERN = re.compile(
     r"((?:House|Senate)\s+Report\s+No\.\s*[\d–-]+)",
     re.IGNORECASE,
@@ -1618,25 +1619,36 @@ def _parse_statutory_notes(raw_notes: str, notes: SectionNotes) -> None:
     # cross-references that don't lend themselves to structured extraction.
     notes.short_titles = _parse_short_titles(statutory_text)
 
-    # Find note headers using [NH]...[/NH] markers from XML parser
-    # These markers are added for <heading class="smallCaps"> elements
+    # Labels that are section-level cross-headings, not individual note headers.
+    # These appear in both [NH] and [H1] marker scans and must be skipped.
+    skip_headers = {
+        "Editorial Notes",
+        "Statutory Notes And Related Subsidiaries",
+        "Executive Documents",
+    }
+
+    # Find note headers using [NH]...[/NH] markers from XML parser.
+    # These markers are added for <heading> elements (with or without class="smallCaps").
 
     # Find all headers and their positions
     header_positions: list[tuple[int, int, str]] = []
     for match in _NH_HEADER_PATTERN.finditer(statutory_text):
         header = match.group(1).strip()
-        # Skip if too short or a fragment
-        if len(header.split()) < 2:
-            continue
-        # Skip cross-heading markers (Editorial Notes, Statutory Notes, Executive Documents)
-        skip_headers = {
-            "Editorial Notes",
-            "Statutory Notes And Related Subsidiaries",
-            "Executive Documents",
-        }
-        if header in skip_headers:
+        # Skip if empty or a cross-heading label
+        if not header or header in skip_headers:
             continue
         header_positions.append((match.start(), match.end(), header))
+
+    # Fallback: if no [NH] headers found, scan for [H1]...[/H1] markers.
+    # These are emitted for <b> elements used as note sub-headings in some
+    # USLM XML structures (e.g. a lone "Effective Date" note whose heading is
+    # encoded as a <b> rather than a <heading> element).
+    if not header_positions:
+        for match in _H1_HEADER_PATTERN.finditer(statutory_text):
+            header = match.group(1).strip()
+            if not header or header in skip_headers:
+                continue
+            header_positions.append((match.start(), match.end(), header))
 
     # Deduplicate and extract content
     seen_headers: set[str] = set()
@@ -1662,6 +1674,36 @@ def _parse_statutory_notes(raw_notes: str, notes: SectionNotes) -> None:
                     category=NoteCategory.STATUTORY,
                 )
             )
+
+    # Final fallback: if no headers were found via any marker, the statutory
+    # block may consist of a single note whose heading appears as plain text
+    # immediately before the first paragraph break (e.g. "Effective Date" as
+    # tail text of a <b> cross-heading element).  Split on the first double-
+    # newline: if the leading fragment looks like a short note title (<=6 words,
+    # no sentence-ending punctuation), treat it as the header.
+    if not header_positions:
+        stripped = _strip_note_markers(statutory_text)
+        if not stripped:
+            return
+        # Split at the first paragraph break
+        parts = re.split(r"\n\n", stripped, maxsplit=1)
+        if len(parts) == 2:
+            candidate_header = parts[0].strip()
+            note_body = parts[1].strip()
+            words = candidate_header.split()
+            is_header_like = (
+                1 <= len(words) <= 6
+                and not candidate_header.endswith(".")
+                and not candidate_header.endswith(",")
+            )
+            if is_header_like and len(note_body) > 30:
+                notes.notes.append(
+                    SectionNote(
+                        header=candidate_header.title(),
+                        lines=normalize_note_content(note_body),
+                        category=NoteCategory.STATUTORY,
+                    )
+                )
 
 
 def _separate_notes_from_text(text: str) -> tuple[str, SectionNotes]:

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1929,7 +1929,10 @@ class TestStatutoryNotesHeaderParsing:
         """
         from lxml import etree
 
-        from pipeline.olrc.normalized_section import SectionNotes, _parse_notes_structure
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
         from pipeline.olrc.parser import USLMParser
 
         # Mirrors the USLM XML structure for 21 U.S.C. ss 1054 as described in Issue #534.

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -1867,6 +1867,90 @@ class TestStatutoryNotesHeaderParsing:
         first_text = " ".join(line.content for line in first_note.lines)
         assert "congressional defense committees" in first_text
 
+    def test_single_statutory_note_h1_header(self) -> None:
+        """Regression for Issue #534: lone note encoded with [H1] heading marker.
+
+        When a USLM section uses <b>Effective Date</b> as the sub-heading for
+        a statutory note (producing [H1]...[/H1] rather than [NH]...[/NH]),
+        _parse_statutory_notes must still capture the note via the [H1] fallback.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_statutory_notes,
+        )
+
+        raw_notes = (
+            "[H1]Statutory Notes and Related Subsidiaries[/H1] "
+            "[H1]Effective Date[/H1]\n\n"
+            "For effective date of this section, see section 29 of Pub. L. 91-597, "
+            "set out as a note under section 1031 of this title."
+        )
+        notes = SectionNotes()
+        _parse_statutory_notes(raw_notes, notes)
+        assert len(notes.notes) == 1
+        assert notes.notes[0].header == "Effective Date"
+        assert notes.notes[0].category.value == "statutory"
+        all_text = " ".join(line.content for line in notes.notes[0].lines)
+        assert "Pub. L. 91-597" in all_text
+
+    def test_single_statutory_note_plain_text_header(self) -> None:
+        """Regression for Issue #534: lone note with header as plain tail text.
+
+        21 U.S.C. ss 1054's XML has "Effective Date" as tail text of the
+        <b>Statutory Notes and Related Subsidiaries</b> element with no marker.
+        The plain-text fallback must capture it when no [NH] or [H1] markers exist.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_statutory_notes,
+        )
+
+        raw_notes = (
+            "[H1]Statutory Notes and Related Subsidiaries[/H1] "
+            "Effective Date\n\n"
+            "For effective date of this section, see section 29 of Pub. L. 91-597, "
+            "set out as a note under section 1031 of this title."
+        )
+        notes = SectionNotes()
+        _parse_statutory_notes(raw_notes, notes)
+        assert len(notes.notes) == 1
+        assert notes.notes[0].header == "Effective Date"
+        assert notes.notes[0].category.value == "statutory"
+        all_text = " ".join(line.content for line in notes.notes[0].lines)
+        assert "Pub. L. 91-597" in all_text
+
+    def test_full_xml_pipeline_issue_534(self) -> None:
+        """End-to-end regression for Issue #534: full XML to parsed notes pipeline.
+
+        Confirms that the complete pipeline (XML parsing -> raw text ->
+        _parse_notes_structure) correctly captures the lone Effective Date
+        statutory note that immediately follows the cross-heading in the USLM
+        XML for 21 U.S.C. ss 1054.
+        """
+        from lxml import etree
+
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_notes_structure
+        from pipeline.olrc.parser import USLMParser
+
+        # Mirrors the USLM XML structure for 21 U.S.C. ss 1054 as described in Issue #534.
+        xml = (
+            "<notes>"
+            "<b>Statutory Notes and Related Subsidiaries</b>"
+            "Effective Date"
+            "<p>For effective date of this section, see section 29 of "
+            "Pub. L. 91-597, set out as a note under section 1031 of this title.</p>"
+            "</notes>"
+        )
+        notes_elem = etree.fromstring(xml)
+        raw = USLMParser()._get_notes_text_content(notes_elem)
+        notes = SectionNotes()
+        _parse_notes_structure(raw, notes)
+        statutory = [n for n in notes.notes if n.category.value == "statutory"]
+        assert len(statutory) == 1, f"Expected 1 statutory note, got {len(statutory)}"
+        assert statutory[0].header == "Effective Date"
+        body = " ".join(line.content for line in statutory[0].lines)
+        assert "Pub. L. 91-597" in body
+
 
 class TestFlatNotesParser:
     """Tests for _parse_flat_notes — fallback for sections without category wrappers.


### PR DESCRIPTION
## Summary

**Bug**: `GET /api/v1/sections/21/1054` returned no statutory notes despite the OLRC XML containing an "Effective Date" note. The authoritative XML has:

```xml
<b>Statutory Notes and Related Subsidiaries</b>
Effective Date
<p>For effective date of this section, see section 29 of Pub. L. 91–597...</p>
```

The "Effective Date" heading in this structure is encoded as tail text of a `<b>` cross-heading element (not a `<heading>` element), so the parser emitted a `[H1]` marker rather than the `[NH]` marker it looks for. With no `[NH]` headers found, the statutory block was silently dropped.

**Fix** (`normalized_section.py`):

1. **`[H1]` fallback scan**: When `_parse_statutory_notes()` finds no `[NH]` headers in the statutory block, it now scans for `[H1]...[/H1]` markers (emitted for `<b>` elements) as a fallback. The new `_H1_HEADER_PATTERN` regex is compiled at module level alongside the existing `_NH_HEADER_PATTERN`.

2. **Plain-text heading fallback**: If neither `[NH]` nor `[H1]` markers are found, the parser tries a structural split: if the text before the first double-newline looks like a short note title (1–6 words, no trailing punctuation) followed by substantive body text, it is treated as the note header and the body is parsed as a single statutory note.

3. **Tightened skip-headers guard**: The `skip_headers` set is now extracted outside the header-scan loops (shared by both `[NH]` and `[H1]` passes), and the too-short guard was simplified from `len(header.split()) < 2` to a falsy check.

## Before / After (21 U.S.C. § 1054)

**Before:**
```json
{"notes": {"notes": [
  {"header": "References In Text", "category": "editorial"},
  {"header": "Amendments", "category": "editorial"}
]}}
```

**After:**
```json
{"notes": {"notes": [
  {"header": "References In Text", "category": "editorial"},
  {"header": "Amendments", "category": "editorial"},
  {"header": "Effective Date", "category": "statutory", "lines": [{"text": "For effective date of this section, see section 29 of Pub. L. 91–597..."}]}
]}}
```

Closes #534

---
_Generated by [Claude Code](https://claude.ai/code/session_017L5AhcbwPbTLXfkAnUuf7a)_