### PR TITLE
fix: don't let Reorganization Plan dates bleed into Public Law citation dates

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1993,6 +1993,32 @@ class USLMParser:
 
         return "".join(parts)
 
+    @staticmethod
+    def _extract_year_from_date_text(date_text: str) -> int | None:
+        """Extract the 4-digit year from a human-readable date string.
+
+        Handles formats such as "Nov. 18, 1988", "June 30, 1940", "Apr. 24, 1996".
+        Returns None when no 4-digit year can be found.
+        """
+        m = re.search(r"\b(\d{4})\b", date_text)
+        return int(m.group(1)) if m else None
+
+    @staticmethod
+    def _date_year_plausible_for_congress(year: int, congress: int) -> bool:
+        """Return True if *year* is plausible for a law enacted by *congress*.
+
+        Each Congress sits for roughly two calendar years.  The 1st Congress
+        started in 1789, so the start year of Congress N is 1789 + 2*(N-1).
+        We allow one year of slop on each side to handle bills signed in the
+        opening or closing days of a session that straddle a calendar year.
+
+        Examples:
+            100th Congress (1987-1989): years 1986-1990 accepted
+            106th Congress (1999-2001): years 1998-2002 accepted
+        """
+        congress_start = 1789 + 2 * (congress - 1)
+        return congress_start - 1 <= year <= congress_start + 2
+
     def _extract_source_credit_refs(
         self, section_elem: etree._Element
     ) -> tuple[list[SourceCreditRef], list[ActRef]]:
@@ -2220,9 +2246,27 @@ class USLMParser:
                 # PL refs only. Attribute each date to the most recently seen PL ref
                 # so that "as added" credits assign the date to the adding law, not
                 # the framework law that precedes the "as added" clause.
+                #
+                # Guard: some sourceCredit elements interleave non-PL references
+                # (e.g., Reorganization Plans, which use /us/rp/ hrefs that are not
+                # matched above) between two PL refs, and those non-PL references
+                # carry their own <date> elements.  Without this check the date for
+                # the non-PL reference bleeds into the immediately preceding PL ref,
+                # and the actual date for that PL ref (appearing later in the XML)
+                # bleeds into the *next* PL ref — shifting all subsequent dates by
+                # one position (Issues #588 / #587).
+                #
+                # We reject a <date> element when the year it contains is
+                # chronologically inconsistent with the most recently seen PL's
+                # Congress number, which is a precise signal that the date belongs
+                # to an interleaved non-PL reference rather than to that PL.
                 date_text = "".join(elem.itertext()).strip()
                 if last_ref_type == "pl" and pl_refs:
-                    pl_refs[-1].date = date_text
+                    year = self._extract_year_from_date_text(date_text)
+                    if year is None or self._date_year_plausible_for_congress(
+                        year, pl_refs[-1].congress
+                    ):
+                        pl_refs[-1].date = date_text
 
         return pl_refs, act_refs
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -2077,6 +2077,73 @@ class TestExtractSourceCreditRefsAsAddedDate:
         assert ref.stat_volume == "90"
         assert ref.stat_page == 2541
 
