### PR TITLE
fix: attribute note-level cross-references to their source note

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -2412,7 +2412,9 @@ def normalize_parsed_section(
         # element the <ref> was found in.  Build a heading -> schemas map and
         # assign matching schemas to each SectionNoteSchema.references list.
         heading_to_schemas: dict[str, list[NoteReferenceSchema]] = {}
-        for raw_ref, schema_ref in zip(parsed_section.notes_refs, notes.references, strict=True):
+        for raw_ref, schema_ref in zip(
+            parsed_section.notes_refs, notes.references, strict=True
+        ):
             if raw_ref.note_heading:
                 key = raw_ref.note_heading.strip().lower()
                 heading_to_schemas.setdefault(key, []).append(schema_ref)

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -2412,7 +2412,7 @@ def normalize_parsed_section(
         # element the <ref> was found in.  Build a heading -> schemas map and
         # assign matching schemas to each SectionNoteSchema.references list.
         heading_to_schemas: dict[str, list[NoteReferenceSchema]] = {}
-        for raw_ref, schema_ref in zip(parsed_section.notes_refs, notes.references):
+        for raw_ref, schema_ref in zip(parsed_section.notes_refs, notes.references, strict=True):
             if raw_ref.note_heading:
                 key = raw_ref.note_heading.strip().lower()
                 heading_to_schemas.setdefault(key, []).append(schema_ref)

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -2407,6 +2407,21 @@ def normalize_parsed_section(
     if parsed_section.notes_refs:
         notes.references = note_refs_to_schemas(parsed_section.notes_refs)
 
+        # Populate per-note references (Issue #620).
+        # Each NoteRef now carries a note_heading field identifying which <note>
+        # element the <ref> was found in.  Build a heading -> schemas map and
+        # assign matching schemas to each SectionNoteSchema.references list.
+        heading_to_schemas: dict[str, list[NoteReferenceSchema]] = {}
+        for raw_ref, schema_ref in zip(parsed_section.notes_refs, notes.references):
+            if raw_ref.note_heading:
+                key = raw_ref.note_heading.strip().lower()
+                heading_to_schemas.setdefault(key, []).append(schema_ref)
+
+        for note in notes.notes:
+            key = note.header.strip().lower()
+            if key in heading_to_schemas:
+                note.references = heading_to_schemas[key]
+
     # Populate the section with normalized data
     parsed_section.provisions = lines
     parsed_section.normalized_text = normalized_text

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -255,6 +255,10 @@ class NoteRef:
     stat_volume: int | None = None  # For STATUTE
     stat_page: int | None = None  # For STATUTE
 
+    # Source attribution (Issue #620): heading of the <note> element that
+    # contains this <ref>, enabling per-note reference attribution.
+    note_heading: str | None = None
+
 
 @dataclass
 class ParsedSection:
@@ -2049,6 +2053,10 @@ class USLMParser:
 
             text = "".join(ref_elem.itertext()).strip()
 
+            # Walk up the XML tree to find the heading of the enclosing <note>
+            # element (Issue #620 — per-note reference attribution).
+            note_heading = _get_note_heading_for_ref(ref_elem)
+
             # Parse /us/pl/CONGRESS/LAW/... hrefs (Public Laws, post-1957)
             if "/us/pl/" in href:
                 match = re.match(
@@ -2063,6 +2071,7 @@ class USLMParser:
                             display_text=text,
                             congress=int(match.group(1)),
                             law_number=int(match.group(2)),
+                            note_heading=note_heading,
                         )
                     )
 
@@ -2080,6 +2089,7 @@ class USLMParser:
                             display_text=text,
                             act_date=match.group(1),
                             act_chapter=int(match.group(2)),
+                            note_heading=note_heading,
                         )
                     )
 
@@ -2098,6 +2108,7 @@ class USLMParser:
                             display_text=text,
                             usc_title=int(match.group(1)),
                             usc_section=section,
