### PR TITLE
chore: fail CI when multiple Alembic heads are detected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Run type checking (mypy)
         run: uv run mypy app --ignore-missing-imports
 
+      - name: Check for multiple Alembic heads
+        run: |
+          head_count=$(uv run alembic heads 2>/dev/null | grep -c "(head)" || true)
+          if [ "$head_count" -gt 1 ]; then
+            echo "ERROR: $head_count Alembic heads detected. Add a merge migration before merging."
+            uv run alembic heads
+            exit 1
+          fi
+
       - name: Run tests
         run: uv run pytest --cov=app --cov-report=xml
 


### PR DESCRIPTION
## Summary

- Adds an Alembic heads check to the backend CI job that fails if more than one head is present
- Catches branched migration history at PR merge time rather than at deploy time (where it surfaces as a cryptic `cwlb-migrate` job failure)
- Particularly important given async cloud routines that can independently add migrations off the same parent without awareness of each other

## Context

PR #636 fixed a case where two migrations both set `down_revision = "ce275a30c5ec"`, blocking every deploy with `Multiple head revisions are present for given argument 'head'`. This check would have caught that conflict before either PR merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)