### PR TITLE
fix: strip soft hyphens (U+00AD) from OLRC note headings before title-casing

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -239,19 +239,29 @@ SUBSECTION_HEADER_PATTERN = re.compile(
 def _clean_heading(heading: str) -> str:
     """Clean heading text for display.
 
-    Applies three transformations:
-    1. Strip trailing '.—' (period + em-dash) heading terminators.
-    2. Strip trailing standalone periods.
-    3. Convert ALL-CAPS headings to Title Case.
+    Applies four transformations:
+    1. Strip invisible presentational characters (U+00AD soft hyphen).
+    2. Strip trailing '.—' (period + em-dash) heading terminators.
+    3. Strip trailing standalone periods.
+    4. Convert ALL-CAPS headings to Title Case.
 
     Examples:
         "Implementation of New START Treaty.—" -> "Implementation of New START Treaty"
         "DEFINITIONS." -> "Definitions"
         "PENALTIES" -> "Penalties"
         "Sense of congress .—" -> "Sense of Congress"
+        "BICENTEN\xadNIAL" -> "Bicentennial"
     """
     if not heading:
         return heading
+    # Strip soft hyphens (U+00AD) before any other processing.
+    # Soft hyphens are purely presentational line-break hints from old typesetting
+    # and carry no semantic meaning in legal headings.  They must be removed before
+    # title-casing because str.title() treats any non-letter as a word boundary and
+    # would capitalize the character following the soft hyphen (e.g. the ALL-CAPS
+    # heading "BICENTEN\xadNIAL" would become "Bicenten\xadNial" instead of the
+    # correct "Bicentennial").  See issue #609.
+    heading = heading.replace("­", "")
     # Strip trailing .— or . — (with optional space before period)
     heading = re.sub(r"\s*\.—\s*$", "", heading)
     # Strip trailing period(s)
@@ -1595,7 +1605,7 @@ def _parse_historical_notes(raw_notes: str, notes: SectionNotes) -> None:
     # Extract unique report sections
     seen_headers: set[str] = set()
     for i, match in enumerate(matches):
-        header = match.group(1).strip().title()
+        header = match.group(1).strip().replace("­", "").title()
         if header in seen_headers:
             continue
         seen_headers.add(header)
@@ -1789,7 +1799,7 @@ def _parse_statutory_notes(raw_notes: str, notes: SectionNotes) -> None:
             if is_header_like and len(note_body) > 30:
                 notes.notes.append(
                     SectionNote(
-                        header=candidate_header.title(),
+                        header=candidate_header.replace("­", "").title(),
                         lines=normalize_note_content(note_body),
                         category=NoteCategory.STATUTORY,
                     )

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3299,6 +3299,44 @@ class TestCleanHeading:
         assert _clean_heading("") == ""
         assert _clean_heading(None) is None
 
+    def test_soft_hyphen_stripped_before_title_case(self) -> None:
+        """Soft hyphen (U+00AD) mid-word is stripped before title-casing.
+
+        OLRC XML sometimes embeds soft hyphens (U+00AD) in heading text as
+        presentational line-break hints from old typesetting.  When the heading
+        is in ALL-CAPS, str.title() treats the soft hyphen as a word boundary
+        and capitalizes the character that follows it, producing garbled output
+        like "Bicenten\\xadNial" instead of "Bicentennial".  The fix strips
+        soft hyphens before the ALL-CAPS check.  See issue #609.
+        """
+        from pipeline.olrc.normalized_section import _clean_heading
+
+        # ALL-CAPS heading with soft hyphen: should produce clean title case
+        assert (
+            _clean_heading(
+                "EX. ORD. NO. 12001. TRANSFERRING CERTAIN BICENTEN\xadNIAL FUNCTIONS"
+            )
+            == "Ex. Ord. No. 12001. Transferring Certain Bicentennial Functions"
+        )
+        # Minimal case: single word with soft hyphen in ALL-CAPS
+        assert _clean_heading("BICENTEN\xadNIAL") == "Bicentennial"
+
+    def test_soft_hyphen_stripped_from_mixed_case(self) -> None:
+        """Soft hyphen (U+00AD) is stripped from mixed-case headings too.
+
+        Even when no title-casing is applied (heading is already mixed-case),
+        soft hyphens must be removed so they do not appear in rendered output
+        or cause unexpected word-breaks in HTML.
+        """
+        from pipeline.olrc.normalized_section import _clean_heading
+
+        assert (
+            _clean_heading("Ex. Ord. No. 12001. Bicenten\xadnial Functions")
+            == "Ex. Ord. No. 12001. Bicentennial Functions"
+        )
+        # Soft hyphen at word start / end (edge cases)
+        assert _clean_heading("Bi\xadcentennial") == "Bicentennial"
+
 
 class TestAmendmentSubsectionPrefix:
     """Tests for amendment parsing with subsection prefix."""


### PR DESCRIPTION
## What was the bug

OLRC XML headings sometimes contain soft-hyphen characters (U+00AD, `\xad`) — old typesetting line-break hints that are invisible in most renderers but are semantically meaningless in legal citations. CWLB preserved these soft hyphens through ingestion without stripping them.

The problem surfaces when a heading is in ALL-CAPS (common in OLRC XML): the `_clean_heading()` function applies Python's `str.title()` to convert it to Title Case. Python's `str.title()` treats **any non-letter character** as a word boundary, so the soft hyphen caused the character immediately after it to be capitalized mid-word:

| Source XML | After `str.title()` without fix |
|------------|----------------------------------|
| `"BICENTENNIAL"` (soft hyphen between N and N) | `"BicentenNial"` ← wrong mid-word capital |

In the reported case (3 USC § 301, Ex. Ord. 12001), the stored heading became:
```
Ex. Ord. No. 12001. Transferring Certain BicentenNial Functions To Secretary Of The Interior
```
instead of the correct:
```
Ex. Ord. No. 12001. Transferring Certain Bicentennial Functions to Secretary of the Interior
```

## What the fix does

Strip U+00AD **before** any title-case conversion in `_clean_heading()` in `backend/pipeline/olrc/normalized_section.py`. The same one-character strip is applied to the two other `str.title()` call sites in the same file (`_parse_historical_notes` report headers and the `_parse_statutory_notes` fallback path) for consistency.

### Before / after (parsing proof)

```python
# Before fix
_clean_heading("EX. ORD. NO. 12001. TRANSFERRING CERTAIN BICENTEN\xadNIAL FUNCTIONS")
# → "Ex. Ord. No. 12001. Transferring Certain Bicenten\xadNial Functions"  ← garbled

# After fix
_clean_heading("EX. ORD. NO. 12001. TRANSFERRING CERTAIN BICENTEN\xadNIAL FUNCTIONS")
# → "Ex. Ord. No. 12001. Transferring Certain Bicentennial Functions"  ← correct
```

## Tests

Two new test cases added to `TestCleanHeading` in `tests/pipeline/test_normalized_section.py`:
- `test_soft_hyphen_stripped_before_title_case` — ALL-CAPS heading with mid-word soft hyphen produces correct Title Case without the spurious capital
- `test_soft_hyphen_stripped_from_mixed_case` — soft hyphen is removed even when no title-case conversion is triggered

All 856 existing tests continue to pass.

Closes #609

---
_Generated by [Claude Code](https://claude.ai/code/session_01T57XEgjLS3ehgmdwvoRyCf)_