### PR TITLE
fix: emit heading-only notes that have no body paragraphs

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1794,8 +1794,18 @@ def _parse_historical_notes(raw_notes: str, notes: SectionNotes) -> None:
     # no inline <p> content), stripping markers yields empty string.  In that
     # pattern the actual sub-notes (e.g. "House Report No. 94–1476") live in
     # sibling <note> elements and will be picked up by _parse_flat_notes.
-    # Skip creating an empty shell note here.  (Issue #526)
+    # Emit the wrapper heading as a standalone header so it surfaces in
+    # notes.notes; _parse_flat_notes will add the sibling sub-notes after it.
+    # _parse_flat_notes skips "Historical and Revision Notes" via existing_lower,
+    # so no duplicate is produced.  (Issue #217)
     if not _strip_note_markers(hist_text):
+        notes.notes.append(
+            SectionNote(
+                header="Historical and Revision Notes",
+                lines=[],
+                category=NoteCategory.HISTORICAL,
+            )
+        )
         return
 
     # Look for report headers (e.g., "House Report No. 94-1476")

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -3886,10 +3886,10 @@ class TestTitle17Section106Notes:
         return notes
 
     def test_note_count(self) -> None:
-        """Exactly 4 notes returned — empty historical shell is suppressed."""
+        """Exactly 5 notes returned — heading-only historical note is included."""
         notes = self._parse()
-        assert len(notes.notes) == 4, (
-            f"Expected 4 notes, got {len(notes.notes)}: "
+        assert len(notes.notes) == 5, (
+            f"Expected 5 notes, got {len(notes.notes)}: "
             + str([n.header for n in notes.notes])
         )
 
@@ -3927,12 +3927,32 @@ class TestTitle17Section106Notes:
                 f"{note.header!r} should be statutory, got {note.category.value}"
             )
 
-    def test_no_empty_historical_shell(self) -> None:
-        """'Historical and Revision Notes' header is not surfaced as a bare note."""
+    def test_historical_heading_only_note_surfaced(self) -> None:
+        """Heading-only 'Historical and Revision Notes' note appears as first entry.
+
+        When the historicalAndRevision <note> element has only a <heading> child
+        and no <p> body paragraphs, the heading must surface as a SectionNote
+        with an empty lines list, placed before the sibling sub-notes.
+        Closes #217.
+        """
         notes = self._parse()
         headers_lower = [n.header.lower() for n in notes.notes]
-        assert "historical and revision notes" not in headers_lower, (
-            "Empty 'Historical and Revision Notes' shell must be suppressed"
+        assert "historical and revision notes" in headers_lower, (
+            "Heading-only 'Historical and Revision Notes' must appear in notes.notes"
+        )
+        hist_note = next(
+            n
+            for n in notes.notes
+            if n.header.lower() == "historical and revision notes"
+        )
+        assert hist_note.lines == [], (
+            f"Heading-only note must have empty lines, got: {hist_note.lines}"
+        )
+        assert hist_note.category.value == "historical"
+        # Must be the first note — it precedes the sibling sub-notes
+        assert notes.notes[0].header.lower() == "historical and revision notes", (
+            f"Expected 'Historical and Revision Notes' first; "
+            f"got: {[n.header for n in notes.notes]}"
         )
 
 


### PR DESCRIPTION
## Residual bug

For 17 U.S.C. § 106, the OLRC XML has a `<note topic="historicalAndRevision">` element whose only child is `<heading>Historical and Revision Notes</heading>` — zero `<p>` body elements. The CWLB parser was silently dropping this note, so `notes.notes` contained only 4 entries (the sibling sub-notes) and the "Historical and Revision Notes" section heading was absent.

**Before the fix** — `notes.notes` for 17 U.S.C. § 106:
```
0: house report no. 94–1476
1: Amendments
2: Effective Date of 1995 Amendment
3: Effective Date of 1990 Amendment
```
Missing: "Historical and Revision Notes" (the heading-only note).

**After the fix**:
```
0: Historical and Revision Notes   ← now present, lines=[]
1: house report no. 94–1476
2: Amendments
3: Effective Date of 1995 Amendment
4: Effective Date of 1990 Amendment
```

## Root cause

In `_parse_historical_notes`, the regex captures everything after "Historical and Revision Notes" until the next `[NH]` marker. When the `historicalAndRevision` note has only a `<heading>` child, the capture group contains only the closing artifact `"[/NH]"`. `_strip_note_markers` reduces that to an empty string, triggering an early `return` that silently dropped the note.

The fix: instead of returning silently when `_strip_note_markers(hist_text)` is empty, emit a `SectionNote` with `header="Historical and Revision Notes"` and `lines=[]`. The sibling sub-notes (e.g. "house report no. 94–1476") continue to be picked up by `_parse_flat_notes`; the `existing_lower` deduplication guard prevents any double-emission.

## Test changes

`TestTitle17Section106Notes` in `test_normalized_section.py`:
- `test_note_count`: updated from 4 to 5 (now includes the heading-only historical note)
- `test_no_empty_historical_shell` renamed to `test_historical_heading_only_note_surfaced` with the assertion flipped — verifies the note IS present, has empty `lines`, is categorised as `historical`, and is the first entry in `notes.notes`

All 965 tests pass.

Closes #217

---
_Generated by [Claude Code](https://claude.ai/code/session_013pZRb8YV63giyhtfjKmfNn)_