### PR TITLE
fix: include uppercase-letter subparagraph segments in citation path_display

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -2129,7 +2129,7 @@ class USLMParser:
                         r"(?:/d([A-Z]+))?"  # Optional division (can be multi-letter: LL, FF)
                         r"(?:/t([IVXLCDM]+))?"  # Optional title
                         r"(?:/s([\w()]+))?"  # Optional section
-                        r"((?:/[a-z0-9]+)*)?",  # Optional subsection path segments (e.g. /a, /a/1)
+                        r"((?:/[a-zA-Z0-9]+)*)?",  # Optional subsection path segments (e.g. /a, /a/1, /A)
                         href,
                     )
                     if match:
@@ -2182,7 +2182,7 @@ class USLMParser:
                         r"/us/act/(\d{4}-\d{2}-\d{2})/ch(\d+)"  # Date and chapter
                         r"(?:/t([IVXLCDM]+))?"  # Optional title
                         r"(?:/s([\w()]+))?"  # Optional section
-                        r"((?:/[a-z0-9]+)*)?",  # Optional subsection path segments (e.g. /a, /a/1)
+                        r"((?:/[a-zA-Z0-9]+)*)?",  # Optional subsection path segments (e.g. /a, /a/1, /A)
                         href,
                     )
                     if match:

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -650,6 +650,35 @@ class TestCitationParsing:
         assert citation2.section == "2(c)"
         assert citation2.path_display == "§2(c)"
 
+    def test_path_display_preserves_uppercase_letter_subparagraph(self) -> None:
+        """path_display must include terminal uppercase-letter subparagraph designators.
+
+        Regression test for Issue #525: citations with href
+        /us/pl/107/273/dC/tIII/s13210/4/A were displayed as §13210(4), dropping
+        the (A) subparagraph designator. The section value produced by the parser
+        must include the full specifier so that path_display shows "§13210(4)(A)".
+        """
+        from app.models.enums import LawLevel
+        from app.schemas import LawPathComponent
+
+        law = ParsedPublicLaw(congress=107, law_number=273)
+
+        # Simulate what the fixed parser produces: section="13210(4)(A)"
+        citation = SourceLaw(
+            law=law,
+            path=[
+                LawPathComponent(level=LawLevel.DIVISION, value="C"),
+                LawPathComponent(level=LawLevel.TITLE, value="III"),
+                LawPathComponent(level=LawLevel.SECTION, value="13210(4)(A)"),
+            ],
+            raw_text="Pub. L. 107–273, div. C, title III, §13210(4)(A), Nov. 2, 2002, 116 Stat. 1909",
+        )
+        assert citation.section == "13210(4)(A)"
+        assert citation.path_display == "div. C, tit. III, §13210(4)(A)", (
+            f"Expected 'div. C, tit. III, §13210(4)(A)' but got {citation.path_display!r}; "
+            "terminal uppercase-letter segment (A) must be included in path_display"
+        )
+
     def test_parse_multi_subcitation_and_stat_pages(self) -> None:
         """Regression test for GitHub issue #547 (26 U.S.C. § 1037).
 

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -326,6 +326,51 @@ class TestUSLMParser:
             "subsection specifier (c) was dropped from the path"
         )
 
+    def test_extract_source_credit_refs_preserves_uppercase_letter_segments(
+        self, parser: USLMParser
+    ) -> None:
+        """Terminal uppercase-letter path segments must be included in the section value.
+
+        OLRC encodes subparagraph designators as uppercase-letter href segments:
+        /us/pl/107/273/dC/tIII/s13210/4/A → section "13210(4)(A)". Previously
+        the subsection tail regex only matched [a-z0-9]+, so the /A segment was
+        silently dropped, producing section="13210(4)" and path_display="§13210(4)"
+        instead of "§13210(4)(A)".
+
+        The structural /dC and /tIII markers are parsed separately (as division
+        and title fields) and must NOT appear in the section value.
+
+        Regression test for Issue #525 (Title 17, release point 113-21).
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t17/s106">
+          <num value="106">§ 106.</num>
+          <heading>Test section</heading>
+          <content>Some content here.</content>
+          <sourceCredit>(<ref href="/us/pl/107/273/dC/tIII/s13210/4/A">Pub. L. 107–273, div. C, title III, §13210(4)(A)</ref>,
+          <date date="2002-11-02">Nov. 2, 2002</date>,
+          <ref href="/us/stat/116/1909">116 Stat. 1909</ref>.)</sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml)
+        pl_refs, _act_refs = parser._extract_source_credit_refs(elem)
+
+        assert len(pl_refs) == 1
+        ref = pl_refs[0]
+        assert ref.congress == 107
+        assert ref.law_number == 273
+        assert ref.division == "C", (
+            f"Expected division='C' but got {ref.division!r}; "
+            "the /dC structural marker must be parsed as division, not section"
+        )
+        assert ref.title == "III", (
+            f"Expected title='III' but got {ref.title!r}; "
+            "the /tIII structural marker must be parsed as title, not section"
+        )
+        assert ref.section == "13210(4)(A)", (
+            f"Expected '13210(4)(A)' but got {ref.section!r}; "
+            "terminal uppercase-letter segment /A must be included in section"
+        )
+
     def test_extract_source_credit_text_returns_parenthetical(
         self, parser: USLMParser
     ) -> None:


### PR DESCRIPTION
## Context

Issue #525 identified a residual truncation bug after PR #494 merged. While lowercase letters and numbers in citation href path segments are now correctly included, terminal **uppercase-letter** segments were still dropped.

Example from the live API:
- OLRC href: `/us/pl/107/273/dC/tIII/s13210/4/A`
- OLRC display: `§ 13210(4)(A)`
- CWLB `path_display` (before fix): `§13210(4)` ❌ — missing `(A)`
- CWLB `path_display` (after fix): `§13210(4)(A)` ✅

Paths already working correctly are unaffected:
- `/us/pl/101/318/s3/d` → `§3(d)` ✅ (still works)
- `/us/pl/101/650/tVII/s704/b/2` → `§704(b)(2)` ✅ (still works)

## Root cause

In `_extract_source_credit_refs` (`backend/pipeline/olrc/parser.py`), the regex group capturing trailing subsection path segments was:

```python
r"((?:/[a-z0-9]+)*)?",  # Optional subsection path segments (e.g. /a, /a/1)
```

The character class `[a-z0-9]` matches only lowercase letters and digits. An uppercase letter like `A` in `/4/A` does not match, so the group stops at `/4` and the `/A` segment is silently ignored.

The structural markers `/d...` (division) and `/t...` (title) are handled by their own dedicated capture groups before the section group, and are unaffected by this change. After `/s...` (section), all remaining slash-delimited segments are subparagraph/clause designators, so matching uppercase letters there is safe.

## Changes

- **`backend/pipeline/olrc/parser.py`**: Changed `[a-z0-9]+` to `[a-zA-Z0-9]+` in the subsection tail capture group for both the PL href regex and the pre-1957 Act href regex.

- **`backend/tests/pipeline/test_parser.py`**: Added `test_extract_source_credit_refs_preserves_uppercase_letter_segments` — verifies that href `/us/pl/107/273/dC/tIII/s13210/4/A` produces `division="C"`, `title="III"`, and `section="13210(4)(A)"`.

- **`backend/tests/pipeline/test_normalized_section.py`**: Added `test_path_display_preserves_uppercase_letter_subparagraph` — verifies that a citation with `section="13210(4)(A)"` produces `path_display="div. C, tit. III, §13210(4)(A)"`.

## Before / After

```
# Before fix
href: /us/pl/107/273/dC/tIII/s13210/4/A
section: 13210(4)          ← /A dropped
path_display: §13210(4)    ← (A) missing

# After fix
href: /us/pl/107/273/dC/tIII/s13210/4/A
section: 13210(4)(A)       ← /A included
path_display: §13210(4)(A) ← correct
```

Closes #525

---
_Generated by [Claude Code](https://claude.ai/code/session_013pZRb8YV63giyhtfjKmfNn)_