### PR TITLE
fix: preserve trailing period on inline bold note subheadings

### DIFF
--- a/backend/pipeline/olrc/normalized_section.py
+++ b/backend/pipeline/olrc/normalized_section.py
@@ -1025,7 +1025,7 @@ def normalize_note_content(text: str) -> list[ParsedLine]:
 
         if h1_text:
             # H1 is a bold header (section-level)
-            header_text = h1_text.strip().rstrip(".")
+            header_text = h1_text.strip()
             if header_text:
                 line_number += 1
                 lines.append(
@@ -1043,7 +1043,7 @@ def normalize_note_content(text: str) -> list[ParsedLine]:
 
         elif h2_text:
             # H2 is an italic sub-header
-            header_text = h2_text.strip().rstrip(".")
+            header_text = h2_text.strip()
             if header_text:
                 line_number += 1
                 lines.append(

--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -1847,9 +1847,8 @@ class USLMParser:
             if el.text:
                 text = el.text
                 if tag == "b":
-                    # Bold text is a header - strip trailing period
-                    header_text = text.rstrip(".")
-                    parts.append(f"[H1]{header_text}[/H1]")
+                    # Bold text is a header; preserve trailing period (meaningful for inline note sub-heads)
+                    parts.append(f"[H1]{text}[/H1]")
                 elif tag == "i":
                     # In USLM, <i> marks inline italic styling — connective phrases,
                     # sub-item designators, role/title text, Latin terms, case

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -2058,6 +2058,63 @@ class TestNormalizeNoteContent:
         assert "par. (11)" in non_blank[0].content
         assert "Par. (11)" in non_blank[1].content
 
+    def test_h1_header_trailing_period_preserved(self) -> None:
+        """H1 bold headers with a trailing period must keep that period.
+
+        Regression test for issue #657: OLRC inline bold note sub-heads end
+        with a period (e.g. <strong>In General.</strong>), but the parser was
+        stripping it via rstrip('.').
+        """
+        text = (
+            "[H1]In General.[/H1] The basic copyright term is life plus seventy years."
+        )
+        lines = normalize_note_content(text)
+
+        header_lines = [ln for ln in lines if ln.is_header]
+        assert len(header_lines) == 1
+        assert header_lines[0].content == "In General."
+
+    def test_h2_header_trailing_period_preserved(self) -> None:
+        """H2 italic sub-headers with a trailing period must keep that period.
+
+        Regression test for issue #657: period was stripped from H2 headers
+        via rstrip('.') in normalized_section.py.
+        """
+        text = "[H2]Basic Term.[/H2] The term of copyright for a work."
+        lines = normalize_note_content(text)
+
+        header_lines = [ln for ln in lines if ln.is_header]
+        assert len(header_lines) == 1
+        assert header_lines[0].content == "Basic Term."
+
+    def test_17usc302_inline_bold_subheadings_preserve_periods(self) -> None:
+        """All five bold inline sub-headings from 17 U.S.C. § 302 historical notes
+        must preserve their trailing periods.
+
+        Regression test for issue #657: the live API returned headers without
+        trailing periods (e.g. 'In General' instead of 'In General.').
+        """
+        text = (
+            "[H1]In General.[/H1] Life plus seventy years."
+            " [H1]Basic Copyright Term.[/H1] The term is seventy years after death."
+            " [H1]Joint Works.[/H1] The term endures for seventy years."
+            " [H1]Works Made for Hire.[/H1] The term is 95 years."
+            " [H1]Anonymous Works.[/H1] The term is 95 years from publication."
+        )
+        lines = normalize_note_content(text)
+
+        header_lines = [ln for ln in lines if ln.is_header]
+        assert len(header_lines) == 5
+        expected_headers = [
+            "In General.",
+            "Basic Copyright Term.",
+            "Joint Works.",
+            "Works Made for Hire.",
+            "Anonymous Works.",
+        ]
+        actual_headers = [ln.content for ln in header_lines]
+        assert actual_headers == expected_headers
+
 
 class TestSentenceSplittingWithParagraphs:
     """Tests for sentence splitting with paragraph break detection."""


### PR DESCRIPTION
## Bug

OLRC historical notes use inline bold elements to mark sub-headings, consistently ending them with a period — e.g. `<strong>In General.</strong>`. CWLB was stripping that trailing period at two points in the pipeline, so the live API returned headers like `"In General"` instead of `"In General."`.

Affected example: `GET /api/v1/sections/17/302` returned:
```
{"content": "In General",          "is_header": true}
{"content": "Basic Copyright Term","is_header": true}
{"content": "Joint Works",         "is_header": true}
```

## Root cause — two stripping sites

**Site 1 — `backend/pipeline/olrc/parser.py`** (around line 1849): when a `<b>` element was encountered, the code applied `.rstrip(".")` before wrapping the text in a `[H1]…[/H1]` marker.

**Site 2 — `backend/pipeline/olrc/normalized_section.py`** (around lines 1028 and 1046): when converting `[H1]`/`[H2]` tokens to `ParsedLine` objects, a second `.rstrip(".")` was applied to both header types.

## Fix

Removed both `.rstrip(".")` calls. The period is meaningful punctuation for inline note sub-heads and must be preserved.

### Before / after

```
# parser.py — before
header_text = text.rstrip(".")
parts.append(f"[H1]{header_text}[/H1]")

# parser.py — after
parts.append(f"[H1]{text}[/H1]")

# normalized_section.py — before
header_text = h1_text.strip().rstrip(".")   # H1
header_text = h2_text.strip().rstrip(".")   # H2

# normalized_section.py — after
header_text = h1_text.strip()   # H1
header_text = h2_text.strip()   # H2
```

## Tests added

Three regression tests in `TestNormalizeNoteContent`:
1. `test_h1_header_trailing_period_preserved` — `[H1]In General.[/H1]` → `content="In General."`
2. `test_h2_header_trailing_period_preserved` — `[H2]Basic Term.[/H2]` → `content="Basic Term."`
3. `test_17usc302_inline_bold_subheadings_preserve_periods` — all five bold sub-headings from 17 U.S.C. § 302 historical notes preserve their trailing periods

Existing tests (e.g. `test_h1_header_markers`) use headers without periods and continue to pass.

## Impact

This fix affects future ingestion runs. Already-seeded data will reflect the corrected output after the next pipeline run.

Closes #657

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnbQRhKRyfsA9TffLkugSv)_