### PR TITLE
fix: populate notes.amendments and last_amendment_year for pre-PL chapter-style citations

### DIFF
--- a/backend/app/crud/us_code.py
+++ b/backend/app/crud/us_code.py
@@ -44,7 +44,7 @@ def _extract_last_amendment(
         return None, None
     latest = amendments[0]
     year = latest.get("year")
-    law = latest.get("law", {})
+    law = latest.get("law") or {}
     congress = law.get("congress")
     law_number = law.get("law_number")
     if congress is not None and law_number is not None:
@@ -334,7 +334,7 @@ async def _enrich_notes_with_titles(
         if c.law and not c.law.short_title:
             pairs.add((c.law.congress, str(c.law.law_number)))
     for a in notes.amendments:
-        if not a.law.short_title:
+        if a.law and not a.law.short_title:
             pairs.add((a.law.congress, str(a.law.law_number)))
 
     if not pairs:
@@ -390,9 +390,10 @@ async def _enrich_notes_with_titles(
         if c.law:
             _apply(c.law, c.law.public_law_id)
 
-    # Enrich amendments
+    # Enrich amendments (skip pre-1957 Acts that have no PL reference)
     for a in notes.amendments:
-        _apply(a.law, a.law.public_law_id)
+        if a.law:
+            _apply(a.law, a.law.public_law_id)
 
 
 async def _get_group_ancestors(

--- a/backend/app/schemas/us_code.py
+++ b/backend/app/schemas/us_code.py
@@ -99,7 +99,8 @@ class AmendmentSchema(BaseModel):
     """
 
     law: PublicLawSchema | None = Field(
-        None, description="The Public Law that made this amendment (None for pre-1957 Acts)"
+        None,
+        description="The Public Law that made this amendment (None for pre-1957 Acts)",
     )
     year: int = Field(..., description="Year of the amendment")
     description: str = Field(..., description="Description of what changed")

--- a/backend/app/schemas/us_code.py
+++ b/backend/app/schemas/us_code.py
@@ -90,12 +90,16 @@ class CodeReferenceSchema(BaseModel):
 class AmendmentSchema(BaseModel):
     """A single amendment to a section.
 
-    Represents one change made to a section by a Public Law,
+    Represents one change made to a section by a Public Law or a pre-1957 Act,
     like a commit in version control.
+
+    For post-1957 amendments, ``law`` is populated with the Public Law reference.
+    For pre-1957 (chapter-style) amendments, ``law`` is None because no modern
+    PL number exists.
     """
 
-    law: PublicLawSchema = Field(
-        ..., description="The Public Law that made this amendment"
+    law: PublicLawSchema | None = Field(
+        None, description="The Public Law that made this amendment (None for pre-1957 Acts)"
     )
     year: int = Field(..., description="Year of the amendment")
     description: str = Field(..., description="Description of what changed")
@@ -103,18 +107,20 @@ class AmendmentSchema(BaseModel):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def public_law_id(self) -> str:
-        """Return normalized PL identifier."""
+        """Return normalized PL identifier, or empty string for pre-1957 Acts."""
+        if self.law is None:
+            return ""
         return self.law.public_law_id
 
     @property
-    def congress(self) -> int:
-        """Return the congress number."""
-        return self.law.congress
+    def congress(self) -> int | None:
+        """Return the congress number, or None for pre-1957 Acts."""
+        return self.law.congress if self.law is not None else None
 
     @property
-    def law_number(self) -> int:
-        """Return the law number."""
-        return self.law.law_number
+    def law_number(self) -> int | None:
+        """Return the law number, or None for pre-1957 Acts."""
+        return self.law.law_number if self.law is not None else None
 
 
 class ShortTitleSchema(BaseModel):

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1243,8 +1243,16 @@ def _parse_amendments(text: str) -> list[Amendment]:
                         description=" ".join(year_block.split()),
                     )
                 )
-            # Skip amendments where we can't extract congress/law_number
-            # since we need valid law references
+            elif re.search(r"\bAct\b", year_block):
+                # Pre-1957 chapter-style citation (e.g. "Act Oct. 31, 1951, ch. 655 …").
+                # No modern PL number exists, so law is None.
+                amendments.append(
+                    Amendment(
+                        law=None,
+                        year=year,
+                        description=" ".join(year_block.split()),
+                    )
+                )
 
     return amendments
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2863,9 +2863,7 @@ class TestPrePLAmendmentCitations:
         """Sections with modern Pub. L. amendments are parsed as before."""
         from pipeline.olrc.normalized_section import _parse_amendments
 
-        text = (
-            "2013—Pub. L. 112–239, § 1033(b)(2)(B), made technical amendments."
-        )
+        text = "2013—Pub. L. 112–239, § 1033(b)(2)(B), made technical amendments."
         amendments = _parse_amendments(text)
 
         assert len(amendments) == 1

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2814,3 +2814,81 @@ class TestNoteReferenceSchema:
             # Missing congress and law_number
         )
         assert schema.target_id == "/us/pl/unknown"
+
+
+class TestPrePLAmendmentCitations:
+    """Regression tests for issues #566 and #567.
+
+    Pre-1957 chapter-style amendment citations (e.g. "Act Oct. 31, 1951, ch. 655")
+    must populate notes.amendments and contribute to last_amendment_year even though
+    they have no modern Pub. L. number.
+    """
+
+    def test_pre_pl_amendment_appears_in_amendments(self) -> None:
+        """A section with only a chapter-style amendment has a non-empty notes.amendments."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            '1951—Act Oct. 31, 1951, substituted "United States district court for"'
+            ' for "United States court in and for", and "by law for" for'
+            ' "on February 12, 1925, for".'
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].year == 1951
+        assert amendments[0].law is None
+        assert "Act Oct. 31, 1951" in amendments[0].description
+
+    def test_pre_pl_amendment_year_from_year_prefix(self) -> None:
+        """last_amendment_year is derived from the year prefix in a chapter-style note."""
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        raw_notes = (
+            "[NH]Amendments[/NH] "
+            '1951—Act Oct. 31, 1951, ch. 655, substituted "United States district court for"'
+            ' for "United States court in and for".'
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        assert len(notes.amendments) == 1
+        assert notes.amendments[0].year == 1951
+        assert notes.amendments[0].law is None
+
+    def test_modern_pl_amendments_unaffected(self) -> None:
+        """Sections with modern Pub. L. amendments are parsed as before."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "2013—Pub. L. 112–239, § 1033(b)(2)(B), made technical amendments."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].year == 2013
+        assert amendments[0].law is not None
+        assert amendments[0].law.congress == 112
+        assert amendments[0].law.law_number == 239
+
+    def test_pre_pl_and_modern_amendments_coexist(self) -> None:
+        """A section amended by both an Act and a Pub. L. returns both entries."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "2000—Pub. L. 106–518 made a change.\n"
+            '1951—Act Oct. 31, 1951, ch. 655, substituted "district court for" for "court in and for".'
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 2
+        years = {a.year for a in amendments}
+        assert years == {2000, 1951}
+        modern = next(a for a in amendments if a.year == 2000)
+        pre_pl = next(a for a in amendments if a.year == 1951)
+        assert modern.law is not None
+        assert modern.law.congress == 106
+        assert pre_pl.law is None


### PR DESCRIPTION
## Bug

Two related bugs affected sections whose only amendments are pre-1957 chapter-style citations (e.g. `Act Oct. 31, 1951, ch. 655, § 54(b)`):

- **#567**: `notes.amendments` was empty even when the OLRC XML contained a valid amendment note. The raw text appeared correctly in `notes.notes` (category=editorial, header=Amendments) but no structured entry was added to `notes.amendments`.
- **#566**: `last_amendment_year` was null in the title structure endpoint (`GET /api/v1/titles/9/structure`) for sections whose only amendments are pre-PL acts.

**Tested section**: 9 U.S.C. § 7, release point OLRC 113-21.  
Amendment note text: `1951—Act Oct. 31, 1951, substituted "United States district court for" for "United States court in and for", and "by law for" for "on February 12, 1925, for".`

## Root cause

`_parse_amendments` in `normalized_section.py` matched amendment citations only against the modern `Pub. L. X-Y` format. When a year block contained only a chapter-style citation (`Act Month DD, YYYY, ch. X`), no structured entry was created and the function silently skipped the block.

Additionally, `AmendmentSchema.law` was a required field typed as `PublicLawSchema` (which itself requires `congress: int` and `law_number: int`), so there was no way to represent a pre-PL amendment without a valid PL number.

## Fix

Four files changed:

**`app/schemas/us_code.py`** — Made `AmendmentSchema.law` optional (`PublicLawSchema | None`, defaulting to `None`). Updated `public_law_id`, `congress`, and `law_number` properties to handle `law=None`. Pre-1957 Acts have no modern PL number, so `law=None` is the correct representation.

**`pipeline/olrc/normalized_section.py`** — In `_parse_amendments`, after the existing `Pub. L.` fallback path, added an `elif` branch: when the year block contains the word `Act` (chapter-style citation pattern) but no `Pub. L.` reference, an `Amendment(law=None, year=year, description=...)` entry is now appended. This makes `last_amendment_year` available for pre-PL sections.

**`app/crud/us_code.py`** — Two guards:
1. `_extract_last_amendment`: changed `latest.get("law", {})` to `latest.get("law") or {}` so a serialized `"law": null` doesn't cause `AttributeError`.
2. `_enrich_notes_with_law_titles`: skip the enrichment loop for amendments where `a.law is None` (pre-1957 Acts have nothing to look up).

**`tests/pipeline/test_normalized_section.py`** — Added `TestPrePLAmendmentCitations` with four tests:
- pre-PL amendment appears in `notes.amendments` with `law=None`
- year prefix is correctly extracted from a flat `[NH]Amendments[/NH]` note
- modern Pub. L. amendments continue to work as before
- sections amended by both an Act and a Pub. L. return both entries

## Before/after (parsing output)

**Before** — `_parse_amendments("1951—Act Oct. 31, 1951, ...")` returned `[]`.  
**After** — returns `[Amendment(law=None, year=1951, description="Act Oct. 31, 1951, ...")]`.

`last_amendment_year` for 9 U.S.C. § 7 changes from `null` to `1951`. `last_amendment_law` remains `null` (correct — no modern PL number exists for this act).

Closes #566
Closes #567

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSKSPHu2H8q8NBZ1PzLqP9)_