### PR TITLE
fix: parse pre-1957 chapter-act amendments into notes.amendments

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1305,6 +1305,37 @@ def _parse_amendments(text: str) -> list[Amendment]:
                     )
                 )
 
+    # Fallback: if no YEAR— prefix markers were found, the entire text may be a
+    # single pre-1957 Act citation whose year prefix was absent or was stripped
+    # before reaching this function.  Two sub-cases arise in OLRC USLM XML for
+    # older sections (e.g. 29 USC §157 with its 1947 amendment):
+    #
+    #   (a) The year appeared in a bold (<b>YEAR</b>) element that _strip_note_markers
+    #       removes, leaving the content starting with a bare em-dash followed by the
+    #       Act citation, e.g. "—Act June 23, 1947, restated rights…".
+    #   (b) The OLRC XML omitted the YEAR— prefix entirely, encoding only the Act
+    #       citation text "Act June 23, 1947, ch. 120, …" in the paragraph body.
+    #
+    # In both cases the year is recoverable from the embedded date in the citation
+    # (e.g. "Act June 23, 1947" → year 1947).
+    if not amendments and text.strip():
+        # Strip any leading dash that survives after the year element is removed.
+        fallback_text = re.sub(r"^\s*[—–-]\s*", "", text.strip())
+        if re.search(r"\bAct\b", fallback_text):
+            year_from_date = re.search(
+                r"\bAct\s+\w+\.?\s+\d{1,2},?\s+(\d{4})",
+                fallback_text,
+            )
+            if year_from_date:
+                year = int(year_from_date.group(1))
+                amendments.append(
+                    Amendment(
+                        law=None,
+                        year=year,
+                        description=" ".join(fallback_text.split()),
+                    )
+                )
+
     return amendments
 
 

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3953,6 +3953,132 @@ class TestPrePLAmendmentCitations:
         assert modern.law.congress == 106
         assert pre_pl.law is None
 
+    def test_29_usc_157_with_year_prefix(self) -> None:
+        """Regression #619: 29 USC §157 — canonical form with YEAR— prefix works.
+
+        This is the clean form of the 1947 amendment as it would appear when the
+        OLRC XML includes the year in the paragraph text itself ("1947—Act…").
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "1947—Act June 23, 1947, restated rights of employees to bargain "
+            "collectively and inserted provision that they have right to refrain "
+            "from joining in concerted activities with their fellow employees."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1
+        assert amendments[0].year == 1947
+        assert amendments[0].law is None
+        assert "Act June 23, 1947" in amendments[0].description
+
+    def test_29_usc_157_without_year_prefix(self) -> None:
+        """Regression #619: 29 USC §157 — YEAR— prefix absent in paragraph body.
+
+        Some OLRC USLM XML releases encode pre-1957 amendment paragraphs without
+        the leading "YEAR—" marker, starting directly with the Act citation.  The
+        year must then be recovered from the embedded date ("Act June 23, 1947").
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "Act June 23, 1947, restated rights of employees to bargain "
+            "collectively and inserted provision that they have right to refrain "
+            "from joining in concerted activities with their fellow employees."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1, (
+            f"Expected 1 amendment but got {len(amendments)}: "
+            + str([a.description for a in amendments])
+        )
+        assert amendments[0].year == 1947
+        assert amendments[0].law is None
+        assert "Act June 23, 1947" in amendments[0].description
+
+    def test_29_usc_157_leading_emdash_year_stripped(self) -> None:
+        """Regression #619: 29 USC §157 — year in bold element, stripped to leading dash.
+
+        When the year appears in a <b>1947</b> element, _strip_note_markers removes
+        the [H1]1947[/H1] marker, leaving the content starting with a bare em-dash:
+        "—Act June 23, 1947, restated rights…".  The year must be extracted from
+        the embedded Act date in this case too.
+        """
+        from pipeline.olrc.normalized_section import _parse_amendments
+
+        text = (
+            "—Act June 23, 1947, restated rights of employees to bargain "
+            "collectively and inserted provision that they have right to refrain "
+            "from joining in concerted activities with their fellow employees."
+        )
+        amendments = _parse_amendments(text)
+
+        assert len(amendments) == 1, (
+            f"Expected 1 amendment but got {len(amendments)}: "
+            + str([a.description for a in amendments])
+        )
+        assert amendments[0].year == 1947
+        assert amendments[0].law is None
+        assert "Act June 23, 1947" in amendments[0].description
+
+    def test_29_usc_157_full_notes_structure_no_year_prefix(self) -> None:
+        """Regression #619: full _parse_notes_structure populates notes.amendments.
+
+        End-to-end test using the flat raw_notes format that 29 USC §157 produces
+        when the OLRC XML omits the YEAR— prefix from the amendment paragraph.
+        notes.amendments must be non-empty and notes.has_amendments must be True.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        raw_notes = (
+            "[NH]Amendments[/NH] "
+            "Act June 23, 1947, ch. 120, title I, §101, 61 Stat. 140, "
+            "restated rights of employees to bargain collectively and inserted "
+            "provision that they have right to refrain from joining in concerted "
+            "activities with their fellow employees."
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        assert len(notes.amendments) == 1, (
+            f"Expected 1 amendment, got {len(notes.amendments)}"
+        )
+        assert notes.amendments[0].year == 1947
+        assert notes.amendments[0].law is None
+        assert notes.has_amendments is True
+
+    def test_29_usc_157_full_notes_structure_bold_year(self) -> None:
+        """Regression #619: full _parse_notes_structure with H1-wrapped year.
+
+        When the OLRC XML has <b>1947</b>—Act…, the parser emits
+        [H1]1947[/H1]—Act… in the raw_notes.  _strip_note_markers removes the
+        [H1] block, leaving "—Act June 23, 1947, …" for _parse_amendments.
+        notes.amendments must still be populated with year=1947.
+        """
+        from pipeline.olrc.normalized_section import (
+            SectionNotes,
+            _parse_notes_structure,
+        )
+
+        raw_notes = (
+            "[NH]Amendments[/NH] "
+            "[H1]1947[/H1]—Act June 23, 1947, ch. 120, title I, §101, "
+            "61 Stat. 140, restated rights of employees to bargain collectively."
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        assert len(notes.amendments) == 1, (
+            f"Expected 1 amendment, got {len(notes.amendments)}"
+        )
+        assert notes.amendments[0].year == 1947
+        assert notes.amendments[0].law is None
+        assert notes.has_amendments is True
+
 
 class TestAmendmentMidSentencePubLFix:
     """Regression tests for issue #558: amendment parser splits mid-sentence on


