### PR TITLE
fix: don't split amendment paragraphs on mid-sentence Pub. L. cross-references

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -365,14 +365,26 @@ _REPORT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _YEAR_PATTERN = re.compile(r"(\d{4})\s*[—–-]\s*", re.MULTILINE)
-_PUB_L_PATTERN = re.compile(
-    r"((?:Subsec\.?\s*"  # "Subsec." or "Subsec"
-    r"(?:\([^)]+\))+"  # One or more parenthesized markers like (c)(1)
-    r"(?:\s*,\s*(?:\([^)]+\))+)*"  # Optional comma-separated markers like , (2)(A)
-    r"\.?\s*)?)"  # Optional trailing period and whitespace
+# Per-paragraph pattern for amendment parsing.
+#
+# Amendment notes in USLM XML have each entry in a separate <p> element.  After
+# XML processing, <p> boundaries become \n\n separators, so _parse_amendments
+# first splits a year-block into paragraphs and then applies this pattern once
+# per paragraph.
+#
+# Because each paragraph is a single amendment entry, the pattern does NOT
+# need to look ahead for the next "Pub. L." to know where an entry ends — it
+# simply captures everything after the law citation to end-of-string.  This
+# avoids the previous bug where a mid-sentence cross-reference like
+# "…without reference to amendment by Pub. L. 94–171." was mistakenly
+# treated as the start of a new entry.
+#
+# The optional leading group handles both singular ("Subsec.") and plural
+# ("Subsecs.") forms and arbitrary range expressions like "(d) to (g)".
+_PUB_L_PARA_PATTERN = re.compile(
+    r"^(Subsecs?\.\s+.*?)?"              # Optional "Subsec." / "Subsecs." prefix (lazy)
     r"(Pub\.\s*L\.\s*(\d+)[—–-](\d+))"  # Pub. L. reference
-    r"(.*?)"  # Description (including any text after)
-    r"(?=Subsec\.?\s*(?:\([^)]+\))+|Pub\.\s*L\.\s*\d+[—–-]\d+|$)",  # Until next Subsec. or Pub. L. or end
+    r"(.*)",                             # Rest of paragraph
     re.DOTALL,
 )
 
@@ -1166,9 +1178,9 @@ def _parse_amendments(text: str) -> list[Amendment]:
     "2010—Pub. L. 111-203 substituted 'Bureau' for 'Board'."
     "1976—Subsec. (e). Pub. L. 94-239 substituted provisions..."
 
-    Multiple amendments can occur in the same year:
-    "1990— Pub. L. 101–650 substituted...
-     Pub. L. 101–318 substituted..."
+    Multiple amendments in the same year appear as separate paragraphs
+    (each a distinct <p> element in the USLM XML, separated by \n\n):
+    "1990—Pub. L. 101–650 substituted...\n\nPub. L. 101–318 substituted..."
 
     Args:
         text: The amendments subsection text.
@@ -1190,49 +1202,58 @@ def _parse_amendments(text: str) -> list[Amendment]:
 
         year_block = text[start:end].strip()
 
-        # Find all Pub. L. references within this year block; save the list so we
-        # can reuse it below without running finditer a second time (Finding 2).
-        matches = list(_PUB_L_PATTERN.finditer(year_block))
+        # Split the year block into paragraphs at double-newlines.
+        # In USLM XML every amendment <p> element is separated from the next by a
+        # [PARA] marker (\u2192 \n\n), so each paragraph is exactly one amendment entry.
+        # Splitting first prevents _PUB_L_PARA_PATTERN from treating mid-sentence
+        # Pub. L. cross-references (e.g. "\u2026by Pub. L. 94\u2013171.") as new entries.
+        paragraphs = [p.strip() for p in re.split(r"\n\n+", year_block) if p.strip()]
+        if not paragraphs:
+            paragraphs = [year_block] if year_block else []
 
-        for pub_match in matches:
-            subsec_prefix = (pub_match.group(1) or "").strip()
-            public_law_text = pub_match.group(2)
-            congress = int(pub_match.group(3))
-            law_number = int(pub_match.group(4))
-            after_text = pub_match.group(5)
+        found_any = False
+        for para in paragraphs:
+            pub_match = _PUB_L_PARA_PATTERN.match(para)
+            if pub_match:
+                subsec_prefix = (pub_match.group(1) or "").strip()
+                public_law_text = pub_match.group(2)
+                congress = int(pub_match.group(3))
+                law_number = int(pub_match.group(4))
+                after_text = pub_match.group(5)
 
-            # Build description: subsec prefix + Pub. L. + rest
-            if subsec_prefix:
-                description = f"{subsec_prefix} {public_law_text}{after_text}"
-            else:
-                description = f"{public_law_text}{after_text}"
+                # Build description: subsec prefix + Pub. L. + rest
+                if subsec_prefix:
+                    description = f"{subsec_prefix} {public_law_text}{after_text}"
+                else:
+                    description = f"{public_law_text}{after_text}"
 
-            # Clean up description - normalize whitespace (handles multiple spaces)
-            description = " ".join(description.split())
+                # Clean up description - normalize whitespace (handles multiple spaces)
+                description = " ".join(description.split())
 
-            # Fix whitespace inside quotes (from XML date element spacing)
-            # e.g., '" December 31, 2021 "' -> '"December 31, 2021"'
-            # Match quoted content and strip leading/trailing spaces inside quotes
-            # Handle both straight quotes (") and curly quotes (" ")
-            description = re.sub(r'"(\s*)(.*?)(\s*)"', r'"\2"', description)
-            # Curly quotes: " (U+201C left) and " (U+201D right)
-            description = re.sub(
-                r"\u201c(\s*)(.*?)(\s*)\u201d", "\u201c\\2\u201d", description
-            )
-
-            law = ParsedPublicLaw(congress=congress, law_number=law_number)
-            amendments.append(
-                Amendment(
-                    law=law,
-                    year=year,
-                    description=description,
+                # Fix whitespace inside quotes (from XML date element spacing)
+                # e.g., '" December 31, 2021 "' -> '"December 31, 2021"'
+                # Match quoted content and strip leading/trailing spaces inside quotes
+                # Handle both straight quotes (") and curly quotes (\u201c \u201d)
+                description = re.sub(r'"(\s*)(.*?)(\s*)"', r'"\2"', description)
+                # Curly quotes: \u201c (U+201C left) and \u201d (U+201D right)
+                description = re.sub(
+                    r"\u201c(\s*)(.*?)(\s*)\u201d", "\u201c\\2\u201d", description
                 )
-            )
 
-        # If no Pub. L. found in the block, still record the year with the description
-        if not matches and year_block:
+                law = ParsedPublicLaw(congress=congress, law_number=law_number)
+                amendments.append(
+                    Amendment(
+                        law=law,
+                        year=year,
+                        description=description,
+                    )
+                )
+                found_any = True
+
+        # If no Pub. L. found in any paragraph, still record the year
+        if not found_any and year_block:
             # Try to extract any Pub. L. reference
-            simple_pub_match = re.search(r"Pub\.\s*L\.\s*(\d+)[—–-](\d+)", year_block)
+            simple_pub_match = re.search(r"Pub\.\s*L\.\s*(\d+)[—\u2013-](\d+)", year_block)
             if simple_pub_match:
                 congress = int(simple_pub_match.group(1))
                 law_number = int(simple_pub_match.group(2))

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -382,9 +382,9 @@ _YEAR_PATTERN = re.compile(r"(\d{4})\s*[—–-]\s*", re.MULTILINE)
 # The optional leading group handles both singular ("Subsec.") and plural
 # ("Subsecs.") forms and arbitrary range expressions like "(d) to (g)".
 _PUB_L_PARA_PATTERN = re.compile(
-    r"^(Subsecs?\.\s+.*?)?"              # Optional "Subsec." / "Subsecs." prefix (lazy)
+    r"^(Subsecs?\.\s+.*?)?"  # Optional "Subsec." / "Subsecs." prefix (lazy)
     r"(Pub\.\s*L\.\s*(\d+)[—–-](\d+))"  # Pub. L. reference
-    r"(.*)",                             # Rest of paragraph
+    r"(.*)",  # Rest of paragraph
     re.DOTALL,
 )
 
@@ -1253,7 +1253,9 @@ def _parse_amendments(text: str) -> list[Amendment]:
         # If no Pub. L. found in any paragraph, still record the year
         if not found_any and year_block:
             # Try to extract any Pub. L. reference
-            simple_pub_match = re.search(r"Pub\.\s*L\.\s*(\d+)[—\u2013-](\d+)", year_block)
+            simple_pub_match = re.search(
+                r"Pub\.\s*L\.\s*(\d+)[—\u2013-](\d+)", year_block
+            )
             if simple_pub_match:
                 congress = int(simple_pub_match.group(1))
                 law_number = int(simple_pub_match.group(2))

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3633,3 +3633,129 @@ class TestPrePLAmendmentCitations:
         assert modern.law is not None
         assert modern.law.congress == 106
         assert pre_pl.law is None
+
+
+class TestAmendmentMidSentencePubLFix:
+    """Regression tests for issue #558: amendment parser splits mid-sentence on
+    Pub. L. cross-references, producing spurious and truncated entries.
+
+    Root cause: the old _PUB_L_PATTERN lookahead fired on any 'Pub. L.' string,
+    including cross-references inside sentences.  The fix splits each year-block
+    into paragraphs at double-newlines (one <p> element → one entry) and uses a
+    per-paragraph anchored pattern (_PUB_L_PARA_PATTERN) instead.
+    """
+
+    def test_bug_a_no_split_on_mid_sentence_pub_l_crossref(self) -> None:
+        """Bug A: Pub. L. cross-reference mid-sentence must NOT create a spurious entry.
+
+        13 USC §141 first 1976 paragraph:
+          "Pub. L. 94–521 substituted catchline … without reference to
+           amendment of catchline by Pub. L. 94–171."
+
+        Must produce exactly ONE entry (for Pub. L. 94–521) with the full
+        sentence.  Previously produced two: a truncated entry ending at "by"
+        and a spurious entry for Pub. L. 94–171.
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "1976—Pub. L. 94–521 substituted “Population and other "
+            "census information” for “Population, unemployment, and housing” "
+            "in section catchline, without reference to amendment of catchline "
+            "by Pub. L. 94–171."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1, (
+            f"Expected 1 amendment but got {len(amendments)}: "
+            + str([a.description for a in amendments])
+        )
+        a = amendments[0]
+        assert a.year == 1976
+        assert a.law.congress == 94
+        assert a.law.law_number == 521
+        # Full sentence must be preserved, including the cross-reference law
+        assert "by Pub. L. 94–171" in a.description
+
+    def test_bug_b_subsecs_plural_prefix_captured(self) -> None:
+        """Bug B: 'Subsecs.' (plural) prefix must be captured, not lost.
+
+        13 USC §141 fifth 1976 paragraph:
+          "Subsecs. (d) to (g). Pub. L. 94–521 added subsecs. (d) to (g)."
+
+        Must produce ONE entry with the prefix included in the description.
+        Previously the 'Subsecs.' form was not recognised as a prefix, so the
+        subsection range bled into the *previous* entry and this entry lost it.
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "1976—Subsecs. (d) to (g). Pub. L. 94–521 "
+            "added subsecs. (d) to (g)."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1, (
+            f"Expected 1 amendment but got {len(amendments)}: "
+            + str([a.description for a in amendments])
+        )
+        a = amendments[0]
+        assert a.year == 1976
+        assert a.law.congress == 94
+        assert a.law.law_number == 521
+        assert "Subsecs. (d) to (g)." in a.description
+        assert "added subsecs. (d) to (g)." in a.description
+
+    def test_13_usc_141_full_1976_block_produces_eight_entries(self) -> None:
+        """Regression: 13 USC §141 must produce exactly 8 amendment entries.
+
+        OLRC shows 5 PL 94-521 entries + 2 PL 94-171 entries + 1 PL 85-207
+        entry = 8 total.  Previously produced 9 entries due to Bugs A and B.
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        # Paragraphs separated by \n\n (as produced from separate <p> elements)
+        text = (
+            "1976—"
+            "Pub. L. 94–521 substituted “Population and other census "
+            "information” for “Population, unemployment, and housing” "
+            "in section catchline, without reference to amendment of catchline "
+            "by Pub. L. 94–171.\n\n"
+            "Subsec. (a). Pub. L. 94–521 substituted provisions in subsec. (a).\n\n"
+            "Subsec. (b). Pub. L. 94–521 substituted provisions in subsec. (b).\n\n"
+            "Subsec. (c). Pub. L. 94–521 substituted “the decennial census "
+            "date” for “the census date” wherever appearing.\n\n"
+            "Subsecs. (d) to (g). Pub. L. 94–521 added subsecs. (d) to (g).\n\n"
+            "1975—"
+            "Pub. L. 94–171, §§ 1, 2(a), inserted “;tabulation "
+            "for legislative apportionment” in catchline.\n\n"
+            "Subsec. (c). Pub. L. 94–171, § 1, added subsec. (c).\n\n"
+            "1957—"
+            "Pub. L. 85–207, § 9, substituted catchline and added "
+            "housing provisions."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 8, (
+            f"Expected 8 amendments but got {len(amendments)}: "
+            + str([(a.year, a.law.congress, a.law.law_number) for a in amendments])
+        )
+
+        years = [a.year for a in amendments]
+        assert years.count(1976) == 5
+        assert years.count(1975) == 2
+        assert years.count(1957) == 1
+
+        # All 1976 entries must be attributed to PL 94-521
+        for a in amendments:
+            if a.year == 1976:
+                assert a.law.congress == 94
+                assert a.law.law_number == 521
+
+        # The first 1976 entry must contain the full cross-reference sentence
+        first_1976 = next(a for a in amendments if a.year == 1976)
+        assert "by Pub. L. 94–171" in first_1976.description
+
+        # The fifth 1976 entry must have the Subsecs. plural prefix
+        fifth_1976 = [a for a in amendments if a.year == 1976][4]
+        assert "Subsecs. (d) to (g)." in fifth_1976.description

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3689,10 +3689,7 @@ class TestAmendmentMidSentencePubLFix:
         """
         from pipeline.olrc.normalized_section import _parse_amendments
 
-        text = (
-            "1976—Subsecs. (d) to (g). Pub. L. 94–521 "
-            "added subsecs. (d) to (g)."
-        )
+        text = "1976—Subsecs. (d) to (g). Pub. L. 94–521 added subsecs. (d) to (g)."
         amendments = _parse_amendments(text)
 
         assert len(amendments) == 1, (


### PR DESCRIPTION
## Context

`GET /api/v1/sections/13/141` was returning 9 amendment entries instead of the correct 8. Two bugs in `_parse_amendments` (in `backend/pipeline/olrc/normalized_section.py`) traced to the same root cause: the old `_PUB_L_PATTERN` used a lookahead that split on **any** `Pub. L. X-Y` string, including cross-references that appear mid-sentence.

**Bug A — spurious entry from mid-sentence cross-reference:**
The 1976 paragraph `"Pub. L. 94–521 substituted catchline … without reference to amendment of catchline by Pub. L. 94–171."` was split at the cross-reference `by Pub. L. 94–171`, producing a truncated entry for PL 94-521 and a spurious stub entry for PL 94-171.

**Bug B — `Subsecs.` (plural) prefix not recognised:**
The 1976 paragraph `"Subsecs. (d) to (g). Pub. L. 94–521 added subsecs. (d) to (g)."` had its `Subsecs. (d) to (g).` prefix bleed into the previous entry's description (because `Subsecs.` didn't match the old `Subsec\.?` pattern), and this entry itself became a prefix-less fragment.

## Changes

**`backend/pipeline/olrc/normalized_section.py`**

- Removed `_PUB_L_PATTERN` (the lookahead-based full-block scanner).
- Added `_PUB_L_PARA_PATTERN` — an anchored, per-paragraph pattern with a lazy optional prefix group `(Subsecs?\.\s+.*?)?` that handles both `Subsec.` and `Subsecs.` (and arbitrary range expressions like `(d) to (g)`).
- Updated `_parse_amendments` to **first split each year-block into paragraphs on `\n\n+`** (each USLM XML `<p>` element produces one paragraph), then apply `_PUB_L_PARA_PATTERN` once per paragraph. Because each paragraph is one amendment entry, there is no need to look ahead for the next `Pub. L.` — mid-sentence cross-references are captured in the description, not treated as new entries.

**`backend/tests/pipeline/test_normalized_section.py`**

Added `TestAmendmentMidSentencePubLFix` with three regression tests:
- `test_bug_a_no_split_on_mid_sentence_pub_l_crossref` — verifies Bug A is fixed (one entry, full sentence, cross-ref law preserved in description).
- `test_bug_b_subsecs_plural_prefix_captured` — verifies Bug B is fixed (`Subsecs. (d) to (g).` captured as prefix).
- `test_13_usc_141_full_1976_block_produces_eight_entries` — full 13 USC §141 scenario: exactly 8 entries, correct year/law distribution, correct descriptions.

## Before / After

**Before (9 entries, 2 bugs):**
| Year | Law | Description |
|------|-----|-------------|
| 1976 | PL 94-521 | `…without reference to amendment of catchline by` ← truncated |
| 1976 | PL 94-171 | `Pub. L. 94–171.` ← **spurious** |
| 1976 | PL 94-521 | Subsec. (a) changes |
| 1976 | PL 94-521 | Subsec. (b) changes |
| 1976 | PL 94-521 | `Subsec. (c)… wherever appearing. Subsecs. (d) to (g).` ← bleeds |
| 1976 | PL 94-521 | `Pub. L. 94–521 added subsecs. (d) to (g).` ← fragment |
| 1975 | PL 94-171 | §2(a) catchline |
| 1975 | PL 94-171 | Subsec. (c) |
| 1957 | PL 85-207 | Substituted catchline |

**After (8 entries, matching OLRC):**
| Year | Law | Description |
|------|-----|-------------|
| 1976 | PL 94-521 | `…without reference to amendment of catchline by Pub. L. 94–171.` ← full |
| 1976 | PL 94-521 | Subsec. (a) changes |
| 1976 | PL 94-521 | Subsec. (b) changes |
| 1976 | PL 94-521 | Subsec. (c) substituted "the decennial census date" |
| 1976 | PL 94-521 | `Subsecs. (d) to (g). Pub. L. 94–521 added subsecs. (d) to (g).` ← correct prefix |
| 1975 | PL 94-171 | §2(a) catchline |
| 1975 | PL 94-171 | Subsec. (c) |
| 1957 | PL 85-207 | Substituted catchline |

All 800 existing tests pass; 3 new regression tests added.

Closes #558

---
_Generated by [Claude Code](https://claude.ai/code/session_018NWejYdb8keDyX83rtvYER)_