### PR TITLE
fix: categorize "Derivation" notes as historical instead of statutory

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1464,10 +1464,21 @@ def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
     so the three category-aware parsers find nothing.
 
     Category assignment uses the header text:
+    - Historical: Derivation, Historical and Revision Notes (legislative-provenance notes)
     - Editorial: Amendments, Change of Name, References in Text, Codification,
       Prior Provisions, Construction, Recodification, Effective Date of Repeal
     - Statutory: everything else (effective dates, savings, miscellaneous, etc.)
     """
+    # Verbatim OLRC heading text for headers classified as historical.
+    # "Derivation" notes record the original pre-codification statute from which
+    # a section derives; OLRC marks them topic="derivation" in USLM XML.
+    # Comparison is case-insensitive so that verbatim and title-cased variants match.
+    HISTORICAL_HEADERS = {
+        "Derivation",
+        "Historical and Revision Notes",
+    }
+    historical_headers_lower = {h.lower() for h in HISTORICAL_HEADERS}
+
     # Verbatim OLRC heading text for headers classified as editorial.
     # Comparison is case-insensitive so that legacy title-cased data and
     # verbatim source text both match (see issue #509).
@@ -1510,7 +1521,9 @@ def _parse_flat_notes(raw_notes: str, notes: SectionNotes) -> None:
             continue
 
         category = (
-            NoteCategory.EDITORIAL
+            NoteCategory.HISTORICAL
+            if header.lower() in historical_headers_lower
+            else NoteCategory.EDITORIAL
             if header.lower() in editorial_headers_lower
             else NoteCategory.STATUTORY
         )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -90,4 +90,7 @@ omit = ["*/tests/*", "*/__pycache__/*"]
 dev = [
     "aiosqlite>=0.22.1",
     "mypy>=1.19.1",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
 ]

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2566,6 +2566,60 @@ class TestFlatNotesParser:
 
         assert len(notes.notes) == 0
 
+    def test_flat_derivation_note_is_historical_issue_605(self) -> None:
+        """Flat 'Derivation' note is categorised as HISTORICAL, not STATUTORY.
+
+        9 U.S.C. §§ 1–14 have <note topic="derivation"> elements without an
+        "Editorial Notes" / "Statutory Notes" category wrapper.  Prior to the
+        fix, _parse_flat_notes defaulted unknown headers to NoteCategory.STATUTORY.
+        OLRC's own classification marks derivation notes as historical provenance
+        (topic="derivation"), so they must land in NoteCategory.HISTORICAL.
+        Closes #605.
+        """
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_flat_notes
+
+        raw_notes = (
+            "[NH]Derivation[/NH] "
+            "Act Feb. 12, 1925, ch. 213, § 1, 43 Stat. 883; "
+            "Act July 30, 1947, ch. 392, § 1, 61 Stat. 669."
+        )
+        notes = SectionNotes()
+        _parse_flat_notes(raw_notes, notes)
+
+        assert len(notes.notes) == 1
+        assert notes.notes[0].header == "Derivation"
+        assert notes.notes[0].category.value == "historical", (
+            f"Expected 'historical', got {notes.notes[0].category.value!r}"
+        )
+
+    def test_flat_derivation_and_amendments_categories_issue_605(self) -> None:
+        """Flat Derivation note is historical; peer Amendments note is editorial.
+
+        Simulates a Title 9 section (e.g. 9 U.S.C. § 1) that has both a
+        Derivation note and an Amendments note as flat <note> siblings.
+        """
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_flat_notes
+
+        raw_notes = (
+            "[NH]Derivation[/NH] "
+            "Act Feb. 12, 1925, ch. 213, § 1, 43 Stat. 883; "
+            "Act July 30, 1947, ch. 392, § 1, 61 Stat. 669. "
+            "[NH]Amendments[/NH] "
+            "1954—Act Sept. 3, 1954, ch. 1262, § 1, 68 Stat. 1233, "
+            "substituted 'district courts of the United States' for 'United States district courts'."
+        )
+        notes = SectionNotes()
+        _parse_flat_notes(raw_notes, notes)
+
+        assert len(notes.notes) == 2
+        categories = {n.header: n.category.value for n in notes.notes}
+        assert categories["Derivation"] == "historical", (
+            f"Derivation should be 'historical', got {categories['Derivation']!r}"
+        )
+        assert categories["Amendments"] == "editorial", (
+            f"Amendments should be 'editorial', got {categories['Amendments']!r}"
+        )
+
     def test_flat_notes_after_historical_note_issue_283(self) -> None:
         """Regression: flat notes after 'Historical and Revision Notes' must not be swallowed.
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -529,6 +529,9 @@ gcs = [
 dev = [
     { name = "aiosqlite" },
     { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -561,6 +564,9 @@ provides-extras = ["gcs", "dev"]
 dev = [
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Bug

`GET /api/v1/sections/9/{N}` (for §§ 1–14) returned "Derivation" notes with `category: "statutory"`. The OLRC USLM XML marks these as `topic="derivation"` — a historical legislative-provenance note recording the original pre-codification statute from which the section derives. Per OLRC's own classification, derivation notes belong in the **historical** category, not statutory.

## Root cause

`_parse_flat_notes()` in `backend/pipeline/olrc/normalized_section.py` had a two-way branch:
- If the header matched `EDITORIAL_HEADERS` → `NoteCategory.EDITORIAL`
- Otherwise → `NoteCategory.STATUTORY` (the default)

`"Derivation"` was absent from `EDITORIAL_HEADERS`, so it silently fell through to `STATUTORY`.

## Fix

Added a `HISTORICAL_HEADERS` set containing `"Derivation"` and `"Historical and Revision Notes"`, and inserted a third branch in the category assignment:

```python
HISTORICAL_HEADERS = {
    "Derivation",
    "Historical and Revision Notes",
}
historical_headers_lower = {h.lower() for h in HISTORICAL_HEADERS}

category = (
    NoteCategory.HISTORICAL
    if header.lower() in historical_headers_lower
    else NoteCategory.EDITORIAL
    if header.lower() in editorial_headers_lower
    else NoteCategory.STATUTORY
)
```

## Tests

Two new tests added to `TestFlatNotesParser` in `tests/pipeline/test_normalized_section.py`:

- `test_flat_derivation_note_is_historical_issue_605` — a lone `[NH]Derivation[/NH]` flat note gets `category: "historical"`
- `test_flat_derivation_and_amendments_categories_issue_605` — Derivation and Amendments peer notes each get the correct category (`historical` and `editorial` respectively), matching the Title 9 §§ 1–14 pattern

Full suite: 856 passed, 21 skipped.

Closes #605

---
_Generated by [Claude Code](https://claude.ai/code/session_01T57XEgjLS3ehgmdwvoRyCf)_