### PR TITLE
fix: strip spurious space after em dash in amendment-year notes

### DIFF
--- a/backend/alembic/versions/e1749da6ffc4_strip_em_dash_space_in_amendments_notes.py
+++ b/backend/alembic/versions/e1749da6ffc4_strip_em_dash_space_in_amendments_notes.py
@@ -1,0 +1,56 @@
+"""strip_em_dash_space_in_amendments_notes
+
+Strip the spurious space that older parser versions inserted between an
+amendment-year em dash and the following "Pub. L." citation in the
+normalized_notes JSONB cache.  For example, "2002— Pub. L. 107–273" should
+be "2002—Pub. L. 107–273".
+
+The parser bug was fixed in issue #600, but section_snapshot rows ingested
+before that fix still store the artifact in their normalized_notes column.
+This migration patches every affected row without requiring a full re-ingest.
+
+See issue #626.
+
+Revision ID: e1749da6ffc4
+Revises: 19521111cd88
+Create Date: 2026-07-23 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e1749da6ffc4"
+down_revision: str | None = "19521111cd88"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The em dash character (U+2014) followed by a space before "Pub." is the
+# spurious artifact.  We replace every occurrence in the text representation
+# of the JSONB and cast back to JSONB.  This safely fixes the pattern in
+# notes[].lines[].content and in the raw_notes field without touching any
+# field where a space after "—" would be intentional (no such field exists
+# in SectionNotesSchema).
+_FIX_SQL = """\
+UPDATE {table}
+SET normalized_notes = regexp_replace(
+    normalized_notes::text,
+    E'\\u2014 (?=Pub\\\\.)',
+    E'\\u2014',
+    'g'
+)::jsonb
+WHERE normalized_notes IS NOT NULL
+  AND normalized_notes::text LIKE E'%— Pub.%'
+"""
+
+
+def upgrade() -> None:
+    """Remove spurious spaces after em dashes in Amendments note lines."""
+    for table in ("section_snapshot", "us_code_section"):
+        op.execute(sa.text(_FIX_SQL.format(table=table)))
+
+
+def downgrade() -> None:
+    """No-op: restoring the spurious spaces would reintroduce incorrect data."""

--- a/backend/alembic/versions/e1749da6ffc4_strip_em_dash_space_in_amendments_notes.py
+++ b/backend/alembic/versions/e1749da6ffc4_strip_em_dash_space_in_amendments_notes.py
@@ -23,7 +23,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "e1749da6ffc4"
-down_revision: str | None = "19521111cd88"
+down_revision: str | None = "2249206d96b1"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1232,6 +1232,14 @@ def _paragraph_lines(raw_content: str) -> list[ParsedLine]:
     cleaned = re.sub(r"\[NH\].*?\[/NH\]", "", raw_content, flags=re.DOTALL)
     cleaned = re.sub(r"\[/NH\]", "", cleaned)
     cleaned = re.sub(r"\[PARA\]", "\n\n", cleaned)
+    # Strip spurious whitespace between an amendment-year em dash and the
+    # following "Pub. L." citation.  Older parser versions (before issue #600)
+    # always joined adjacent text fragments with a space, so XML like
+    # "<p>2002—<ref>Pub. L. 107–273</ref>…</p>" produced "2002— Pub. L. 107–273"
+    # in the stored raw notes text.  Removing that space here ensures the
+    # display lines are correct even for data ingested before the parser fix.
+    # (See issue #626.)
+    cleaned = re.sub("—\\s+(?=Pub\\.)", "—", cleaned)
 
     lines: list[ParsedLine] = []
     pos = 0

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -4664,8 +4664,7 @@ class TestAmendmentEmDashSpaceFix:
         from pipeline.olrc.normalized_section import _paragraph_lines
 
         raw_content = (
-            "[NH]Amendments[/NH]"
-            "[PARA]1996—Pub. L. 104–159 substituted other text."
+            "[NH]Amendments[/NH][PARA]1996—Pub. L. 104–159 substituted other text."
         )
         lines = _paragraph_lines(raw_content)
         contents = [line.content for line in lines if line.content]

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -7,9 +7,11 @@ from app.schemas import NoteReferenceSchema
 from pipeline.olrc.normalized_section import (
     PARAGRAPH_BREAK_MARKER,
     ParsedPublicLaw,
+    SectionNotes,
     SourceLaw,
     _detect_marker_level,
     _is_sentence_boundary,
+    _parse_notes_structure,
     _split_into_sentences,
     _strip_note_markers,
     char_span_to_line_span,
@@ -4679,8 +4681,6 @@ class TestAmendmentEmDashSpaceFix:
         Simulates stored raw notes text (with the legacy space artifact) flowing
         through _parse_notes_structure and verifies the rendered lines are clean.
         """