+                            note_heading=note_heading,
                         )
                     )
 
@@ -2112,10 +2123,47 @@ class USLMParser:
                             display_text=text,
                             stat_volume=int(match.group(1)),
                             stat_page=int(match.group(2)),
+                            note_heading=note_heading,
                         )
                     )
 
         return refs
+
+
+def _get_note_heading_for_ref(ref_elem: etree._Element) -> str | None:
+    """Walk up the XML tree from a <ref> element to find its enclosing <note> heading.
+
+    Each <ref> element belongs to a <note> element somewhere up the tree.
+    Returns the text of the <heading> child of that <note>, or the display
+    string derived from the note's ``topic`` attribute when no <heading>
+    child is present.  Returns None if no enclosing <note> is found.
+
+    Args:
+        ref_elem: A <ref> XML element.
+
+    Returns:
+        The note heading string, or None.
+    """
+    elem = ref_elem.getparent()
+    while elem is not None:
+        local_tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
+        if local_tag == "note":
+            # Try to get heading text from a <heading> child element.
+            for child in elem:
+                child_tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                if child_tag == "heading":
+                    heading_text = "".join(child.itertext()).strip()
+                    if heading_text:
+                        return heading_text
+            # Fall back to the topic attribute (synthesized heading).
+            topic: str = elem.get("topic", "") or ""
+            if topic:
+                normalized_topic = topic[0].lower() + topic[1:]
+                fallback: str = topic.title()
+                return _NOTE_TOPIC_DISPLAY.get(normalized_topic, fallback)
+            return None
+        elem = elem.getparent()
+    return None
 
 
 def compute_text_hash(text: str) -> str:

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3878,6 +3878,152 @@ class TestNoteReferenceSchema:
         assert schema.target_id == "/us/pl/unknown"
 
 
