### PR TITLE
fix: preserve OLRC paragraph structure in References in Text notes

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1171,6 +1171,45 @@ def _amendment_lines(raw_content: str) -> list[ParsedLine]:
     return lines
 
 
+def _references_in_text_lines(raw_content: str) -> list[ParsedLine]:
+    """Preserve OLRC paragraph structure for References in Text notes.
+
+    Each <p> element in the source XML is represented as a [PARA]-separated
+    block.  Converting [PARA] to \\n\\n and splitting there — rather than
+    applying sentence-boundary detection — ensures that one <p> element
+    becomes exactly one display line.  This prevents multi-sentence paragraphs
+    (e.g. "The Tax Reform Act of 1976... Section 2521... 94-455.") from being
+    incorrectly split into multiple lines by _split_into_sentences.
+    """
+    cleaned = re.sub(r"\[NH\].*?\[/NH\]", "", raw_content, flags=re.DOTALL)
+    cleaned = re.sub(r"\[/NH\]", "", cleaned)
+    cleaned = re.sub(r"\[PARA\]", "\n\n", cleaned)
+    cleaned = cleaned.strip()
+
+    if not cleaned:
+        return []
+
+    lines: list[ParsedLine] = []
+    pos = 0
+    for para in re.split(r"\n\n+", cleaned):
+        content = para.strip()
+        if content:
+            lines.append(
+                ParsedLine(
+                    line_number=len(lines) + 1,
+                    content=content,
+                    indent_level=1,
+                    marker=None,
+                    is_header=False,
+                    is_signature=False,
+                    start_char=pos,
+                    end_char=pos + len(para.rstrip()),
+                )
+            )
+        pos += len(para) + 2  # +2 for the \n\n separator
+    return lines
+
+
 def _parse_amendments(text: str) -> list[Amendment]:
     """Parse amendment entries from the Amendments subsection.
 
@@ -1496,6 +1535,8 @@ def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
                 header=header,
                 lines=_amendment_lines(raw_content)
                 if header == "Amendments"
+                else _references_in_text_lines(raw_content)
+                if header == "References in Text"
                 else normalize_note_content(raw_content),
                 category=category,
             )
@@ -1651,6 +1692,8 @@ def _parse_editorial_notes(raw_notes: str, notes: SectionNotes) -> None:
                     header=header,
                     lines=_amendment_lines(raw_content)
                     if header == "Amendments"
+                    else _references_in_text_lines(raw_content)
+                    if header == "References in Text"
                     else normalize_note_content(raw_content),
                     category=NoteCategory.EDITORIAL,
                 )

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3917,3 +3917,98 @@ class TestAmendmentMidSentencePubLFix:
         # The fifth 1976 entry must have the Subsecs. plural prefix
         fifth_1976 = [a for a in amendments if a.year == 1976][4]
         assert "Subsecs. (d) to (g)." in fifth_1976.description
+
+
+class TestReferencesInTextLines:
+    """Tests for _references_in_text_lines function.
+
+    Regression tests for Issue #601: a single <p> element in a References in
+    Text note must not be split into multiple lines by sentence-boundary
+    detection.  Each <p> element (represented by [PARA] markers in the raw
+    content) must produce exactly one ParsedLine.
+    """
+
+    def test_single_para_with_multiple_sentences_produces_one_line(self) -> None:
+        """A single <p> element with multiple sentences stays as one line.
+
+        Regression test for Issue #601: the sentence splitter was incorrectly
+        breaking a References in Text note paragraph into multiple lines.
+        The paragraph for 26 U.S.C. § 2504 contains three sentence-ending
+        periods but should appear as a single display line.
+        """
+        from pipeline.olrc.normalized_section import _references_in_text_lines
+
+        # One <p> element whose text contains three sentence-ending periods —
+        # the exact structure that triggered Issue #601.
+        raw = (
+            " The Tax Reform Act of 1976, referred to in subsec. (b), "
+            "is Pub. L. 94–455, Oct. 4, 1976, 90 Stat. 1520. "
+            "Section 2521 of the Internal Revenue Code of 1954 was repealed "
+            "by Pub. L. 94–455. "
+            "For complete classification of this Act to the Code, "
+            "see Tables."
+        )
+
+        lines = _references_in_text_lines(raw)
+
+        assert len(lines) == 1, (
+            f"Expected 1 line for single <p> with multiple sentences, "
+            f"got {len(lines)}: {[ln.content for ln in lines]}"
+        )
+        assert "Tax Reform Act" in lines[0].content
+        assert "Section 2521" in lines[0].content
+        assert "see Tables" in lines[0].content
+
+    def test_multiple_paras_produce_separate_lines(self) -> None:
+        """Multiple <p> elements (separated by [PARA]) each become one line."""
+        from pipeline.olrc.normalized_section import _references_in_text_lines
+
+        raw = (
+            " First paragraph text with multiple sentences. It continues here.[PARA]"
+            " Second paragraph with different content. Also multiple sentences here."
+        )
+
+        lines = _references_in_text_lines(raw)
+
+        assert len(lines) == 2, (
+            f"Expected 2 lines (one per <p> element), got {len(lines)}: "
+            f"{[ln.content for ln in lines]}"
+        )
+        assert "First paragraph" in lines[0].content
+        assert "Second paragraph" in lines[1].content
+
+    def test_nh_markers_stripped(self) -> None:
+        """[NH]...[/NH] note-header markers are stripped from content."""
+        from pipeline.olrc.normalized_section import _references_in_text_lines
+
+        raw = (
+            "[NH]References in Text[/NH]"
+            " The relevant act, Pub. L. 94–455, applies here."
+        )
+
+        lines = _references_in_text_lines(raw)
+
+        assert len(lines) == 1
+        assert "[NH]" not in lines[0].content
+        assert "Pub. L. 94–455" in lines[0].content
+
+    def test_empty_content_returns_empty_list(self) -> None:
+        """Empty or whitespace-only content returns an empty list."""
+        from pipeline.olrc.normalized_section import _references_in_text_lines
+
+        assert _references_in_text_lines("") == []
+        assert _references_in_text_lines("   ") == []
+        assert _references_in_text_lines("[NH]Header[/NH]") == []
+
+    def test_lines_have_indent_level_one(self) -> None:
+        """All parsed lines are at indent_level=1 (matching other note lines)."""
+        from pipeline.olrc.normalized_section import _references_in_text_lines
+
+        raw = "First reference paragraph.[PARA]Second reference paragraph."
+        lines = _references_in_text_lines(raw)
+
+        assert len(lines) == 2
+        for ln in lines:
+            assert ln.indent_level == 1
+            assert ln.marker is None
+            assert ln.is_header is False


### PR DESCRIPTION
## Context

Issue #601 reported that the parser was splitting a single `<p>` element in a "References in Text" note into multiple lines. For example, 26 U.S.C. § 2504's note — which is a single `<p>` containing three sentences — was being rendered as three separate lines instead of one.

The root cause: `normalize_note_content` calls `_split_into_sentences` on each paragraph, breaking at sentence boundaries. But OLRC intends each `<p>` element to be a single display unit; sentence-level splitting destroys that structure for "References in Text" notes.

(The "`, as amended`" phrase mentioned in the issue was legitimately present in the older OLRC release point and is not injected by the parser — no fix needed there.)

## Changes

**`pipeline/olrc/normalized_section.py`**
- Add `_references_in_text_lines(raw_content)`: strips `[NH]` markers, converts `[PARA]` → `\n\n`, then splits only at paragraph boundaries (not sentence boundaries). One `<p>` element → one `ParsedLine`. Pattern mirrors the existing `_amendment_lines` fast-path.
- Wire it into `_parse_editorial_notes` and `_parse_flat_notes`: use `_references_in_text_lines` when `header == "References in Text"`, sitting between the existing `Amendments` branch and the `normalize_note_content` fallback.

**`tests/pipeline/test_normalized_section.py`**
- `TestReferencesInTextLines` (5 tests): single multi-sentence `<p>` → 1 line, multiple `<p>` elements → separate lines, `[NH]` marker stripping, empty-content guard, and `indent_level=1` / `marker=None` checks.

## Before / After

**Before** (26 U.S.C. § 2504 "References in Text" note — single `<p>` element):
```
Line 1: The Tax Reform Act of 1976, referred to in subsec. (b), is Pub. L. 94–455, Oct. 4, 1976, 90 Stat. 1520.
Line 2: Section 2521 of the Internal Revenue Code of 1954 was repealed by Pub. L. 94–455.
Line 3: For complete classification of this Act to the Code, see Tables.
```

**After** (same `<p>` element, now one line):
```
Line 1: The Tax Reform Act of 1976, referred to in subsec. (b), is Pub. L. 94–455, Oct. 4, 1976, 90 Stat. 1520. Section 2521 of the Internal Revenue Code of 1954 was repealed by Pub. L. 94–455. For complete classification of this Act to the Code, see Tables.
```

Closes #601

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm5ewBNb17wSKd4cFxfwo4)_