-        from pipeline.olrc.normalized_section import SectionNotes, _parse_notes_structure
-
         # Mimic what the DB stores for a section ingested before the #600 fix:
         # the Amendments entry has "2002— Pub." with a space after the em dash.
         raw_notes = (

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -4620,6 +4620,90 @@ class TestAmendmentLawMetadata:
         assert law_1999.date == "Aug. 5, 1999"
 
 
+class TestAmendmentEmDashSpaceFix:
+    """Regression tests for issue #626: spurious space after em dash in Amendments.
+
+    Older parser versions (before issue #600) joined adjacent XML text fragments
+    with a plain space even when the preceding fragment ended with an em dash.
+    This produced raw notes text like "2002— Pub. L. 107–273" (with a space).
+    The _paragraph_lines() function must strip that space so the stored
+    normalized_notes JSONB and the displayed content are both correct.
+    """
+
+    def test_paragraph_lines_strips_space_after_em_dash_before_pub_l(self) -> None:
+        """_paragraph_lines strips spurious space between year em dash and Pub. L.
+
+        Regression test for issue #626: the raw notes column in the DB retains
+        the artifact from old ingest runs.  Normalizing via _paragraph_lines
+        must remove the extra space so the rendered line reads correctly.
+        """
+        from pipeline.olrc.normalized_section import _paragraph_lines
+
+        # Simulates a raw_content slice from an Amendments note where the
+        # 2002 entry has a spurious space (stored in the DB from old ingest).
+        raw_content = (
+            "[NH]Amendments[/NH]"
+            "[PARA]2002— Pub. L. 107–273 substituted text."
+            "[PARA]1996—Pub. L. 104–159 substituted other text."
+        )
+        lines = _paragraph_lines(raw_content)
+        contents = [line.content for line in lines if line.content]
+
+        # The spurious space must be gone from the 2002 entry
+        assert any("2002—Pub." in c for c in contents), (
+            f"Expected '2002—Pub.' (no space) in lines, got: {contents!r}"
+        )
+        assert not any("2002— Pub." in c for c in contents), (
+            f"Spurious space still present in 2002 line: {contents!r}"
+        )
+
+    def test_paragraph_lines_does_not_alter_lines_without_artifact(self) -> None:
+        """Lines that already lack the spurious space are unchanged."""
+        from pipeline.olrc.normalized_section import _paragraph_lines
+
+        raw_content = (
+            "[NH]Amendments[/NH]"
+            "[PARA]1996—Pub. L. 104–159 substituted other text."
+        )
+        lines = _paragraph_lines(raw_content)
+        contents = [line.content for line in lines if line.content]
+
+        # Correctly formatted entry must be preserved as-is
+        assert any("1996—Pub." in c for c in contents), (
+            f"Expected '1996—Pub.' unchanged in lines, got: {contents!r}"
+        )
+
+    def test_amendment_em_dash_space_stripped_end_to_end(self) -> None:
+        """End-to-end: _parse_editorial_notes strips spurious space in Amendments lines.
+
+        Simulates stored raw notes text (with the legacy space artifact) flowing
+        through _parse_notes_structure and verifies the rendered lines are clean.
+        """
+        from pipeline.olrc.normalized_section import SectionNotes, _parse_notes_structure
+
+        # Mimic what the DB stores for a section ingested before the #600 fix:
+        # the Amendments entry has "2002— Pub." with a space after the em dash.
+        raw_notes = (
+            "[H1]Editorial Notes[/H1]"
+            "[NH]Amendments[/NH]"
+            "[PARA]2002— Pub. L. 107–273 substituted text."
+            "[PARA]1996—Pub. L. 104–159 substituted other text."
+        )
+        notes = SectionNotes()
+        _parse_notes_structure(raw_notes, notes)
+
+        amend_note = next((n for n in notes.notes if n.header == "Amendments"), None)
+        assert amend_note is not None, "Amendments note not found in parsed notes"
+
+        line_contents = [line.content for line in amend_note.lines if line.content]
+        assert any("2002—Pub." in c for c in line_contents), (
+            f"Expected '2002—Pub.' (no space) in amendment lines; got: {line_contents!r}"
+        )
+        assert not any("2002— Pub." in c for c in line_contents), (
+            f"Spurious space still present after end-to-end normalization: {line_contents!r}"
+        )
+
+
 class TestMultiSentenceSplitting:
     """Tests for splitting multi-sentence paragraphs onto separate provision lines.
 


### PR DESCRIPTION
## What

Fixes the spurious space between the year em dash and `Pub. L.` in the **Amendments** editorial note for sections ingested before the issue #600 parser fix.

**Repro:** `GET /api/v1/sections/17/121` — `notes.notes[1].lines[3].content` was `"2002— Pub. L. 107–273 substituted …"` instead of `"2002—Pub. L. 107–273 substituted …"`.

## Root Cause

Older parser versions (before issue #600) always joined adjacent XML text fragments with a space, even when the preceding text node ended with an em dash. OLRC XML like `<p>2002—<ref href="…">Pub. L. 107–273</ref>…</p>` was serialised as `"2002— Pub. L. 107–273"` (with a trailing space). That raw text was stored in the `notes` column and propagated into the `normalized_notes` JSONB cache.

The parser-side fix (issue #600) prevents new ingest from producing this artifact, but existing rows in `section_snapshot` and `us_code_section` still contain the old data.

## Fix

**`backend/pipeline/olrc/normalized_section.py` — `_paragraph_lines()`**

After stripping structural markers (`[NH]`, `[PARA]`), apply a targeted regex to collapse `—\s+(?=Pub\.)` → `—`. This is the normalization layer that converts the stored raw notes text into rendered `ParsedLine` objects, so the fix takes effect for both old and new data.

**Before / After (17 USC § 121, Amendments note, line 4):**
```
Before: 2002— Pub. L. 107–273 substituted …
After:  2002—Pub. L. 107–273 substituted …
```

**`backend/alembic/versions/e1749da6ffc4_strip_em_dash_space_in_amendments_notes.py`**

Data migration that patches the already-computed `normalized_notes` JSONB in `section_snapshot` and `us_code_section` without requiring a full re-ingest. Uses `regexp_replace` on the text representation of the JSONB to replace every `— Pub.` occurrence.

## Tests

Three new regression tests in `TestAmendmentEmDashSpaceFix`:

1. `test_paragraph_lines_strips_space_after_em_dash_before_pub_l` — unit test of `_paragraph_lines()` directly
2. `test_paragraph_lines_does_not_alter_lines_without_artifact` — confirms correct entries are unchanged
3. `test_amendment_em_dash_space_stripped_end_to_end` — end-to-end via `_parse_notes_structure()`

Closes #626

---
_Generated by [Claude Code](https://claude.ai/code/session_015CsKNZU6M7MuSamPJwCd5v)_