+class TestPerNoteReferenceAttribution:
+    """Regression tests for Issue #620 — per-note reference attribution.
+
+    Cross-references found within individual notes must appear in both:
+    1. notes.references (global list) — already worked before the fix
+    2. The specific note's SectionNoteSchema.references field — was always empty
+
+    Representative case: 29 USC § 157, "Effective Date Of 1947 Amendment" note
+    contains a reference to section 151 of this title.
+    """
+
+    def _build_section_with_notes_refs(self) -> "ParsedSection":  # type: ignore[name-defined]
+        """Build a ParsedSection that mimics 29 USC § 157 note structure."""
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import NoteRef, ParsedSection
+
+        # Simulate the raw_notes string that the parser would produce for 29 USC § 157.
+        # The key part is the [NH] marker matching the note_heading on the NoteRef.
+        raw_notes = (
+            "Statutory Notes and Related Subsidiaries\n"
+            "[NH]Effective Date Of 1947 Amendment[/NH] "
+            "For effective date of amendment by act June 23, 1947, see section 104 "
+            "of act June 23, 1947, set out as a note under section 151 of this title.\n"
+            "[NH]References in Text[/NH] "
+            "The Labor Management Relations Act of 1947 is Pub. L. 80–101."
+        )
+
+        notes_refs = [
+            NoteRef(
+                ref_type="usc_section",
+                href="/us/usc/t29/s151",
+                display_text="section 151 of this title",
+                usc_title=29,
+                usc_section="151",
+                note_heading="Effective Date Of 1947 Amendment",
+            ),
+            NoteRef(
+                ref_type="public_law",
+                href="/us/pl/80/101",
+                display_text="Pub. L. 80–101",
+                congress=80,
+                law_number=101,
+                note_heading="References in Text",
+            ),
+        ]
+
+        section = ParsedSection(
+            section_number="157",
+            heading="Right of employees as to organization",
+            full_citation="29 U.S.C. § 157",
+            text_content="Employees shall have the right to self-organization.",
+            notes=raw_notes,
+            notes_refs=notes_refs,
+        )
+        return normalize_parsed_section(section)
+
+    def test_global_references_populated(self) -> None:
+        """Global notes.references is populated (regression guard — was already correct)."""
+        result = self._build_section_with_notes_refs()
+        assert result.section_notes is not None
+        assert len(result.section_notes.references) == 2
+
+    def test_per_note_references_populated(self) -> None:
+        """Each note's .references list contains only its own refs (Issue #620)."""
+        result = self._build_section_with_notes_refs()
+        notes = result.section_notes
+        assert notes is not None
+
+        # Find the "Effective Date Of 1947 Amendment" note.
+        eff_date_notes = [
+            n
+            for n in notes.notes
+            if "effective date of 1947 amendment" in n.header.lower()
+        ]
+        assert eff_date_notes, "Expected to find 'Effective Date Of 1947 Amendment' note"
+        eff_date_note = eff_date_notes[0]
+
+        assert len(eff_date_note.references) == 1
+        ref = eff_date_note.references[0]
+        assert ref.href == "/us/usc/t29/s151"
+        assert ref.usc_title == 29
+        assert ref.usc_section == "151"
+
+    def test_refs_attributed_to_correct_note(self) -> None:
+        """Refs from different notes are attributed to their respective notes (Issue #620)."""
+        result = self._build_section_with_notes_refs()
+        notes = result.section_notes
+        assert notes is not None
+
+        # Find the "References in Text" note.
+        ref_in_text_notes = [
+            n for n in notes.notes if "references in text" in n.header.lower()
+        ]
+        assert ref_in_text_notes, "Expected to find 'References in Text' note"
+        ref_note = ref_in_text_notes[0]
+
+        assert len(ref_note.references) == 1
+        ref = ref_note.references[0]
+        assert ref.href == "/us/pl/80/101"
+        assert ref.congress == 80
+
+    def test_note_without_refs_has_empty_references(self) -> None:
+        """A note that has no cross-references keeps an empty .references list."""
+        from pipeline.olrc.normalized_section import normalize_parsed_section
+        from pipeline.olrc.parser import NoteRef, ParsedSection
+
+        raw_notes = (
+            "Statutory Notes and Related Subsidiaries\n"
+            "[NH]Short Title[/NH] "
+            "This chapter may be cited as the National Labor Relations Act.\n"
+            "[NH]Effective Date Of 1947 Amendment[/NH] "
+            "For effective date of amendment see section 151 of this title."
+        )
+
+        # Only the "Effective Date" note has a ref — "Short Title" has none.
+        notes_refs = [
+            NoteRef(
+                ref_type="usc_section",
+                href="/us/usc/t29/s151",
+                display_text="section 151 of this title",
+                usc_title=29,
+                usc_section="151",
+                note_heading="Effective Date Of 1947 Amendment",
+            ),
+        ]
+
+        section = ParsedSection(
+            section_number="157",
+            heading="Right of employees",
+            full_citation="29 U.S.C. § 157",
+            text_content="Employees shall have the right to self-organization.",
+            notes=raw_notes,
+            notes_refs=notes_refs,
+        )
+        result = normalize_parsed_section(section)
+        notes_obj = result.section_notes
+        assert notes_obj is not None
+
+        short_title_notes = [
+            n for n in notes_obj.notes if "short title" in n.header.lower()
+        ]
+        assert short_title_notes, "Expected to find 'Short Title' note"
+        short_title_note = short_title_notes[0]
+        assert short_title_note.references == []
+
+
 class TestPrePLAmendmentCitations:
     """Regression tests for issues #566 and #567.
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3889,7 +3889,7 @@ class TestPerNoteReferenceAttribution:
     contains a reference to section 151 of this title.
     """
 
