### PR TITLE
fix: update stale int assertions/fixtures for stat_volume str migration

### DIFF
--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -4148,7 +4148,7 @@ class TestAmendmentLawMetadata:
 
         assert len(amendments) == 1
         assert amendments[0].law is not None
-        assert amendments[0].law.stat_volume == 124
+        assert amendments[0].law.stat_volume == "124"
 
     def test_amendment_law_stat_page_parsed(self) -> None:
         """stat_page is extracted from the amendment description citation."""
@@ -4188,7 +4188,7 @@ class TestAmendmentLawMetadata:
         assert law.congress == 106
         assert law.law_number == 44
         assert law.date == "Aug. 5, 1999"
-        assert law.stat_volume == 113
+        assert law.stat_volume == "113"
         assert law.stat_page == 222
         assert law.stat_reference == "113 Stat. 222"
 
@@ -4221,7 +4221,7 @@ class TestAmendmentLawMetadata:
         law_2010 = amendments[0].law
         assert law_2010 is not None
         assert law_2010.congress == 111
-        assert law_2010.stat_volume == 124
+        assert law_2010.stat_volume == "124"
         assert law_2010.stat_page == 3180
         assert law_2010.date == "Dec. 9, 2010"
 
@@ -4229,7 +4229,7 @@ class TestAmendmentLawMetadata:
         law_1999 = amendments[1].law
         assert law_1999 is not None
         assert law_1999.congress == 106
-        assert law_1999.stat_volume == 113
+        assert law_1999.stat_volume == "113"
         assert law_1999.stat_page == 222
         assert law_1999.date == "Aug. 5, 1999"
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -2143,7 +2143,7 @@ class TestExtractSourceCreditActRefs:
         assert act_ref.section == "1", (
             "section sub-path must be captured from tail text"
         )
-        assert act_ref.stat_volume == 48
+        assert act_ref.stat_volume == "48"
         assert act_ref.stat_page == 1022
 
     def test_act_ref_href_with_title_and_section_unchanged(

--- a/backend/tests/pipeline/test_section_ingestion.py
+++ b/backend/tests/pipeline/test_section_ingestion.py
@@ -417,7 +417,7 @@ class TestUpsertSectionAsAdded:
         This produces:
           - act_refs: [ActRef(date="1938-06-25", chapter=675)]  → Framework
           - source_credit_refs: [SourceCreditRef(congress=110, law_number=85,
-                date="Sept. 27, 2007", stat_volume=121, stat_page=939)]  → Enactment
+                date="Sept. 27, 2007", stat_volume="121", stat_page=939)]  → Enactment
         """
         from pipeline.olrc.parser import ActRef, ParsedSection, SourceCreditRef
 
@@ -444,7 +444,7 @@ class TestUpsertSectionAsAdded:
                     title="IX",
                     section="901(d)(2)",
                     date="Sept. 27, 2007",
-                    stat_volume=121,
+                    stat_volume="121",
                     stat_page=939,
                     raw_text="Pub. L. 110-85, title IX, § 901(d)(2), Sept. 27, 2007, 121 Stat. 939",
                 ),


### PR DESCRIPTION
## Context

`main`'s Backend Tests CI job has been red since PR #622 merged. Discovered while rebasing an unrelated batch of open PRs with merge conflicts — every rebased PR's CI inherited these same 6 pre-existing failures regardless of the conflict fix, so this needed to be fixed on `main` directly first.

## Changes

PR #622 (pre-1957 amendments parsing) changed `stat_volume` from `int` to `str` across `ParsedPublicLaw`/`ActSchema`/`NoteReferenceSchema` (pydantic models in `app/schemas/public_law.py` / `app/schemas/us_code.py`) to support letter-suffixed pre-1957 volumes (e.g. `"70A"`). The parsing code in `pipeline/olrc/parser.py` and `pipeline/olrc/normalized_section.py` was already correctly producing strings. But a few test assertions and one test fixture still used `int` literals for `stat_volume`, and pydantic v2 doesn't coerce `int` -> `str` by default, so those calls raised `ValidationError` / failed assertions.

Fixed:
- `tests/pipeline/test_normalized_section.py` — 4 assertions (`== 124` / `== 113` -> `== "124"` / `== "113"`)
- `tests/pipeline/test_parser.py` — 1 assertion (`== 48` -> `== "48"`)
- `tests/pipeline/test_section_ingestion.py` — 1 fixture (`SourceCreditRef(..., stat_volume=121, ...)` -> `stat_volume="121"`) shared by both failing tests, plus a docstring example

No production code changes — `stat_volume` was already correctly typed and produced as `str` throughout the parsing pipeline; only the stale test expectations needed updating.

Closes #639

## Before / after

Before (on `main` @ 4fe8701):
```
FAILED tests/pipeline/test_normalized_section.py::TestAmendmentLawMetadata::test_amendment_law_stat_volume_parsed
FAILED tests/pipeline/test_normalized_section.py::TestAmendmentLawMetadata::test_second_amendment_pl106_44
FAILED tests/pipeline/test_normalized_section.py::TestAmendmentLawMetadata::test_multiple_amendments_each_get_metadata
FAILED tests/pipeline/test_parser.py::TestExtractSourceCreditActRefs::test_act_ref_chapter_only_href_captures_tail_title_and_section
FAILED tests/pipeline/test_section_ingestion.py::TestUpsertSectionAsAdded::test_as_added_section_uses_adding_law_date
FAILED tests/pipeline/test_section_ingestion.py::TestUpsertSectionAsAdded::test_as_added_section_uses_adding_law_statutes_citation
6 failed, 910 passed, 21 skipped
```

After:
```
916 passed, 21 skipped
```

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format --check .` clean
- [x] `uv run mypy app --ignore-missing-imports` clean
- [x] `uv run pytest` — 916 passed, 21 skipped, 0 failed