### PR TITLE
fix: preserve title-level path components in citation paths from source credits

### DIFF
--- a/backend/pipeline/olrc/parser.py
+++ b/backend/pipeline/olrc/parser.py
@@ -2164,11 +2164,25 @@ class USLMParser:
                                 if part.strip()
                             ]
 
+                        # The href sometimes omits the /t segment even when the
+                        # display text reads "title VII, § 713". Fall back to
+                        # parsing the title from the display text, mirroring
+                        # the ActRef tail-text fallback below.
+                        href_pl_title = match.group(4)
+                        if href_pl_title is None:
+                            pl_title_match = re.search(
+                                r",?\s*title\s+([IVXLCDM]+)",
+                                full_text,
+                                re.IGNORECASE,
+                            )
+                            if pl_title_match:
+                                href_pl_title = pl_title_match.group(1).upper()
+
                         ref = SourceCreditRef(
                             congress=int(match.group(1)),
                             law_number=int(match.group(2)),
                             division=match.group(3),
-                            title=match.group(4),
+                            title=href_pl_title,
                             section=section_value,
                             raw_text=full_text,
                             extra_sections=extra_sections,

--- a/backend/tests/pipeline/test_normalized_section.py
+++ b/backend/tests/pipeline/test_normalized_section.py
@@ -898,6 +898,38 @@ class TestCitationsFromSourceCreditRefs:
         assert citations[1].extra_sections == ["(b)(3)(I)"]
         assert citations[1].extra_stat_pages == [1793]
 
+    def test_title_in_source_credit_ref_appears_in_path(self) -> None:
+        """Regression test for Issue #659: a SourceCreditRef whose title is
+        populated (whether from the href /t segment or from the display-text
+        fallback) must produce a path that includes a title-level component
+        before the section component.
+
+        Before the fix the title was silently dropped for PL hrefs that lacked
+        a /t segment, so the path contained only the section entry.
+        """
+        from app.models.enums import LawLevel
+
+        ref = SourceCreditRef(
+            congress=109,
+            law_number=177,
+            title="VII",
+            section="713",
+            date="Mar. 9, 2006",
+            stat_volume="120",
+            stat_page=263,
+            raw_text="Pub. L. 109–177, title VII, § 713",
+        )
+
+        citations = citations_from_source_credit_refs([ref])
+
+        assert len(citations) == 1
+        path = citations[0].path
+        assert len(path) == 2, f"Expected 2 path components, got {path}"
+        assert path[0].level == LawLevel.TITLE
+        assert path[0].value == "VII"
+        assert path[1].level == LawLevel.SECTION
+        assert path[1].value == "713"
+
 
 class TestNormalizeParsedSection:
     """Tests for normalizing ParsedSection with structured subsections."""

--- a/backend/tests/pipeline/test_parser.py
+++ b/backend/tests/pipeline/test_parser.py
@@ -2427,6 +2427,9 @@ class TestExtractSourceCreditRefsMultiSubcitation:
         original_ref = pl_refs[0]
         assert original_ref.congress == 86
         assert original_ref.law_number == 346
+        # href /us/pl/86/346/s201/a has no /t segment; title must be parsed
+        # from the display text "Pub. L. 86-346, title II, § 201(a)".
+        assert original_ref.title == "II"
         assert original_ref.extra_sections == []
         assert original_ref.extra_stat_pages == []
 
@@ -2438,6 +2441,9 @@ class TestExtractSourceCreditRefsMultiSubcitation:
         multi_ref = pl_refs[1]
         assert multi_ref.congress == 94
         assert multi_ref.law_number == 455
+        # href /us/pl/94/455/s1901/a/130 has no /t segment; title must be
+        # parsed from the display text "Pub. L. 94-455, title XIX, § 1901(a)(130)".
+        assert multi_ref.title == "XIX"
         assert multi_ref.section == "1901(a)(130)"
         assert multi_ref.date == "Oct. 4, 1976"
         assert multi_ref.stat_volume == "90"
@@ -2450,6 +2456,66 @@ class TestExtractSourceCreditRefsMultiSubcitation:
         assert trailing_ref.law_number == 452
         assert trailing_ref.extra_sections == []
         assert trailing_ref.extra_stat_pages == []
+
+    def test_pl_title_parsed_from_display_text_when_href_lacks_t_segment(
+        self, parser: USLMParser
+    ) -> None:
+        """PL hrefs sometimes omit the /t segment even when display text
+        names a title (Issue #659). The title must be parsed from the
+        display text as a fallback, mirroring the ActRef tail-text fallback.
+
+        Example from 21 U.S.C. § 826: href /us/pl/109/177/s713 has no /tVII
+        segment, but the display text reads "Pub. L. 109-177, title VII, § 713".
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t21/s826">
+          <sourceCredit>
+            (amended <ref href="/us/pl/109/177/s713">Pub. L. 109&#8211;177,
+            title VII, &#167; 713</ref>, <date date="2006-03-09">Mar. 9, 2006</date>,
+            <ref href="/us/stat/120/263">120 Stat. 263</ref>.)
+          </sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml.encode())
+
+        pl_refs, act_refs = parser._extract_source_credit_refs(elem)
+
+        assert act_refs == []
+        assert len(pl_refs) == 1
+
+        ref = pl_refs[0]
+        assert ref.congress == 109
+        assert ref.law_number == 177
+        assert ref.section == "713"
+        # Title must be recovered from display text despite absent /t segment.
+        assert ref.title == "VII"
+
+    def test_pl_title_from_href_takes_precedence_over_display_text(
+        self, parser: USLMParser
+    ) -> None:
+        """When the href already encodes the /t segment, it wins and the
+        display-text fallback is not invoked. This guards against inadvertent
+        double-parsing when both sources are present.
+        """
+        xml = """<section xmlns="http://xml.house.gov/schemas/uslm/1.0"
+            identifier="/us/usc/t17/s106">
+          <sourceCredit>
+            (<ref href="/us/pl/94/553/tI/s106">Pub. L. 94&#8211;553, title I,
+            &#167; 106</ref>, <date date="1976-10-19">Oct. 19, 1976</date>,
+            <ref href="/us/stat/90/2546">90 Stat. 2546</ref>.)
+          </sourceCredit>
+        </section>"""
+        elem = etree.fromstring(xml.encode())
+
+        pl_refs, act_refs = parser._extract_source_credit_refs(elem)
+
+        assert act_refs == []
+        assert len(pl_refs) == 1
+
+        ref = pl_refs[0]
+        assert ref.congress == 94
+        assert ref.law_number == 553
+        assert ref.section == "106"
+        assert ref.title == "I"
 
     def test_single_subcitation_unchanged(self, parser: USLMParser) -> None:
         """Regression test: a normal single sub-citation/Stat. page


### PR DESCRIPTION
## Bug

OLRC XML hrefs for Public Laws sometimes omit the `/t` (title) segment even when the display text names a title. For example:

- href: `/us/pl/109/177/s713`
- display text: `Pub. L. 109–177, title VII, § 713`

Because the parser read the title exclusively from `match.group(4)` (the `/t` capture group), it returned `None` when the href lacked that segment. The title was silently dropped, producing a citation path of `[{"level": "section", "value": "713"}]` instead of the correct:

```json
[
  {"level": "title", "value": "VII"},
  {"level": "section", "value": "713"}
]
```

Affected sections include 21 U.S.C. § 826 (PL 91-513, PL 109-177, PL 112-144) and any other section whose source credit references a provision nested inside a public-law title where OLRC encodes only the chapter+section in the href.

## Fix

In `backend/pipeline/olrc/parser.py`, after reading `match.group(4)` for the PL title, added a fallback that searches for a `title <roman numeral>` pattern in the `<ref>` element's display text (`full_text`) when the href group is `None`. This mirrors the existing ActRef tail-text fallback (lines ~2191–2213) exactly.

The fix is minimal — one new variable and a `re.search` guard, touching only the PL ref block.

## Tests

- **`test_parser.py`** — added `assert original_ref.title == "II"` and `assert multi_ref.title == "XIX"` to the existing `test_multi_subcitation_and_stat_pages_captured` test (both hrefs lack `/t` segments but carry titles in display text). Added two new tests: `test_pl_title_parsed_from_display_text_when_href_lacks_t_segment` (the canonical Issue #659 scenario) and `test_pl_title_from_href_takes_precedence_over_display_text` (guards against double-parsing).

- **`test_normalized_section.py`** — added `test_title_in_source_credit_ref_appears_in_path` in `TestCitationsFromSourceCreditRefs` to verify that a `SourceCreditRef` with `title="VII"` produces a two-component path with `LawLevel.TITLE` before `LawLevel.SECTION`.

All 972 tests pass.

Closes #659

---
_Generated by [Claude Code](https://claude.ai/code/session_016FsrzF9WFcUvwPUfdbKiPM)_