### PR TITLE
fix: regression test + backfill script for stale References in Text note splits (#625)

### DIFF
--- a/backend/pipeline/backfill_renormalize_notes.py
+++ b/backend/pipeline/backfill_renormalize_notes.py
@@ -27,7 +27,6 @@ import sys
 from sqlalchemy import text
 
 from app.models.base import async_session_maker
-from app.schemas.us_code import SectionNotesSchema
 from pipeline.olrc.normalized_section import SectionNotes, _parse_notes_structure
 
 logger = logging.getLogger(__name__)
@@ -67,9 +66,7 @@ def _renormalize_notes_list(raw_notes: str) -> list[dict]:
     """Return the re-parsed notes[] list for the given raw notes text."""
     schema = SectionNotes()
     _parse_notes_structure(raw_notes, schema)
-    return [
-        note.model_dump(mode="json", exclude_none=True) for note in schema.notes
-    ]
+    return [note.model_dump(mode="json", exclude_none=True) for note in schema.notes]
 
 
 async def _backfill_table(
@@ -82,9 +79,7 @@ async def _backfill_table(
     changed = 0
 
     async with async_session_maker() as session:
-        result = await session.execute(
-            text(_SELECT_SQL.format(table=table, pk=pk))
-        )
+        result = await session.execute(text(_SELECT_SQL.format(table=table, pk=pk)))
         rows = result.all()
         logger.info("[%s] Found %d candidate rows", table, len(rows))
 

--- a/backend/pipeline/backfill_renormalize_notes.py
+++ b/backend/pipeline/backfill_renormalize_notes.py
@@ -1,0 +1,163 @@
+"""Backfill renormalized notes[] list for sections with stale cached data.
+
+Re-parses the raw ``notes`` text column and overwrites only the ``notes``
+key inside the ``normalized_notes`` JSONB, leaving citations, amendments,
+references, and other structured fields untouched.
+
+Targets rows whose raw notes contain "References in Text", which is the note
+type affected by two bug fixes applied after initial ingestion:
+
+  1. ``subsecs.`` added to ``LEGAL_ABBREVIATIONS`` — stops false sentence
+     splits at "subsecs." abbreviations.
+  2. ``"References in Text"`` added to ``PARAGRAPH_LINE_HEADERS`` — routes
+     that note type through ``_paragraph_lines()`` (one line per ``<p>``).
+
+See GitHub issue #625.
+
+Usage:
+    uv run python -m pipeline.backfill_renormalize_notes          # dry-run
+    uv run python -m pipeline.backfill_renormalize_notes --apply  # commit
+"""
+
+import asyncio
+import json
+import logging
+import sys
+
+from sqlalchemy import text
+
+from app.models.base import async_session_maker
+from app.schemas.us_code import SectionNotesSchema
+from pipeline.olrc.normalized_section import SectionNotes, _parse_notes_structure
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO, format="%(levelname)-5.5s [%(name)s] %(message)s"
+)
+
+BATCH_SIZE = 100
+
+# Tables that store (raw) notes + normalized_notes JSONB
+_TABLES = [
+    ("section_snapshot", "snapshot_id"),
+    ("us_code_section", "section_id"),
+]
+
+_SELECT_SQL = """\
+SELECT {pk}, notes, normalized_notes
+FROM {table}
+WHERE notes LIKE '%References in Text%'
+  AND notes IS NOT NULL
+  AND normalized_notes IS NOT NULL
+ORDER BY {pk}
+"""
+
+_UPDATE_SQL = """\
+UPDATE {table}
+SET normalized_notes = jsonb_set(
+        normalized_notes,
+        '{{notes}}',
+        :new_notes::jsonb
+    )
+WHERE {pk} = :row_id
+"""
+
+
+def _renormalize_notes_list(raw_notes: str) -> list[dict]:
+    """Return the re-parsed notes[] list for the given raw notes text."""
+    schema = SectionNotes()
+    _parse_notes_structure(raw_notes, schema)
+    return [
+        note.model_dump(mode="json", exclude_none=True) for note in schema.notes
+    ]
+
+
+async def _backfill_table(
+    table: str,
+    pk: str,
+    *,
+    dry_run: bool,
+) -> int:
+    """Backfill one table; return the number of rows that differ."""
+    changed = 0
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            text(_SELECT_SQL.format(table=table, pk=pk))
+        )
+        rows = result.all()
+        logger.info("[%s] Found %d candidate rows", table, len(rows))
+
+        batch: list[dict] = []
+
+        for row_id, raw_notes, normalized_notes in rows:
+            if not raw_notes or not normalized_notes:
+                continue
+
+            new_notes = _renormalize_notes_list(raw_notes)
+            old_notes = normalized_notes.get("notes", [])
+
+            # Compare serialised forms to detect any difference
+            if json.dumps(new_notes, sort_keys=True) == json.dumps(
+                old_notes, sort_keys=True
+            ):
+                continue
+
+            batch.append(
+                {
+                    "row_id": row_id,
+                    "new_notes": json.dumps(new_notes),
+                }
+            )
+
+            if len(batch) >= BATCH_SIZE:
+                if not dry_run:
+                    for item in batch:
+                        await session.execute(
+                            text(_UPDATE_SQL.format(table=table, pk=pk)),
+                            item,
+                        )
+                    await session.commit()
+                changed += len(batch)
+                logger.info("[%s] Processed %d changed rows so far", table, changed)
+                batch = []
+
+        # Final batch
+        if batch:
+            if not dry_run:
+                for item in batch:
+                    await session.execute(
+                        text(_UPDATE_SQL.format(table=table, pk=pk)),
+                        item,
+                    )
+                await session.commit()
+            changed += len(batch)
+
+    mode = "DRY-RUN" if dry_run else "APPLIED"
+    logger.info("[%s][%s] %d rows would be updated", mode, table, changed)
+    return changed
+
+
+async def backfill(*, dry_run: bool = True) -> int:
+    """Backfill stale notes[] in all affected tables.
+
+    Returns the total number of rows updated (or that would be updated).
+    """
+    total = 0
+    for table, pk in _TABLES:
+        total += await _backfill_table(table, pk, dry_run=dry_run)
+
+    mode = "DRY-RUN" if dry_run else "APPLIED"
+    logger.info("[%s] Total rows affected: %d", mode, total)
+    return total
+
+
+def main() -> None:
+    dry_run = "--apply" not in sys.argv
+    if dry_run:
+        logger.info("Running in dry-run mode (pass --apply to commit changes)")
+    asyncio.run(backfill(dry_run=dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -4190,3 +4190,64 @@ class TestReferencesInTextAbbreviationPeriods:
             f"Second line was cut at 'subsecs.': {second!r}"
         )
         assert "Computer Fraud and Abuse Act of 1986" in second
+
+    def test_17_usc_121_references_in_text_two_paragraphs_two_lines(self) -> None:
+        """17 U.S.C. § 121 References in Text: each source <p> maps to exactly one line.
+
+        Regression test for issue #625. The first paragraph contains 'subsecs.'
+        which previously triggered a spurious sentence-boundary split because
+        'subsecs.' was absent from LEGAL_ABBREVIATIONS and the note was being
+        processed by normalize_note_content() instead of _paragraph_lines().
+
+        After both fixes — adding 'subsecs.' to LEGAL_ABBREVIATIONS and adding
+        'References in Text' to PARAGRAPH_LINE_HEADERS — each source <p> must
+        produce exactly one lines[] entry.
+        """
+        xml = (
+            '<notes xmlns="http://xml.house.gov/schemas/uslm/1.0" type="uscNote">'
+            '<note class="editorial">'
+            "<heading>Editorial Notes</heading>"
+            '<note topic="referencesInText">'
+            "<heading>References in Text</heading>"
+            '<p class="indent0">Sections 612, 613, and 674 of the Individuals with '
+            "Disabilities Education Act, referred to in subsecs. (c) and (d)(3), "
+            "are classified to sections 1412, 1413, and 1474, respectively, "
+            "of Title 20, Education.</p>"
+            '<p class="indent0">The Act approved March 3, 1931, referred to in '
+            "subsec. (d)(2), is act Mar. 3, 1931, ch. 400, 46 Stat. 1487, as amended, "
+            "which is classified generally to sections 135a and 135b of Title 2, "
+            "The Congress. For complete classification of this Act to the Code, "
+            "see Tables.</p>"
+            "</note>"
+            "</note>"
+            "</notes>"
+        )
+
+        notes = self._parse_editorial_notes_xml(xml)
+
+        ref_notes = [n for n in notes.notes if n.header == "References in Text"]
+        assert len(ref_notes) == 1, (
+            f"Expected 1 References in Text note, got {len(ref_notes)}"
+        )
+        lines = ref_notes[0].lines
+
+        # Exactly 2 non-empty lines — one per source <p> — no spurious splits
+        non_empty = [line for line in lines if line.content]
+        assert len(non_empty) == 2, (
+            f"Expected 2 non-empty lines but got {len(non_empty)}: "
+            f"{[line.content for line in lines]}"
+        )
+
+        # First line: full first paragraph — not split at "subsecs."
+        first = non_empty[0].content
+        assert "subsecs. (c) and (d)(3)" in first, (
+            f"First line was split at 'subsecs.': {first!r}"
+        )
+        assert first.endswith("Title 20, Education.")
+
+        # Second line: full second paragraph — not split at "subsec." or truncated
+        second = non_empty[1].content
+        assert "subsec. (d)(2)" in second, (
+            f"Second line was split at 'subsec.': {second!r}"
+        )
+        assert second.endswith("see Tables.")


### PR DESCRIPTION
## Context

17 USC § 121's "References in Text" note was rendered split mid-sentence in production. The root cause was a stale `normalized_notes` JSONB cache generated before two normalizer fixes reached `main`:

1. `subsecs.` added to `LEGAL_ABBREVIATIONS` — prevented false sentence-boundary splits at `subsecs.` abbreviation periods (#551).
2. `"References in Text"` added to `PARAGRAPH_LINE_HEADERS` — routes that note type through `_paragraph_lines()` (one line per source `<p>`) instead of `normalize_note_content()` (sentence-splitter) (#559).

Both code fixes are already on `main`. The `normalized_notes` column is read from the DB cache at request time and never re-normalised on the fly, so rows ingested before those fixes still carry the stale split data.

## Changes

- **`backend/tests/pipeline/test_normalized_section.py`** — adds `test_17_usc_121_references_in_text_two_paragraphs_two_lines` in `TestReferencesInTextAbbreviationPeriods`. Verifies that two source `<p>` elements produce exactly two `lines[]` entries and that neither is split at `subsecs.` or `subsec.`.

- **`backend/pipeline/backfill_renormalize_notes.py`** — new one-shot backfill script. Queries `section_snapshot` and `us_code_section` for rows whose raw `notes` text contains `"References in Text"`, re-parses the notes list via `_parse_notes_structure()`, and patches only the `notes` key in `normalized_notes` using `jsonb_set()` — leaving citations, amendments, references, and other structured fields intact.

  ```
  uv run python -m pipeline.backfill_renormalize_notes          # dry-run
  uv run python -m pipeline.backfill_renormalize_notes --apply  # commit
  ```

## Before / After (17 USC § 121 "References in Text")

**Before (stale cache — split at `subsecs.`):**
```
lines:
  [0] "Sections 612, 613, and 674 of the Individuals with Disabilities Education Act, referred to in subsecs."
  [1] "(c) and (d)(3), are classified to sections 1412, 1413, and 1474, respectively, of Title 20, Education."
  [2] "The Act approved March 3, 1931, referred to in subsec."
  [3] "(d)(2), is act Mar. 3, 1931 ... see Tables."
```

**After (re-parsed — one line per source `<p>`):**
```
lines:
  [0] "Sections 612, 613, and 674 of the Individuals with Disabilities Education Act, referred to in subsecs. (c) and (d)(3), are classified to sections 1412, 1413, and 1474, respectively, of Title 20, Education."
  [1] "The Act approved March 3, 1931, referred to in subsec. (d)(2), is act Mar. 3, 1931, ch. 400, 46 Stat. 1487, as amended, which is classified generally to sections 135a and 135b of Title 2, The Congress. For complete classification of this Act to the Code, see Tables."
```

Closes #625