### PR TITLE
fix: merge divergent alembic heads to unblock CD deploys

### DIFF
--- a/backend/alembic/versions/2249206d96b1_merge_codeowners_and_district_heads.py
+++ b/backend/alembic/versions/2249206d96b1_merge_codeowners_and_district_heads.py
@@ -1,0 +1,24 @@
+"""merge_codeowners_and_district_heads
+
+Revision ID: 2249206d96b1
+Revises: 19521111cd88, d5b05c4c4e7e
+Create Date: 2026-07-25 19:47:28.805345
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "2249206d96b1"
+down_revision: str | None = ("19521111cd88", "d5b05c4c4e7e")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade database schema."""
+    pass


### PR DESCRIPTION
## Summary

- CD has been failing on every merge to main since PRs #a913b6c (add_codeowners_tables) and #05339dd (add_district_to_law_sponsor) both landed with `down_revision = "ce275a30c5ec"`, creating a split in the migration history
- The `cwlb-migrate` Cloud Run job fails with `Multiple head revisions are present for given argument 'head'` on every deploy
- This adds a single no-op merge migration (`2249206d96b1`) that joins the two branches back into a single linear head

## Test plan

- [ ] Confirm `alembic heads` locally shows `2249206d96b1 (head)` only (verified ✓)
- [ ] CI passes
- [ ] CD deploys successfully after merge (migration job should no longer fail)

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)