### PR TITLE
fix: use actual amendment enactment date for last_modified_date (not Jan 1)

### DIFF
--- a/backend/app/crud/us_code.py
+++ b/backend/app/crud/us_code.py
@@ -486,17 +486,9 @@ async def get_section(
 
                 enacted_date = _parse_citation_date(law_data["date"])
 
-        # Extract last_modified_date from amendments
-        amendments = state.normalized_notes.get("amendments", [])
-        if amendments:
-            from datetime import date
-
-            max_year = max(a["year"] for a in amendments if "year" in a)
-            last_modified_date = date(max_year, 1, 1)
-
-        # Fallback: derive last_modified_date from amendment citations when
-        # the amendments list is empty (e.g. stale ingestion or unstructured notes)
-        if last_modified_date is None and citations:
+        # Extract last_modified_date from amendment citations (full enactment date
+        # preferred — yields the actual date rather than a Jan 1 approximation)
+        if citations:
             from pipeline.olrc.group_service import _parse_citation_date
 
             amendment_dates = []
@@ -509,6 +501,15 @@ async def get_section(
                             amendment_dates.append(parsed)
             if amendment_dates:
                 last_modified_date = max(amendment_dates)
+
+        # Fallback: use year-only from amendments when citation dates are unavailable
+        if last_modified_date is None:
+            amendments = state.normalized_notes.get("amendments", [])
+            if amendments:
+                from datetime import date
+
+                max_year = max(a["year"] for a in amendments if "year" in a)
+                last_modified_date = date(max_year, 1, 1)
 
     # Find the revision that last *changed* this section's content.
     # Reuse the same chain to avoid re-fetching HEAD + CTE.

--- a/backend/pipeline/backfill_last_modified.py
+++ b/backend/pipeline/backfill_last_modified.py
@@ -14,6 +14,7 @@ from sqlalchemy import select, update
 
 from app.models.base import async_session_maker
 from app.models.us_code import USCodeSection
+from pipeline.olrc.group_service import _parse_citation_date
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -24,7 +25,10 @@ BATCH_SIZE = 500
 
 
 async def backfill(*, dry_run: bool = True) -> int:
-    """Backfill last_modified_date from normalized_notes amendments.
+    """Backfill last_modified_date from normalized_notes amendment citations.
+
+    Prefers the full enactment date from amendment citations over the
+    year-only approximation from the amendments list.
 
     Returns the number of rows updated.
     """
@@ -46,16 +50,34 @@ async def backfill(*, dry_run: bool = True) -> int:
 
         batch: list[dict] = []
         for section_id, notes in rows:
-            amendments = notes.get("amendments", []) if notes else []
-            if not amendments:
+            if not notes:
                 continue
 
-            years = [a.get("year") for a in amendments if a.get("year")]
-            if not years:
+            lmd: date | None = None
+
+            # Prefer full date from amendment citations
+            citations = notes.get("citations", [])
+            amendment_dates = []
+            for c in citations:
+                if c.get("relationship") == "Amendment":
+                    law_data = c.get("law") or c.get("act")
+                    if law_data and law_data.get("date"):
+                        parsed = _parse_citation_date(law_data["date"])
+                        if parsed is not None:
+                            amendment_dates.append(parsed)
+            if amendment_dates:
+                lmd = max(amendment_dates)
+            else:
+                # Fallback: year-only from amendments
+                amendments = notes.get("amendments", [])
+                years = [a.get("year") for a in amendments if a.get("year")]
+                if years:
+                    lmd = date(max(years), 1, 1)
+
+            if lmd is None:
                 continue
 
-            max_year = max(years)
-            batch.append({"sid": section_id, "lmd": date(max_year, 1, 1)})
+            batch.append({"sid": section_id, "lmd": lmd})
 
             if len(batch) >= BATCH_SIZE:
                 if not dry_run:

--- a/backend/pipeline/olrc/ingestion.py
+++ b/backend/pipeline/olrc/ingestion.py
@@ -238,11 +238,22 @@ class USCodeIngestionService:
                         f"{first_citation.act.stat_page}"
                     )
 
-        # Derive last_modified_date from the most recent amendment year
+        # Derive last_modified_date from the most recent amendment citation
+        # (full enactment date preferred over year-only approximation)
         last_modified_date = None
-        if normalized.section_notes and normalized.section_notes.amendments:
-            max_year = max(a.year for a in normalized.section_notes.amendments)
-            last_modified_date = date(max_year, 1, 1)
+        if normalized.section_notes:
+            amendment_dates = [
+                _parse_citation_date(c.date)
+                for c in normalized.section_notes.citations
+                if c.relationship == "Amendment" and c.date
+            ]
+            amendment_dates = [d for d in amendment_dates if d is not None]
+            if amendment_dates:
+                last_modified_date = max(amendment_dates)
+            elif normalized.section_notes.amendments:
+                # Fallback: year-only when citations lack dates
+                max_year = max(a.year for a in normalized.section_notes.amendments)
+                last_modified_date = date(max_year, 1, 1)
 
         result = await self.session.execute(
             select(USCodeSection).where(

--- a/backend/tests/test_last_modified_date.py
+++ b/backend/tests/test_last_modified_date.py
@@ -185,7 +185,11 @@ class TestLastModifiedDateFromNotes:
                     "relationship": "Enactment",
                 },
                 {
-                    "law": {"congress": 102, "law_number": 492, "date": "Oct. 24, 1992"},
+                    "law": {
+                        "congress": 102,
+                        "law_number": 492,
+                        "date": "Oct. 24, 1992",
+                    },
                     "relationship": "Amendment",
                 },
             ],

--- a/backend/tests/test_last_modified_date.py
+++ b/backend/tests/test_last_modified_date.py
@@ -1,12 +1,15 @@
 """Unit tests for last_modified_date derivation from amendment citations.
 
-These tests verify the fallback logic added to get_section() in
-app/crud/us_code.py: when the `amendments` list is empty but `citations`
-contains entries with relationship "Amendment", last_modified_date should be
-derived from the most recent amendment citation date.
+These tests verify the logic in get_section() (app/crud/us_code.py) that
+derives last_modified_date from normalized_notes.  The correct value is the
+full enactment date of the most recent amending Public Law (from the
+``citations`` list), NOT a Jan-1 approximation built from a year integer.
 
-The tests exercise the same computation as the production code by calling
-_parse_citation_date directly and running the equivalent selection logic.
+Regression coverage for issue #510: sections such as 17 U.S.C. § 107 were
+returning 1992-01-01 instead of 1992-10-24 (Pub. L. 102-492, Oct. 24, 1992)
+because the primary derivation path read a year-only ``amendments`` entry and
+constructed date(year, 1, 1) rather than parsing the full date from the
+corresponding citation.
 """
 
 from datetime import date
@@ -15,7 +18,12 @@ from pipeline.olrc.group_service import _parse_citation_date
 
 
 def _compute_last_modified_date_from_citations(citations: list[dict]) -> date | None:
-    """Mirror of the fallback logic in get_section() for isolated testing."""
+    """Mirror of the citation-based derivation in get_section() for unit testing.
+
+    Iterates over ``citations`` (from normalized_notes), finds all entries with
+    relationship ``"Amendment"``, parses their date strings, and returns the
+    maximum.  Returns None when no amendment citations carry a date.
+    """
     amendment_dates = []
     for c in citations:
         if c.get("relationship") == "Amendment":
@@ -27,8 +35,26 @@ def _compute_last_modified_date_from_citations(citations: list[dict]) -> date | 
     return max(amendment_dates) if amendment_dates else None
 
 
+def _compute_last_modified_date_from_notes(normalized_notes: dict) -> date | None:
+    """Mirror of the full last_modified_date derivation in get_section().
+
+    Prefers the full enactment date from amendment citations; falls back to the
+    year-only value from the ``amendments`` list when no citation dates exist.
+    """
+    citations = normalized_notes.get("citations", [])
+    result = _compute_last_modified_date_from_citations(citations)
+    if result is not None:
+        return result
+    # Fallback: year-only from amendments
+    amendments = normalized_notes.get("amendments", [])
+    years = [a["year"] for a in amendments if "year" in a]
+    if years:
+        return date(max(years), 1, 1)
+    return None
+
+
 class TestLastModifiedDateFromCitations:
-    """last_modified_date fallback: derive from amendment citations."""
+    """last_modified_date primary path: derive full date from amendment citations."""
 
     def test_single_amendment_citation(self) -> None:
         """A single amendment citation yields its date as last_modified_date."""
@@ -97,7 +123,7 @@ class TestLastModifiedDateFromCitations:
         assert result is None
 
     def test_amendment_citation_using_act_key(self) -> None:
-        """Fallback also works when citation uses 'act' key instead of 'law'."""
+        """Works when citation uses 'act' key instead of 'law'."""
         citations = [
             {
                 "law_id": "PL 94-553",
@@ -140,3 +166,116 @@ class TestLastModifiedDateFromCitations:
         ]
         result = _compute_last_modified_date_from_citations(citations)
         assert result == date(1996, 10, 12)
+
+
+class TestLastModifiedDateFromNotes:
+    """Full derivation from normalized_notes: citation dates preferred, year fallback."""
+
+    def test_citation_date_wins_over_year_only_from_amendments(self) -> None:
+        """Regression test for issue #510 (17 USC §107 scenario).
+
+        When normalized_notes has both an amendments entry (year-only) AND a
+        citation with relationship "Amendment" carrying a full date, the full
+        date must be returned — NOT the Jan-1 approximation.
+        """
+        normalized_notes = {
+            "citations": [
+                {
+                    "law": {"congress": 94, "law_number": 553, "date": "Oct. 19, 1976"},
+                    "relationship": "Enactment",
+                },
+                {
+                    "law": {"congress": 102, "law_number": 492, "date": "Oct. 24, 1992"},
+                    "relationship": "Amendment",
+                },
+            ],
+            "amendments": [
+                {"law": {"congress": 102, "law_number": 492}, "year": 1992},
+            ],
+        }
+        result = _compute_last_modified_date_from_notes(normalized_notes)
+        assert result == date(1992, 10, 24), (
+            "Expected full date Oct 24, not Jan 1 approximation"
+        )
+        assert result != date(1992, 1, 1)
+
+    def test_17_usc_101_citation_date(self) -> None:
+        """Regression: 17 USC §101 last_modified_date must be 2010-12-09, not 2010-01-01."""
+        normalized_notes = {
+            "citations": [
+                {
+                    "law": {"congress": 94, "law_number": 553, "date": "Oct. 19, 1976"},
+                    "relationship": "Enactment",
+                },
+                {
+                    "law": {"congress": 111, "law_number": 295, "date": "Dec. 9, 2010"},
+                    "relationship": "Amendment",
+                },
+            ],
+            "amendments": [
+                {"law": {"congress": 111, "law_number": 295}, "year": 2010},
+            ],
+        }
+        result = _compute_last_modified_date_from_notes(normalized_notes)
+        assert result == date(2010, 12, 9)
+
+    def test_17_usc_106_citation_date(self) -> None:
+        """Regression: 17 USC §106 last_modified_date must be 2002-11-02, not 2002-01-01."""
+        normalized_notes = {
+            "citations": [
+                {
+                    "law": {"congress": 94, "law_number": 553, "date": "Oct. 19, 1976"},
+                    "relationship": "Enactment",
+                },
+                {
+                    "law": {"congress": 107, "law_number": 273, "date": "Nov. 2, 2002"},
+                    "relationship": "Amendment",
+                },
+            ],
+            "amendments": [
+                {"law": {"congress": 107, "law_number": 273}, "year": 2002},
+            ],
+        }
+        result = _compute_last_modified_date_from_notes(normalized_notes)
+        assert result == date(2002, 11, 2)
+
+    def test_fallback_to_year_only_when_no_citation_dates(self) -> None:
+        """Year-only fallback is used when no amendment citations have dates."""
+        normalized_notes = {
+            "citations": [
+                {
+                    "law": {"congress": 94, "law_number": 553},
+                    "relationship": "Enactment",
+                },
+                {
+                    # Amendment citation but no date field
+                    "law": {"congress": 102, "law_number": 492},
+                    "relationship": "Amendment",
+                },
+            ],
+            "amendments": [
+                {"law": {"congress": 102, "law_number": 492}, "year": 1992},
+            ],
+        }
+        result = _compute_last_modified_date_from_notes(normalized_notes)
+        # Falls back to year-only since citation has no date
+        assert result == date(1992, 1, 1)
+
+    def test_no_amendments_and_no_citation_dates_returns_none(self) -> None:
+        """Returns None when neither citations nor amendments provide dates."""
+        normalized_notes = {
+            "citations": [
+                {
+                    "law": {"congress": 94, "law_number": 553, "date": "Oct. 19, 1976"},
+                    "relationship": "Enactment",
+                },
+            ],
+            "amendments": [],
+        }
+        result = _compute_last_modified_date_from_notes(normalized_notes)
+        assert result is None
+
+    def test_empty_normalized_notes_returns_none(self) -> None:
+        """Returns None for empty normalized_notes dict."""
+        result = _compute_last_modified_date_from_notes({})
+        assert result is None


### PR DESCRIPTION
## Bug

`last_modified_date` on section detail responses was always set to `{year}-01-01` (January 1 of the amendment year) instead of the actual enactment date of the most recent amending law.

Examples from issue #510:

| Section | Before (wrong) | After (correct) |
|---------|---------------|-----------------|
| 17 U.S.C. § 107 | `1992-01-01` | `1992-10-24` (Pub. L. 102-492) |
| 17 U.S.C. § 101 | `2010-01-01` | `2010-12-09` (Pub. L. 111-295) |
| 17 U.S.C. § 106 | `2002-01-01` | `2002-11-02` (Pub. L. 107-273) |

## Root Cause

`normalized_notes` stores two parallel structures:

- **`amendments`** — parsed from the "Amendments" editorial note; contains only a `year` integer (e.g. `1992`)
- **`citations`** — parsed from the OLRC `<sourceCredit>` XML element; contains the full enactment date string (e.g. `"Oct. 24, 1992"`) and a `relationship` field (`"Enactment"` or `"Amendment"`)

The old code in `get_section()` (and in the ingestion pipeline) read the year-only `amendments` list and called `date(year, 1, 1)`, ignoring the full date already available in `citations`. A later fallback used citation dates, but only when `amendments` was empty — which is rarely the case.

## Fix

Three files changed, all applying the same logic change:

### `app/crud/us_code.py` — primary API fix

Promote the citation-based derivation from fallback to primary path:

```
Before:
  if amendments:
      last_modified_date = date(max_year, 1, 1)   # always Jan 1
  elif citations with relationship "Amendment":
      last_modified_date = max(citation_dates)     # only used as fallback

After:
  if citations with relationship "Amendment":
      last_modified_date = max(citation_dates)     # full date, primary
  elif amendments:
      last_modified_date = date(max_year, 1, 1)   # year-only, last resort
```

### `pipeline/olrc/ingestion.py`

Same logic applied when computing `USCodeSection.last_modified_date` during ingestion. Uses `_parse_citation_date` (already imported) on each amendment citation from `normalized.section_notes.citations`.

### `pipeline/backfill_last_modified.py`

Backfill script updated to prefer full citation dates over year-only values, matching the new ingestion logic.

## Tests

New `TestLastModifiedDateFromNotes` class in `tests/test_last_modified_date.py` covers:
- The three sections from the issue report (§107, §101, §106) confirming full date returned
- Year-only fallback when citation dates are absent
- Edge cases: empty notes, no amendments, no amendment citations

Full suite: **803 passed, 21 skipped** (no regressions).

## Before / After

For 17 U.S.C. § 107 (release point 113-21, revision_id=1):

**Before:**
```json
{ "last_modified_date": "1992-01-01" }
```

**After:**
```json
{ "last_modified_date": "1992-10-24" }
```

The `citations` array in the same response already carried `"date": "Oct. 24, 1992"` — this fix makes `last_modified_date` use that value consistently.

Closes #510

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQJYv4atKNwegtWA66dVaY)_