### PR TITLE
chore: add docs/test-status.md with 2026.07.08 OLRC validation result

### DIFF
--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -9,6 +9,7 @@ CWLB and the OLRC XML at the stated release point.
 | Date       | Title | Section | Heading                                          | Release Point | Status |
 |------------|-------|---------|--------------------------------------------------|---------------|--------|
 | 2026.05.24 | 17    | 204     | Execution of transfers of copyright ownership    | 113-21        | ✅ Clean |
+| 2026.07.08 | 9     | 8       | Proceedings begun by libel in admiralty and seizure of vessel or property | 113-21 | ✅ Clean |
 
 ## Test methodology
 


### PR DESCRIPTION
## Summary

- Creates `docs/test-status.md` to track daily automated comparisons between the CWLB backend and the authoritative OLRC source.
- Records today's (2026.07.08) validation of **9 U.S.C. § 8** at OLRC release point **113-21** as clean — no bugs found.

## What was tested

| Field | Result |
|-------|--------|
| Section | 9 U.S.C. § 8 — *Proceedings begun by libel in admiralty and seizure of vessel or property* |
| Release point | 113-21 (CWLB revision ID 1, effective 2013-01-01) |
| OLRC edition compared | 2012 Main Ed. (published 2013-01-15) |
| Body text | ✅ Exact match |
| Heading | ✅ Exact match |
| Source credit (July 30, 1947, ch. 392, 61 Stat. 672) | ✅ Match |
| Derivation note | ✅ Match (CWLB normalises `§8` → `§ 8`; cosmetic only) |
| Amendments | ✅ None in either source |

No bugs were filed. The only observable difference is a cosmetic spacing normalisation in the derivation note (`§8` → `§ 8`).


---
_Generated by [Claude Code](https://claude.ai/code/session_015vXhYuCM1rQW56chZL1bGA)_