+    def test_reorganization_plan_date_does_not_bleed_into_pl_ref(
+        self, parser: USLMParser, tmp_path: Path
+    ) -> None:
+        """Reorganization Plan <date> elements must not bleed into adjacent PL ref dates.
+
+        Regression test for Issues #588 / #587:
+            27 U.S.C. § 205 sourceCredit contains a Reorganization Plan reference
+            (Reorg. Plan No. 3 of 1940, eff. June 30, 1940) that appears after
+            PL 100–690's <ref> element.  Without the congress-year guard the date
+            "June 30, 1940" was wrongly assigned to PL 100–690 (100th Congress,
+            1987–1989), and "Nov. 18, 1988" (PL 100–690's actual date) was shifted
+            to PL 106–113, leaving PL 106–113's real date "Nov. 29, 1999" uncaptured.
+
+        The fix rejects a <date> element whose year is outside the plausible range
+        for the most recently seen PL's Congress, so dates from non-PL references
+        interleaved in sourceCredit are silently skipped.
+        """
+        # Simplified version of 27 U.S.C. § 205's sourceCredit with the three
+        # key references: PL 100-690 (enactment), Reorg Plan (non-PL, no <ref>
+        # matched), and PL 106-113 (amendment).
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<usc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <meta><identifier>usc/27</identifier></meta>
+  <main>
+    <title identifier="/us/usc/t27" number="27">
+      <heading>INTOXICATING LIQUORS</heading>
+      <chapter identifier="/us/usc/t27/ch8" number="8">
+        <heading>FEDERAL ALCOHOL ADMINISTRATION ACT</heading>
+        <section identifier="/us/usc/t27/s205" number="205">
+          <heading>Unfair competition and unlawful practices</heading>
+          <content><p>Test content.</p></content>
+          <sourceCredit>(<ref href="/us/pl/100/690/tIX/s9007">Pub. L. 100–690</ref>, title IX, § 9007, Nov. 18, 1988, <ref href="/us/stat/102/4518">102 Stat. 4518</ref>; Reorg. Plan No. 3 of 1940, §§2(a), 3(b), eff. <date>June 30, 1940</date>, 5 F.R. 2107, 54 Stat. 1231; <ref href="/us/pl/106/113/dB/s1000a(7)">Pub. L. 106–113</ref>, div. B, § 1000(a)(7), <date>Nov. 29, 1999</date>, <ref href="/us/stat/113/1536">113 Stat. 1536</ref>.)</sourceCredit>
+        </section>
+      </chapter>
+    </title>
+  </main>
+</usc>
+"""
+        xml_path = tmp_path / "test_reorg_plan_date.xml"
+        xml_path.write_text(xml_content)
+        result = parser.parse_file(xml_path)
+
+        assert len(result.sections) == 1
+        section = result.sections[0]
+
+        pl_refs = section.source_credit_refs
+        assert len(pl_refs) == 2, f"Expected 2 PL refs, got {len(pl_refs)}"
+
+        # PL 100-690 (100th Congress, 1987-1989): date is Nov. 18, 1988 — NOT June 30, 1940
+        pl_100_690 = pl_refs[0]
+        assert pl_100_690.congress == 100
+        assert pl_100_690.law_number == 690
+        assert pl_100_690.date is None, (
+            f"PL 100-690 date should be None (no <date> element follows it before "
+            f"the Reorg Plan date), got {pl_100_690.date!r}"
+        )
+
+        # PL 106-113 (106th Congress, 1999-2001): date is Nov. 29, 1999 — NOT Nov. 18, 1988
+        pl_106_113 = pl_refs[1]
+        assert pl_106_113.congress == 106
+        assert pl_106_113.law_number == 113
+        assert pl_106_113.date == "Nov. 29, 1999", (
+            f"PL 106-113 should have date='Nov. 29, 1999', got {pl_106_113.date!r}"
+        )
+        assert pl_106_113.stat_volume == "113"
+        assert pl_106_113.stat_page == 1536
+
 
 class TestExtractSourceCreditActRefs:
     """Tests for _extract_source_credit_refs with pre-1957 Act citations.


### PR DESCRIPTION
## Summary

- **Root cause**: In `_extract_source_credit_refs`, any `<date>` element appearing after a PL `<ref>` was blindly attributed to that PL ref. Reorganization Plans (which use `/us/rp/` hrefs that are not matched by the parser) can appear inline in `<sourceCredit>` between two PL refs and carry their own `<date>` elements. Without a validity check, those Reorg Plan dates were assigned to the preceding PL ref, shifting all subsequent citation dates by one position.
- **Fix**: Before attributing a `<date>` element to the most recently seen PL ref, validate that the year extracted from the date string is chronologically plausible for that PL's Congress number (formula: `1789 + 2*(N-1)`, with ±1 year of tolerance). Implausible years (e.g. 1940 for a 100th-Congress law) are silently skipped.
- **Two new static helpers** on `USLMParser`: `_extract_year_from_date_text` and `_date_year_plausible_for_congress`.
- **Regression test** added covering the 27 U.S.C. § 205 scenario (Reorg. Plan No. 3 of 1940 date "June 30, 1940" must not bleed into PL 100–690's citation).

## Before / After (27 U.S.C. § 205)

**Before** (buggy):
```
citations[7]: PL 100-690  date = "June 30, 1940"   ← Reorg Plan date leaked in
citations[8]: PL 106-113  date = "Nov. 18, 1988"   ← PL 100-690's date shifted here
last_modified_date = 1988-11-18                     ← wrong
```

**After** (fixed):
```
citations[7]: PL 100-690  date = "Nov. 18, 1988"   ← correct (Reorg Plan date rejected)
citations[8]: PL 106-113  date = "Nov. 29, 1999"   ← correct
last_modified_date = 1999-11-29                     ← correct
```

## Test plan

- [x] `uv run mypy app --ignore-missing-imports` — no issues
- [x] `uv run pytest` — 833 passed, 21 skipped, 0 failures
- [x] Existing `test_as_added_date_attributed_to_adding_law_not_framework` (Issue #480 regression) still passes — the "as added" pattern uses PL 104-132 (Congress 104, start year 1995) with date "Apr. 24, 1996" (year 1996, within [1994, 1997]) and is correctly accepted
- [x] New test `test_reorganization_plan_date_does_not_bleed_into_pl_ref` covers the 27 U.S.C. § 205 scenario

Closes #588
Closes #587

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuNHup1ZiHC2n4ahTyMudg)_