-    def _build_section_with_notes_refs(self) -> "ParsedSection":  # type: ignore[name-defined]
+    def _build_section_with_notes_refs(self) -> "ParsedSection":  # type: ignore[name-defined]  # noqa: F821
         """Build a ParsedSection that mimics 29 USC § 157 note structure."""
         from pipeline.olrc.normalized_section import normalize_parsed_section
         from pipeline.olrc.parser import NoteRef, ParsedSection

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3952,7 +3952,9 @@ class TestPerNoteReferenceAttribution:
             for n in notes.notes
             if "effective date of 1947 amendment" in n.header.lower()
         ]
-        assert eff_date_notes, "Expected to find 'Effective Date Of 1947 Amendment' note"
+        assert eff_date_notes, (
+            "Expected to find 'Effective Date Of 1947 Amendment' note"
+        )
         eff_date_note = eff_date_notes[0]
 
         assert len(eff_date_note.references) == 1

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -1367,6 +1367,73 @@ class TestExtractNotesRefs:
         assert ref.usc_section == "2349aa-10"
         assert ref.href == "/us/usc/t22/s2349aa–10"
 
+    @pytest.fixture
+    def xml_with_multi_note_refs(self, tmp_path: Path) -> Path:
+        """Create XML with refs distributed across two named notes (Issue #620).
+
+        Models the structure of 29 USC § 157 where the "Effective Date Of 1947
+        Amendment" note contains a reference to section 151, and a separate
+        "References in Text" note contains a reference to a Public Law.
+        """
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<usc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <meta><identifier>usc/29</identifier></meta>
+  <main>
+    <title identifier="/us/usc/t29" number="29">
+      <heading>LABOR</heading>
+      <chapter identifier="/us/usc/t29/ch7" number="7">
+        <heading>LABOR-MANAGEMENT RELATIONS</heading>
+        <section identifier="/us/usc/t29/s157" number="157">
+          <heading>Right of employees as to organization, collective bargaining, etc.</heading>
+          <content><p>Employees shall have the right to self-organization.</p></content>
+          <notes>
+            <note topic="effectiveDateOfAmendment">
+              <heading>Effective Date Of 1947 Amendment</heading>
+              <p>For effective date of amendment by act June 23, 1947, see section 104
+              of act June 23, 1947, set out as a note under
+              <ref href="/us/usc/t29/s151">section 151 of this title</ref>.</p>
+            </note>
+            <note topic="referencesInText">
+              <heading>References in Text</heading>
+              <p>The Labor Management Relations Act of 1947 is
+              <ref href="/us/pl/80/101">Pub. L. 80-101</ref>.</p>
+            </note>
+          </notes>
+        </section>
+      </chapter>
+    </title>
+  </main>
+</usc>
+"""
+        xml_path = tmp_path / "test_multi_note_refs.xml"
+        xml_path.write_text(xml_content)
+        return xml_path
+
+    def test_note_heading_attributed_per_note(
+        self, parser: USLMParser, xml_with_multi_note_refs: Path
+    ) -> None:
+        """Each NoteRef carries the heading of its enclosing <note> (Issue #620).
+
+        Regression test for 29 USC § 157 where a USC section ref inside the
+        "Effective Date Of 1947 Amendment" note had note_heading=None.
+        """
+        result = parser.parse_file(xml_with_multi_note_refs)
+        section = result.sections[0]
+
+        assert len(section.notes_refs) == 2
+
+        # First ref (USC section) should be attributed to the effective date note.
+        usc_ref = section.notes_refs[0]
+        assert usc_ref.ref_type == "usc_section"
+        assert usc_ref.usc_section == "151"
+        assert usc_ref.note_heading == "Effective Date Of 1947 Amendment"
+
+        # Second ref (Public Law) should be attributed to the references note.
+        pl_ref = section.notes_refs[1]
+        assert pl_ref.ref_type == "public_law"
+        assert pl_ref.congress == 80
+        assert pl_ref.note_heading == "References in Text"
+
 
 class TestNoteRefDataclass:
     """Tests for NoteRef dataclass."""
@@ -1424,6 +1491,29 @@ class TestNoteRefDataclass:
         assert ref.ref_type == "act"
         assert ref.act_date == "1935-08-14"
         assert ref.act_chapter == 531
+
+    def test_note_heading_defaults_to_none(self) -> None:
+        """NoteRef.note_heading defaults to None when not provided (Issue #620)."""
+        ref = NoteRef(
+            ref_type="usc_section",
+            href="/us/usc/t29/s151",
+            display_text="section 151 of this title",
+            usc_title=29,
+            usc_section="151",
+        )
+        assert ref.note_heading is None
+
+    def test_note_heading_can_be_set(self) -> None:
+        """NoteRef.note_heading stores the enclosing note's heading (Issue #620)."""
+        ref = NoteRef(
+            ref_type="usc_section",
+            href="/us/usc/t29/s151",
+            display_text="section 151 of this title",
+            usc_title=29,
+            usc_section="151",
+            note_heading="Effective Date Of 1947 Amendment",
+        )
+        assert ref.note_heading == "Effective Date Of 1947 Amendment"
 
 
 class TestCitationTailTextSubdivision:


### PR DESCRIPTION
## Context

Issue #620: `SectionNoteSchema.references` (the per-note reference list added in Task 1.17b) was always empty, even when the note's text contained cross-references. The global `notes.references` list was populated correctly, but the per-note field was a no-op.

Root cause: `_extract_notes_refs` in `parser.py` extracted all `<ref>` elements from the `<notes>` block globally but never recorded which `<note>` element each `<ref>` came from. Without that attribution, `normalize_parsed_section` had no way to populate `SectionNoteSchema.references` per note.

Reproducer: `GET /api/v1/sections/29/157` — the "Effective Date Of 1947 Amendment" note contains a reference to `/us/usc/t29/s151` that appeared in `notes.references` but was absent from the note's own `.references` field.

## Changes

**`pipeline/olrc/parser.py`**
- Added `note_heading: str | None = None` field to `NoteRef` dataclass
- Added `_get_note_heading_for_ref(ref_elem)` helper that walks up the XML tree from a `<ref>` element to find its enclosing `<note>` element, returning the text of the `<heading>` child or the display string derived from the `topic` attribute as a fallback
- In `_extract_notes_refs`, call `_get_note_heading_for_ref` for each ref element and set `note_heading` on the constructed `NoteRef`

**`pipeline/olrc/normalized_section.py`**
- In `normalize_parsed_section`, after converting `notes_refs` to the global `notes.references`, build a `heading -> [NoteReferenceSchema]` map keyed on `note_heading` (case-insensitive) and assign matching schemas to each `SectionNoteSchema.references` list

**`tests/pipeline/test_parser.py`**
- Added `test_note_heading_defaults_to_none` and `test_note_heading_can_be_set` to `TestNoteRefDataclass`
- Added `xml_with_multi_note_refs` fixture and `test_note_heading_attributed_per_note` to `TestExtractNotesRefs`, modelling the 29 USC § 157 structure

**`tests/pipeline/test_normalized_section.py`**
- Added `TestPerNoteReferenceAttribution` with 4 tests verifying the fix end-to-end

## Parsing proof (29 USC § 157)

**Before fix** — note's `.references` always empty:
```json
{
    "header": "Effective Date Of 1947 Amendment",
    "lines": [{"content": "For effective date of amendment...", "indent_level": 1}],
    "category": "statutory",
    "references": []
}
```

**After fix** — note's `.references` populated:
```json
{
    "header": "Effective Date Of 1947 Amendment",
    "lines": [{"content": "For effective date of amendment...", "indent_level": 1}],
    "category": "statutory",
    "references": [
        {
            "ref_type": "usc_section",
            "href": "/us/usc/t29/s151",
            "display_text": "section 151 of this title",
            "usc_title": 29,
            "usc_section": "151",
            "target_id": "29 USC 151"
        }
    ]
}
```

Closes #620

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEswYNA1HArXvz7aVWudEn)_