### PR TITLE
fix: normalize leading whitespace before computing note line offsets

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1251,6 +1251,11 @@ def _paragraph_lines(raw_content: str) -> list[ParsedLine]:
     # display lines are correct even for data ingested before the parser fix.
     # (See issue #626.)
     cleaned = re.sub("—\\s+(?=Pub\\.)", "—", cleaned)
+    # Strip leading whitespace so that the first content line gets start_char=0.
+    # Without this, raw_content often begins with "\n\n" (the gap between the
+    # [/NH] header marker and the first <p> element), causing pos to advance
+    # by 2 before the first non-empty line is processed (issue #616).
+    cleaned = cleaned.lstrip()
 
     lines: list[ParsedLine] = []
     pos = 0

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -4455,6 +4455,87 @@ class TestAmendmentsIndentLevel:
         )
 
 
+class TestAmendmentsStartCharOffset:
+    """Regression tests for issue #616: Amendments note lines must start at start_char=0.
+
+    When raw_content passed to _paragraph_lines begins with "\\n\\n" (the gap
+    between the [/NH] header marker and the first <p> element), the pos counter
+    was being incremented twice before reaching the first non-empty line, making
+    start_char=2 for the first content line instead of 0.
+    """
+
+    def test_paragraph_lines_first_line_start_char_is_zero(self) -> None:
+        """_paragraph_lines first content line must have start_char=0 (issue #616).
+
+        The raw_content for an Amendments note typically begins with "\\n\\n" because
+        the content is sliced from editorial_text immediately after the [/NH] closing
+        tag and the first paragraph is preceded by a double-newline separator.
+        _paragraph_lines must normalise this leading whitespace before computing
+        byte-position offsets so that start_char for the first line is always 0.
+        """
+        from pipeline.olrc.normalized_section import _paragraph_lines
+
+        # Simulate the raw_content as received from _parse_editorial_notes:
+        # starts with "\n\n" (the gap between [/NH] and the first <p>).
+        raw = (
+            "\n\n1976—Subsec. (c). Pub. L. 94–521 added subsec. (c).\n\n"
+            "1964—Subsec. (b). Pub. L. 88–448 inserted provisions."
+        )
+        lines = _paragraph_lines(raw)
+
+        assert len(lines) >= 1, "Expected at least one content line"
+        assert lines[0].start_char == 0, (
+            f"Expected start_char=0 for first Amendments line, got {lines[0].start_char}"
+        )
+
+    def test_amendments_note_start_char_zero_via_xml(self) -> None:
+        """13 U.S.C. § 23 pattern: first Amendments note line has start_char=0 (issue #616).
+
+        Exercises the full XML parsing → notes structure pipeline to confirm that
+        start_char for the first line of an Amendments note is 0 when the note is
+        parsed from real OLRC-style XML with a <heading> element and <p> paragraphs.
+        """
+        from lxml import etree
+
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+        from pipeline.olrc.parser import USLMParser
+
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0">'
+            '<note class="editorial">'
+            '<heading class="smallCaps">Editorial Notes</heading>'
+            '<note topic="amendments">'
+            "<heading>Amendments</heading>"
+            "<p>1976—Subsec. (c). Pub. L. 94–521 added subsec. (c).</p>"
+            "<p>1964—Subsec. (b). Pub. L. 88–448 inserted provisions.</p>"
+            "<p>1960—Subsec. (a). Pub. L. 86–769 substituted provisions.</p>"
+            "</note>"
+            "</note>"
+            "</notes>"
+        )
+        notes_elem = etree.fromstring(xml)
+        raw = USLMParser()._get_notes_text_content(notes_elem)
+        notes = SectionNotes()
+        _parse_notes_structure(raw, notes)
+
+        amendments = next(
+            (n for n in notes.notes if n.header == "Amendments"), None
+        )
+        assert amendments is not None, "Amendments note not found"
+
+        content_lines = [ln for ln in amendments.lines if ln.content]
+        assert len(content_lines) >= 1, "Expected at least one content line in Amendments note"
+
+        first_line = content_lines[0]
+        assert first_line.start_char == 0, (
+            f"Expected start_char=0 for first Amendments note line, "
+            f"got start_char={first_line.start_char} for content: {first_line.content!r}"
+        )
+
+
 class TestNoteHeadersVerbatim:
     """Regression tests for issue #509: note headers must not be title-cased.
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -4521,13 +4521,13 @@ class TestAmendmentsStartCharOffset:
         notes = SectionNotes()
         _parse_notes_structure(raw, notes)
 
-        amendments = next(
-            (n for n in notes.notes if n.header == "Amendments"), None
-        )
+        amendments = next((n for n in notes.notes if n.header == "Amendments"), None)
         assert amendments is not None, "Amendments note not found"
 
         content_lines = [ln for ln in amendments.lines if ln.content]
-        assert len(content_lines) >= 1, "Expected at least one content line in Amendments note"
+        assert len(content_lines) >= 1, (
+            "Expected at least one content line in Amendments note"
+        )
 
         first_line = content_lines[0]
         assert first_line.start_char == 0, (


### PR DESCRIPTION
## Summary

**Bug:** In `_paragraph_lines()`, the raw content for an Amendments note (and any note using the paragraph-line fast-path) was passed with a leading `\n\n` — the gap between the `[/NH]` header marker and the first `<p>` element. Because there was no `lstrip()` before the position-counting loop, the `pos` counter advanced twice (once per empty string from `split("\n")`) before the first real content line was reached. This made `start_char=2` for the first Amendments line instead of `0`, and left a consistent 2-char offset on every subsequent line as well.

**Root cause:** `_paragraph_lines()` in `backend/pipeline/olrc/normalized_section.py` iterated directly over `cleaned.split("\n")` without stripping leading whitespace, so empty lines before the first content contributed to byte-position accounting even though their content was suppressed.

**Fix:** Add `cleaned = cleaned.lstrip()` after the regex substitutions in `_paragraph_lines()`. This normalises the leading whitespace before any position tracking begins, ensuring `start_char=0` for the first content line in all notes that use the paragraph-line fast-path (Amendments, References in Text).

## Changes

- `backend/pipeline/olrc/normalized_section.py`: One-line fix — `cleaned = cleaned.lstrip()` in `_paragraph_lines()`, with a comment explaining why.
- `backend/tests/pipeline/test_normalized_section.py`: New `TestAmendmentsStartCharOffset` class with two regression tests:
  - `test_paragraph_lines_first_line_start_char_is_zero` — unit test directly calling `_paragraph_lines()` with leading `\n\n` input.
  - `test_amendments_note_start_char_zero_via_xml` — integration test parsing real OLRC-style XML through `_get_notes_text_content` → `_parse_notes_structure` and asserting the first Amendments content line has `start_char=0`.

## Before / After

**Before (13 U.S.C. § 23 Amendments note):**

```
Line 1: start_char=2, end_char=53,   content="1976—Subsec. (c). Pub. L. 94–521 added subsec. (c)."
Line 2: start_char=55, end_char=158, content="1964—Subsec. (b). Pub. L. 88–448 inserted…"
```

**After:**

```
Line 1: start_char=0, end_char=51,   content="1976—Subsec. (c). Pub. L. 94–521 added subsec. (c)."
Line 2: start_char=53, end_char=156, content="1964—Subsec. (b). Pub. L. 88–448 inserted…"
```

The 2-char leading offset is removed. The gap between `end_char` and the next `start_char` is now 2 (for `\n\n` paragraph separators), which correctly reflects the actual separator characters.

Closes #616

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwAQMc9r4cgbsEc2czVr3E)_