### PR TITLE
fix: strip spurious space after em dash in amendment-year note lines

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1707,7 +1707,14 @@ class USLMParser:
             stripped = part.strip()
             if not stripped:
                 continue
-            if not result or result[-1] == "\n\n" or stripped[0] in ";,.":
+            # Do not insert a space when the previous fragment ends with an em
+            # dash (U+2014).  In OLRC XML, amendment-year lines are split across
+            # the paragraph's own text node ("1981—") and a child <ref>
+            # element ("Pub. L. 97–34").  Stripping both fragments and
+            # joining them with a space produces a spurious "1981— Pub." —
+            # see issue #600.
+            prev_ends_em_dash = bool(result) and result[-1].endswith("—")
+            if not result or result[-1] == "\n\n" or stripped[0] in ";,." or prev_ends_em_dash:
                 result.append(stripped)
             else:
                 result.append(" " + stripped)

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1714,7 +1714,12 @@ class USLMParser:
             # joining them with a space produces a spurious "1981— Pub." —
             # see issue #600.
             prev_ends_em_dash = bool(result) and result[-1].endswith("—")
-            if not result or result[-1] == "\n\n" or stripped[0] in ";,." or prev_ends_em_dash:
+            if (
+                not result
+                or result[-1] == "\n\n"
+                or stripped[0] in ";,."
+                or prev_ends_em_dash
+            ):
                 result.append(stripped)
             else:
                 result.append(" " + stripped)

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2135,11 +2135,11 @@ class TestParserNotesContent:
         # The <p> text node ends with an em dash immediately before the <ref>.
         xml = (
             "<notes>"
-            "<note topic=\"amendments\">"
+            '<note topic="amendments">'
             "<heading>Amendments</heading>"
-            "<p>1981—<ref href=\"/us/pl/97/34\">Pub. L. 97–34</ref>"
+            '<p>1981—<ref href="/us/pl/97/34">Pub. L. 97–34</ref>'
             ", § 442(a)(4)(D), substituted text.</p>"
-            "<p>1970—<ref href=\"/us/pl/91/614\">Pub. L. 91–614</ref>"
+            '<p>1970—<ref href="/us/pl/91/614">Pub. L. 91–614</ref>'
             " substituted other text.</p>"
             "<p>1998—Subsec. (c). Pub. L. 105–34 did something.</p>"
             "</note>"

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2113,6 +2113,60 @@ class TestParserNotesContent:
                 f"Role text 'Counsel' ended up in a non-signature line: {content!r}"
             )
 
+    def test_no_space_inserted_after_em_dash_before_ref(self) -> None:
+        """No spurious space after em dash when a <ref> element immediately follows.
+
+        Regression test for issue #600: 26 U.S.C. § 2504 Amendments note lines
+        like "1981—Pub. L. 97–34, §..." were rendered as "1981— Pub. L. 97–34"
+        because the joiner always inserted a space between adjacent text fragments
+        even when the preceding fragment ended with an em dash (U+2014).
+
+        The OLRC XML splits the paragraph's text across the <p> text node
+        ("1981—") and a child <ref> element ("Pub. L. 97–34"), so stripping
+        both and joining with a space introduced the extra space.
+        """
+        from lxml import etree
+
+        from pipeline.olrc.parser import USLMParser
+
+        parser = USLMParser()
+
+        # Simulates: <p>1981—<ref href="...">Pub. L. 97–34</ref>, § 442(a).</p>
+        # The <p> text node ends with an em dash immediately before the <ref>.
+        xml = (
+            "<notes>"
+            "<note topic=\"amendments\">"
+            "<heading>Amendments</heading>"
+            "<p>1981—<ref href=\"/us/pl/97/34\">Pub. L. 97–34</ref>"
+            ", § 442(a)(4)(D), substituted text.</p>"
+            "<p>1970—<ref href=\"/us/pl/91/614\">Pub. L. 91–614</ref>"
+            " substituted other text.</p>"
+            "<p>1998—Subsec. (c). Pub. L. 105–34 did something.</p>"
+            "</note>"
+            "</notes>"
+        )
+        elem = etree.fromstring(xml)
+
+        content = parser._get_notes_text_content(elem)
+
+        # No space should appear between the em dash and "Pub."
+        assert "1981— Pub." not in content, (
+            f"Spurious space after em dash in '1981—' line: {content!r}"
+        )
+        assert "1981—Pub." in content, (
+            f"Expected '1981—Pub.' with no space: {content!r}"
+        )
+        assert "1970— Pub." not in content, (
+            f"Spurious space after em dash in '1970—' line: {content!r}"
+        )
+        assert "1970—Pub." in content, (
+            f"Expected '1970—Pub.' with no space: {content!r}"
+        )
+        # Lines using plain text (no child ref element) must be unaffected
+        assert "1998—Subsec." in content, (
+            f"Expected '1998—Subsec.' to be unchanged: {content!r}"
+        )
+
 
 class TestStripNoteMarkers:
     """Tests for _strip_note_markers function."""


### PR DESCRIPTION
## Context

`GET /api/v1/sections/26/2504` returned Amendments note lines with a spurious extra space (U+0020) after the em dash separating the amendment year from the Public Law citation — e.g. `"1981— Pub. L. 97–34"` instead of the correct `"1981—Pub. L. 97–34"`.

The bug only affected lines where the year-dash was immediately followed by `Pub.` (a bare law citation, no `Subsec.` prefix), because those are the lines where OLRC XML uses a child `<ref>` element:

```xml
<p>1981—<ref href="/us/pl/97/34">Pub. L. 97–34</ref>, § 442(a)(4)(D)…</p>
```

Lines like `"1998—Subsec. (c)."` were correct because the entire text sat in a single text node.

## Root cause

`_get_notes_text_content()` in `backend/pipeline/olrc/parser.py` assembles note text by collecting text fragments from XML text nodes and child elements, then joins them. The joining step always inserts a space between adjacent fragments (unless the next fragment starts with `;`, `,`, or `.`). When the `<p>` text node `"1981—"` was stripped and joined with the next fragment `"Pub. L. 97–34"` from the `<ref>` child, an extra space was inserted.

## Fix

Added one guard condition to the joining loop: if the previous result fragment ends with an em dash (U+2014), suppress the space before the next fragment.

```python
# Before
if not result or result[-1] == "\n\n" or stripped[0] in ";,.":

# After
prev_ends_em_dash = bool(result) and result[-1].endswith("—")
if not result or result[-1] == "\n\n" or stripped[0] in ";,." or prev_ends_em_dash:
```

## Parsing proof

**Before fix** (output of `_get_notes_text_content` for the affected paragraph):
```
1981— Pub. L. 97–34, § 442(a)(4)(D), substituted text.
1970— Pub. L. 91–614 substituted other text.
1998—Subsec. (c). Pub. L. 105–34 did something.
```

**After fix**:
```
1981—Pub. L. 97–34, § 442(a)(4)(D), substituted text.
1970—Pub. L. 91–614 substituted other text.
1998—Subsec. (c). Pub. L. 105–34 did something.
```

## Test

Added `test_no_space_inserted_after_em_dash_before_ref` to `TestParserNotesContent` in `test_normalized_section.py`. The test constructs an XML fragment that mirrors the OLRC pattern for 26 U.S.C. § 2504 (year-dash + `<ref>Pub. L.</ref>`) and asserts no space appears after the em dash, while the plain-text `Subsec.` line is unaffected.

Closes #600

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm5ewBNb17wSKd4cFxfwo4)_