### PR TITLE
fix: populate note_categories in section detail endpoint

### DIFF
--- a/backend/app/schemas/us_code.py
+++ b/backend/app/schemas/us_code.py
@@ -455,6 +455,19 @@ class SectionViewerSchema(BaseModel):
     last_revision: HeadRevisionSchema | None = None
     group_ancestors: list[GroupAncestorSchema] = []
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def note_categories(self) -> list[str]:
+        """Return the distinct note categories present in notes, sorted.
+
+        Mirrors the note_categories field on SectionSummarySchema so that
+        clients receive consistent data from both the listing and detail
+        endpoints.
+        """
+        if self.notes is None:
+            return []
+        return sorted({n.category.value for n in self.notes.notes})
+
 
 class TitleSummarySchema(BaseModel):
     """Summary of a US Code title for list views."""

--- a/backend/tests/api/test_sections.py
+++ b/backend/tests/api/test_sections.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 from app.schemas.us_code import (
     CodeLineSchema,
     GroupAncestorSchema,
+    NoteCategoryEnum,
+    SectionNoteSchema,
     SectionNotesSchema,
     SectionViewerSchema,
 )
@@ -246,3 +248,75 @@ def test_get_section_provisions_null_by_default(
     response = client.get("/api/v1/sections/17/106")
     assert response.status_code == 200
     assert response.json()["provisions"] is None
+
+
+@patch("app.api.v1.sections.get_section", new_callable=AsyncMock)
+def test_get_section_note_categories_null_when_no_notes(
+    mock_get: AsyncMock, client: TestClient
+) -> None:
+    """note_categories is an empty list when notes is None (Issue #594)."""
+    mock_get.return_value = SectionViewerSchema(
+        title_number=17,
+        section_number="107",
+        heading="Limitations on exclusive rights: Fair use",
+        full_citation="17 U.S.C. § 107",
+        text_content="Notwithstanding the provisions of sections 106 and 106A...",
+        is_positive_law=True,
+        is_repealed=False,
+        notes=None,
+    )
+
+    response = client.get("/api/v1/sections/17/107")
+    assert response.status_code == 200
+    assert response.json()["note_categories"] == []
+
+
+@patch("app.api.v1.sections.get_section", new_callable=AsyncMock)
+def test_get_section_note_categories_populated_from_notes(
+    mock_get: AsyncMock, client: TestClient
+) -> None:
+    """note_categories is derived from notes.notes entries (Issue #594).
+
+    17 U.S.C. § 107 has notes in three categories: editorial, historical,
+    and statutory. The detail endpoint must return all three so clients can
+    render note-type tabs without treating the section as category-free.
+    """
+    mock_get.return_value = SectionViewerSchema(
+        title_number=17,
+        section_number="107",
+        heading="Limitations on exclusive rights: Fair use",
+        full_citation="17 U.S.C. § 107",
+        text_content="Notwithstanding the provisions of sections 106 and 106A...",
+        is_positive_law=True,
+        is_repealed=False,
+        notes=SectionNotesSchema(
+            notes=[
+                SectionNoteSchema(
+                    header="Codification",
+                    category=NoteCategoryEnum.EDITORIAL,
+                    lines=[],
+                ),
+                SectionNoteSchema(
+                    header="House Report No. 94-1476",
+                    category=NoteCategoryEnum.HISTORICAL,
+                    lines=[],
+                ),
+                SectionNoteSchema(
+                    header="Effective Date of 1992 Amendment",
+                    category=NoteCategoryEnum.STATUTORY,
+                    lines=[],
+                ),
+                SectionNoteSchema(
+                    header="References in Text",
+                    category=NoteCategoryEnum.EDITORIAL,
+                    lines=[],
+                ),
+            ],
+        ),
+    )
+
+    response = client.get("/api/v1/sections/17/107")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["note_categories"] == ["editorial", "historical", "statutory"]


### PR DESCRIPTION
## What was the bug

`GET /api/v1/sections/{title}/{section}` always returned `"note_categories": null` even when the section had notes in multiple categories. For example, `GET /api/v1/sections/17/107` returned a full `notes` object with 6 entries spanning editorial, historical, and statutory categories, but `note_categories` was null.

The cause: `SectionViewerSchema` (the detail response schema) had no `note_categories` field at all. `SectionSummarySchema` (used by the listing endpoint) correctly had `note_categories: list[str]` populated via `_extract_note_categories`. The two schemas diverged, leaving the detail endpoint with no way to surface this data.

## What the fix does

Added a `computed_field` property to `SectionViewerSchema` that derives `note_categories` from the already-populated `notes.notes` list:

```python
@computed_field
@property
def note_categories(self) -> list[str]:
    if self.notes is None:
        return []
    return sorted({n.category.value for n in self.notes.notes})
```

This mirrors what `SectionSummarySchema` exposes on the listing endpoint, with no CRUD changes needed — the data is already present in the `notes` field.

## Tests added

Two new test cases in `backend/tests/api/test_sections.py`:
- `test_get_section_note_categories_null_when_no_notes` — asserts `note_categories` is `[]` when `notes` is `None`
- `test_get_section_note_categories_populated_from_notes` — asserts all three categories (`editorial`, `historical`, `statutory`) are returned for 17 U.S.C. § 107 (the exact section from the bug report), sorted alphabetically

All 834 existing tests continue to pass.

Closes #594

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtsRcfcckp1JmBZ8paXG3X)_