### PR TITLE
fix: parse date, stat_volume, stat_page from amendment description text

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1250,7 +1250,9 @@ def _parse_amendments(text: str) -> list[Amendment]:
                 law = ParsedPublicLaw(
                     congress=congress,
                     law_number=law_number,
-                    date=_parsed_src.law.date if _parsed_src and _parsed_src.law else None,
+                    date=_parsed_src.law.date
+                    if _parsed_src and _parsed_src.law
+                    else None,
                     stat_volume=_parsed_src.law.stat_volume
                     if _parsed_src and _parsed_src.law
                     else None,

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1240,7 +1240,24 @@ def _parse_amendments(text: str) -> list[Amendment]:
                     r"\u201c(\s*)(.*?)(\s*)\u201d", "\u201c\\2\u201d", description
                 )
 
-                law = ParsedPublicLaw(congress=congress, law_number=law_number)
+                # Parse date, stat_volume, and stat_page from the citation text.
+                # "Pub. L. NNN-NNN{after_text}" contains these fields — e.g.
+                # "Pub. L. 111-295, §3(a), Dec. 9, 2010, 124 Stat. 3180, struck out..."
+                # Use a plain hyphen so CITATION_PARSE_PATTERN always matches the
+                # law-number separator regardless of dash variant in source text.
+                _citation_text = f"Pub. L. {congress}-{law_number}{after_text}"
+                _parsed_src = parse_citation(_citation_text)
+                law = ParsedPublicLaw(
+                    congress=congress,
+                    law_number=law_number,
+                    date=_parsed_src.law.date if _parsed_src and _parsed_src.law else None,
+                    stat_volume=_parsed_src.law.stat_volume
+                    if _parsed_src and _parsed_src.law
+                    else None,
+                    stat_page=_parsed_src.law.stat_page
+                    if _parsed_src and _parsed_src.law
+                    else None,
+                )
                 amendments.append(
                     Amendment(
                         law=law,
@@ -1259,7 +1276,21 @@ def _parse_amendments(text: str) -> list[Amendment]:
             if simple_pub_match:
                 congress = int(simple_pub_match.group(1))
                 law_number = int(simple_pub_match.group(2))
-                law = ParsedPublicLaw(congress=congress, law_number=law_number)
+                # Also parse date/stat from the surrounding year_block text
+                _fallback_parsed = parse_citation(year_block)
+                law = ParsedPublicLaw(
+                    congress=congress,
+                    law_number=law_number,
+                    date=_fallback_parsed.law.date
+                    if _fallback_parsed and _fallback_parsed.law
+                    else None,
+                    stat_volume=_fallback_parsed.law.stat_volume
+                    if _fallback_parsed and _fallback_parsed.law
+                    else None,
+                    stat_page=_fallback_parsed.law.stat_page
+                    if _fallback_parsed and _fallback_parsed.law
+                    else None,
+                )
                 amendments.append(
                     Amendment(
                         law=law,

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3199,6 +3199,120 @@ class TestAmendmentDateSpacing:
         assert '" December' not in desc
 
 
+class TestAmendmentLawMetadata:
+    """Tests for issue #582: amendment law objects have all-null metadata.
+
+    The amendment description text (e.g. "Pub. L. 111–295, §3(a), Dec. 9, 2010,
+    124 Stat. 3180") contains date, stat_volume, and stat_page.  These must be
+    parsed and stored in the law sub-object rather than left null.
+    """
+
+    def test_amendment_law_date_parsed(self) -> None:
+        """date is extracted from the amendment description citation."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = "2010—Subsec. (c)(2). Pub. L. 111–295, §3(a), Dec. 9, 2010, 124 Stat. 3180, struck out something."
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].law is not None
+        assert amendments[0].law.date == "Dec. 9, 2010"
+
+    def test_amendment_law_stat_volume_parsed(self) -> None:
+        """stat_volume is extracted from the amendment description citation."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = "2010—Subsec. (c)(2). Pub. L. 111–295, §3(a), Dec. 9, 2010, 124 Stat. 3180, struck out something."
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].law is not None
+        assert amendments[0].law.stat_volume == 124
+
+    def test_amendment_law_stat_page_parsed(self) -> None:
+        """stat_page is extracted from the amendment description citation."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = "2010—Subsec. (c)(2). Pub. L. 111–295, §3(a), Dec. 9, 2010, 124 Stat. 3180, struck out something."
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].law is not None
+        assert amendments[0].law.stat_page == 3180
+
+    def test_amendment_law_stat_reference_computed(self) -> None:
+        """stat_reference computed field returns 'N Stat. M' once volume/page populated."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = "2010—Pub. L. 111–295, §3(a), Dec. 9, 2010, 124 Stat. 3180, struck out something."
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].law is not None
+        assert amendments[0].law.stat_reference == "124 Stat. 3180"
+
+    def test_second_amendment_pl106_44(self) -> None:
+        """PL 106-44 metadata matches OLRC data for 17 USC § 512 (issue #582)."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "1999—Subsec. (e). Pub. L. 106–44, §1(d)(1)(A), Aug. 5, 1999, "
+            "113 Stat. 222, substituted something for something else."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        law = amendments[0].law
+        assert law is not None
+        assert law.congress == 106
+        assert law.law_number == 44
+        assert law.date == "Aug. 5, 1999"
+        assert law.stat_volume == 113
+        assert law.stat_page == 222
+        assert law.stat_reference == "113 Stat. 222"
+
+    def test_amendment_without_stat_leaves_fields_null(self) -> None:
+        """Amendment citations without Stat. reference leave stat fields null."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = "1988—Pub. L. 100–568 amended section generally."
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].law is not None
+        assert amendments[0].law.stat_volume is None
+        assert amendments[0].law.stat_page is None
+        assert amendments[0].law.stat_reference is None
+
+    def test_multiple_amendments_each_get_metadata(self) -> None:
+        """Multiple amendments in the same section each get their own metadata."""
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "2010—Pub. L. 111–295, §3(a), Dec. 9, 2010, 124 Stat. 3180, struck out.\n\n"
+            "1999—Pub. L. 106–44, §1(d), Aug. 5, 1999, 113 Stat. 222, substituted."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 2
+
+        # 2010 amendment
+        law_2010 = amendments[0].law
+        assert law_2010 is not None
+        assert law_2010.congress == 111
+        assert law_2010.stat_volume == 124
+        assert law_2010.stat_page == 3180
+        assert law_2010.date == "Dec. 9, 2010"
+
+        # 1999 amendment
+        law_1999 = amendments[1].law
+        assert law_1999 is not None
+        assert law_1999.congress == 106
+        assert law_1999.stat_volume == 113
+        assert law_1999.stat_page == 222
+        assert law_1999.date == "Aug. 5, 1999"
+
+
 class TestMultiSentenceSplitting:
     """Tests for splitting multi-sentence paragraphs onto separate provision lines.
 


### PR DESCRIPTION
## Context

Every amendment object in `notes.amendments[].law` had `null` for `date`, `stat_volume`, `stat_page`, and the computed `stat_reference`. The OLRC encodes all of this information directly in the amendment note text, e.g.:

```
2010—Subsec. (c)(2). Pub. L. 111–295, §3(a), Dec. 9, 2010, 124 Stat. 3180, struck out ...
1999—Subsec. (e). Pub. L. 106–44, §1(d), Aug. 5, 1999, 113 Stat. 222, substituted ...
```

But `_parse_amendments()` was creating `ParsedPublicLaw(congress=congress, law_number=law_number)` — ignoring the date and Statutes at Large data sitting right there in `after_text`.

## Changes

**`backend/pipeline/olrc/normalized_section.py`**

In `_parse_amendments()`, after extracting `congress`, `law_number`, and `after_text` from each paragraph via `_PUB_L_PARA_PATTERN`, now calls the existing `parse_citation()` function on `f"Pub. L. {congress}-{law_number}{after_text}"` to extract `date`, `stat_volume`, and `stat_page`. A plain hyphen is used as the separator so `CITATION_PARSE_PATTERN` always matches regardless of whether the source used an en dash or em dash. The same fix is applied to the fallback code path that handles year blocks without structured paragraphs.

**`backend/tests/pipeline/test_normalized_section.py`**

Added `TestAmendmentLawMetadata` class with 7 tests covering the exact example from the issue (PL 111-295 and PL 106-44 for 17 USC § 512), the `stat_reference` computed field, graceful null-fallback when no Stat. citation is present, and correct independent metadata for multiple amendments in the same section.

## Before / After

**Before** (`_parse_amendments`, PL 111-295):
```json
{
  "congress": 111,
  "law_number": 295,
  "date": null,
  "stat_volume": null,
  "stat_page": null,
  "stat_reference": null
}
```

**After**:
```json
{
  "congress": 111,
  "law_number": 295,
  "date": "Dec. 9, 2010",
  "stat_volume": 124,
  "stat_page": 3180,
  "stat_reference": "124 Stat. 3180"
}
```

## Fields still null (by design)

`official_title`, `short_title`, `short_title_aliases`, and `display_title` are **not** present in amendment note text — they would require a separate join to the `PublicLaw` DB table. Those remain null and are out of scope for this fix.

Closes #582

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmX5Q7M6hDRjgEnMeEGxxv)_