### PR DESCRIPTION
## Context

Issue #619: `notes.amendments` is empty for 29 USC §157 despite a 1947 amendment being present in the OLRC source and captured in `notes.notes`. `notes.has_amendments` incorrectly returns `false`.

## Root Cause

`_parse_amendments()` requires text of the form `"YEAR—Act…"` (matched by `_YEAR_PATTERN = r"(\d{4})\s*[—–-]\s*"`). For older USLM XML, two failure modes exist where the year prefix is absent when the function is called:

**(a) Year in a bold element** — the OLRC XML encodes `<b>1947</b>—Act June 23, 1947…`. The parser emits `[H1]1947[/H1]—Act June 23, 1947…` in `raw_notes`. `_strip_note_markers` strips `[H1]...[/H1]` content, leaving `—Act June 23, 1947…` (bare leading em-dash). `_YEAR_PATTERN` finds no match → returns `[]`.

**(b) Year omitted from paragraph body** — the OLRC XML paragraph starts directly with `Act June 23, 1947…` without any `YEAR—` prefix. `_YEAR_PATTERN` finds no match → returns `[]`.

In both cases the SectionNote IS added to `notes.notes` (via `_paragraph_lines` which does not strip `[H1]` markers), but `notes.amendments` stays empty because `_parse_amendments` returned `[]`.

## Fix

Added a fallback at the end of `_parse_amendments()`: when no `YEAR—` markers are found, strip any leading em-dash and attempt to extract the year from the embedded Act date citation (e.g. `"Act June 23, 1947"` → year `1947`). The fallback only fires when the text contains `\bAct\b` and the date pattern `\bAct\s+\w+\.?\s+\d{1,2},?\s+\d{4}` is present.

## Before / After

**Before (both failing forms):**
```python
_parse_amendments("Act June 23, 1947, restated rights…")
# → []

_parse_amendments("—Act June 23, 1947, restated rights…")
# → []
```

**After:**
```python
_parse_amendments("Act June 23, 1947, restated rights…")
# → [Amendment(law=None, year=1947, description="Act June 23, 1947, restated rights…")]

_parse_amendments("—Act June 23, 1947, restated rights…")
# → [Amendment(law=None, year=1947, description="Act June 23, 1947, restated rights…")]
```

The canonical form (`"1947—Act June 23, 1947…"`) continues to work as before.

## Tests Added

Five new test methods in `TestPrePLAmendmentCitations`:
- `test_29_usc_157_with_year_prefix` — canonical form (already worked; added for explicitness)
- `test_29_usc_157_without_year_prefix` — Act text with no YEAR— prefix (bug case)
- `test_29_usc_157_leading_emdash_year_stripped` — leading em-dash after [H1] stripping (bug case)
- `test_29_usc_157_full_notes_structure_no_year_prefix` — integration via `_parse_notes_structure`
- `test_29_usc_157_full_notes_structure_bold_year` — integration with `[H1]`-wrapped year

All 859 tests pass.

Closes #619

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEswYNA1HArXvz7aVWudEn)_